### PR TITLE
feat: scan history management + collapsible timeline filters (#54, #55)

### DIFF
--- a/app/src/main/java/com/androdr/data/db/ForensicTimelineEventDao.kt
+++ b/app/src/main/java/com/androdr/data/db/ForensicTimelineEventDao.kt
@@ -62,4 +62,10 @@ interface ForensicTimelineEventDao {
 
     @Query("DELETE FROM forensic_timeline WHERE source = :source")
     suspend fun deleteBySource(source: String)
+
+    @Query("DELETE FROM forensic_timeline WHERE scanResultId = :scanResultId")
+    suspend fun deleteByScanId(scanResultId: Long)
+
+    @Query("DELETE FROM forensic_timeline")
+    suspend fun deleteAll()
 }

--- a/app/src/main/java/com/androdr/data/db/ScanResultDao.kt
+++ b/app/src/main/java/com/androdr/data/db/ScanResultDao.kt
@@ -17,4 +17,10 @@ interface ScanResultDao {
 
     @Insert
     suspend fun insert(scan: ScanResult)
+
+    @Query("DELETE FROM ScanResult WHERE id = :id")
+    suspend fun deleteById(id: Long)
+
+    @Query("DELETE FROM ScanResult")
+    suspend fun deleteAll()
 }

--- a/app/src/main/java/com/androdr/data/repo/ScanRepository.kt
+++ b/app/src/main/java/com/androdr/data/repo/ScanRepository.kt
@@ -63,4 +63,14 @@ class ScanRepository @Inject constructor(
     suspend fun pruneOldDnsEvents(cutoff: Long) {
         dnsEventDao.deleteOlderThan(cutoff)
     }
+
+    suspend fun deleteScan(scanId: Long) {
+        forensicTimelineEventDao.deleteByScanId(scanId)
+        scanResultDao.deleteById(scanId)
+    }
+
+    suspend fun deleteAllScans() {
+        forensicTimelineEventDao.deleteAll()
+        scanResultDao.deleteAll()
+    }
 }

--- a/app/src/main/java/com/androdr/ui/history/HistoryScreen.kt
+++ b/app/src/main/java/com/androdr/ui/history/HistoryScreen.kt
@@ -26,9 +26,12 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.DeleteSweep
 import androidx.compose.material.icons.filled.Description
 import androidx.compose.material.icons.filled.History
 import androidx.compose.material.icons.filled.Share
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -43,6 +46,7 @@ import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.SuggestionChip
 import androidx.compose.material3.SuggestionChipDefaults
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -80,6 +84,8 @@ fun HistoryScreen(
     val shareUri   by viewModel.shareUri.collectAsStateWithLifecycle()
     val sheetScan  by viewModel.sheetScan.collectAsStateWithLifecycle()
     val sheetReportText by viewModel.sheetReportText.collectAsStateWithLifecycle()
+    val showDeleteConfirm by viewModel.showDeleteConfirm.collectAsStateWithLifecycle()
+    val showClearAllConfirm by viewModel.showClearAllConfirm.collectAsStateWithLifecycle()
 
     val context = LocalContext.current
 
@@ -131,6 +137,22 @@ fun HistoryScreen(
         contentPadding = androidx.compose.foundation.layout.PaddingValues(16.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
+        if (allScans.isNotEmpty()) {
+            item {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.End
+                ) {
+                    IconButton(onClick = { viewModel.requestClearAll() }) {
+                        Icon(
+                            imageVector = Icons.Filled.DeleteSweep,
+                            contentDescription = "Clear all scan history",
+                            tint = MaterialTheme.colorScheme.error
+                        )
+                    }
+                }
+            }
+        }
         items(allScans) { scan ->
             val isSelected = selectedScan?.id == scan.id
             ScanHistoryItem(
@@ -141,7 +163,8 @@ fun HistoryScreen(
                 exporting = exporting,
                 onClick = { viewModel.selectScan(scan) },
                 onExport = { viewModel.exportReport(scan) },
-                onViewReport = { viewModel.openSheet(scan) }
+                onViewReport = { viewModel.openSheet(scan) },
+                onDelete = { viewModel.requestDeleteScan(scan.id) }
             )
         }
     }
@@ -152,6 +175,44 @@ fun HistoryScreen(
             scan = scan,
             reportText = sheetReportText,
             onDismiss = { viewModel.closeSheet() }
+        )
+    }
+
+    // Single delete confirmation
+    if (showDeleteConfirm != null) {
+        AlertDialog(
+            onDismissRequest = { viewModel.dismissDeleteConfirm() },
+            title = { Text("Delete Scan") },
+            text = { Text("Delete this scan and its timeline events?") },
+            confirmButton = {
+                TextButton(onClick = { viewModel.confirmDeleteScan() }) {
+                    Text("Delete", color = MaterialTheme.colorScheme.error)
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { viewModel.dismissDeleteConfirm() }) {
+                    Text("Cancel")
+                }
+            }
+        )
+    }
+
+    // Clear all confirmation
+    if (showClearAllConfirm) {
+        AlertDialog(
+            onDismissRequest = { viewModel.dismissClearAll() },
+            title = { Text("Clear All History") },
+            text = { Text("Delete all scan history? This cannot be undone.") },
+            confirmButton = {
+                TextButton(onClick = { viewModel.confirmClearAll() }) {
+                    Text("Delete All", color = MaterialTheme.colorScheme.error)
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { viewModel.dismissClearAll() }) {
+                    Text("Cancel")
+                }
+            }
         )
     }
 }
@@ -308,7 +369,8 @@ private fun ScanHistoryItem(
     exporting: Boolean,
     onClick: () -> Unit,
     onExport: () -> Unit,
-    onViewReport: () -> Unit
+    onViewReport: () -> Unit,
+    onDelete: () -> Unit
 ) {
     val dateFormatter = remember { SimpleDateFormat("MMM d, yyyy  HH:mm", Locale.getDefault()) }
     val dateString = dateFormatter.format(Date(scan.timestamp))
@@ -446,6 +508,14 @@ private fun ScanHistoryItem(
                             else
                                 MaterialTheme.colorScheme.primary
                         )
+
+                        IconButton(onClick = onDelete) {
+                            Icon(
+                                imageVector = Icons.Filled.Delete,
+                                contentDescription = "Delete scan",
+                                tint = MaterialTheme.colorScheme.error
+                            )
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/androdr/ui/history/HistoryViewModel.kt
+++ b/app/src/main/java/com/androdr/ui/history/HistoryViewModel.kt
@@ -107,4 +107,28 @@ class HistoryViewModel @Inject constructor(
     fun onShareConsumed() {
         _shareUri.value = null
     }
+
+    private val _showDeleteConfirm = MutableStateFlow<Long?>(null)
+    val showDeleteConfirm: StateFlow<Long?> = _showDeleteConfirm.asStateFlow()
+
+    private val _showClearAllConfirm = MutableStateFlow(false)
+    val showClearAllConfirm: StateFlow<Boolean> = _showClearAllConfirm.asStateFlow()
+
+    fun requestDeleteScan(scanId: Long) { _showDeleteConfirm.value = scanId }
+    fun dismissDeleteConfirm() { _showDeleteConfirm.value = null }
+
+    fun confirmDeleteScan() {
+        val id = _showDeleteConfirm.value ?: return
+        _showDeleteConfirm.value = null
+        viewModelScope.launch { repository.deleteScan(id) }
+    }
+
+    fun requestClearAll() { _showClearAllConfirm.value = true }
+    fun dismissClearAll() { _showClearAllConfirm.value = false }
+
+    fun confirmClearAll() {
+        _showClearAllConfirm.value = false
+        _selectedScan.value = null
+        viewModelScope.launch { repository.deleteAllScans() }
+    }
 }

--- a/app/src/main/java/com/androdr/ui/timeline/TimelineScreen.kt
+++ b/app/src/main/java/com/androdr/ui/timeline/TimelineScreen.kt
@@ -5,6 +5,8 @@ import android.content.ClipboardManager
 import android.content.Context
 import android.content.Intent
 import android.widget.Toast
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -25,6 +27,8 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.Description
+import androidx.compose.material.icons.filled.ExpandLess
+import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material.icons.filled.Timeline
@@ -48,6 +52,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -96,6 +101,7 @@ fun TimelineScreen(
 
     val reportText by viewModel.reportText.collectAsStateWithLifecycle()
 
+    var filterPanelExpanded by rememberSaveable { mutableStateOf(true) }
     var exportMenuExpanded by remember { mutableStateOf(false) }
     var pendingCopy by remember { mutableStateOf(false) }
 
@@ -187,105 +193,135 @@ fun TimelineScreen(
             }
         )
 
-        // Severity filter chips
-        val filterOptions = listOf(
-            null to stringResource(R.string.timeline_filter_all),
-            "CRITICAL" to stringResource(R.string.timeline_filter_critical),
-            "HIGH" to stringResource(R.string.timeline_filter_high),
-            "MEDIUM" to stringResource(R.string.timeline_filter_medium)
-        )
-        LazyRow(
-            contentPadding = PaddingValues(horizontal = 16.dp),
-            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable { filterPanelExpanded = !filterPanelExpanded }
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween
         ) {
-            items(filterOptions) { (severity, label) ->
-                FilterChip(
-                    selected = severityFilter == severity,
-                    onClick = { viewModel.setSeverityFilter(severity) },
-                    label = { Text(label) }
-                )
-            }
+            Text(
+                text = "Filters",
+                style = MaterialTheme.typography.labelLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Icon(
+                imageVector = if (filterPanelExpanded) Icons.Filled.ExpandLess
+                    else Icons.Filled.ExpandMore,
+                contentDescription = if (filterPanelExpanded) "Collapse filters"
+                    else "Expand filters",
+                tint = MaterialTheme.colorScheme.onSurfaceVariant
+            )
         }
 
-        // Package filter chips
-        val packages by viewModel.availablePackages.collectAsStateWithLifecycle()
-        val packageFilter by viewModel.packageFilter.collectAsStateWithLifecycle()
-
-        if (packages.isNotEmpty()) {
-            LazyRow(
-                contentPadding = PaddingValues(horizontal = 16.dp),
-                horizontalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                items(packages.take(10)) { pkg ->
-                    FilterChip(
-                        selected = packageFilter == pkg,
-                        onClick = { viewModel.setPackageFilter(if (packageFilter == pkg) null else pkg) },
-                        label = { Text(pkg.substringAfterLast("."), maxLines = 1) }
-                    )
+        AnimatedVisibility(visible = filterPanelExpanded) {
+            Column {
+                // Severity filter chips
+                val filterOptions = listOf(
+                    null to stringResource(R.string.timeline_filter_all),
+                    "CRITICAL" to stringResource(R.string.timeline_filter_critical),
+                    "HIGH" to stringResource(R.string.timeline_filter_high),
+                    "MEDIUM" to stringResource(R.string.timeline_filter_medium)
+                )
+                LazyRow(
+                    contentPadding = PaddingValues(horizontal = 16.dp),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    items(filterOptions) { (severity, label) ->
+                        FilterChip(
+                            selected = severityFilter == severity,
+                            onClick = { viewModel.setSeverityFilter(severity) },
+                            label = { Text(label) }
+                        )
+                    }
                 }
-            }
-        }
 
-        // Group mode toggle
-        LazyRow(
-            contentPadding = PaddingValues(horizontal = 16.dp),
-            horizontalArrangement = Arrangement.spacedBy(8.dp)
-        ) {
-            item {
-                FilterChip(
-                    selected = groupMode == TimelineGroupMode.DATE,
-                    onClick = { viewModel.setGroupMode(TimelineGroupMode.DATE) },
-                    label = { Text(stringResource(R.string.timeline_group_date)) }
-                )
-            }
-            item {
-                FilterChip(
-                    selected = groupMode == TimelineGroupMode.SCAN,
-                    onClick = { viewModel.setGroupMode(TimelineGroupMode.SCAN) },
-                    label = { Text(stringResource(R.string.timeline_group_scan)) }
-                )
-            }
-        }
+                // Package filter chips
+                val packages by viewModel.availablePackages.collectAsStateWithLifecycle()
+                val packageFilter by viewModel.packageFilter.collectAsStateWithLifecycle()
 
-        // Date range filter chips — use stable labels, compute timestamps on click
-        val dateRange by viewModel.dateRange.collectAsStateWithLifecycle()
-
-        data class RangeOption(val hoursBack: Int?, val label: String)
-        val rangeOptions = listOf(
-            RangeOption(null, stringResource(R.string.timeline_filter_all)),
-            RangeOption(24, stringResource(R.string.timeline_range_24h)),
-            RangeOption(24 * 7, stringResource(R.string.timeline_range_7d)),
-            RangeOption(24 * 30, stringResource(R.string.timeline_range_30d))
-        )
-        // Track which range is active by hours, not by raw timestamp
-        var activeRangeHours by remember { mutableStateOf<Int?>(null) }
-
-        // Sync with ViewModel dateRange state
-        if (dateRange == null) activeRangeHours = null
-
-        LazyRow(
-            contentPadding = PaddingValues(horizontal = 16.dp),
-            horizontalArrangement = Arrangement.spacedBy(8.dp)
-        ) {
-            items(rangeOptions) { option ->
-                FilterChip(
-                    selected = activeRangeHours == option.hoursBack,
-                    onClick = {
-                        if (option.hoursBack == null) {
-                            activeRangeHours = null
-                            viewModel.clearDateRange()
-                        } else {
-                            activeRangeHours = option.hoursBack
-                            val now = System.currentTimeMillis()
-                            viewModel.setDateRange(now - option.hoursBack * 3600_000L, now)
+                if (packages.isNotEmpty()) {
+                    LazyRow(
+                        contentPadding = PaddingValues(horizontal = 16.dp),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        items(packages.take(10)) { pkg ->
+                            FilterChip(
+                                selected = packageFilter == pkg,
+                                onClick = {
+                                    viewModel.setPackageFilter(
+                                        if (packageFilter == pkg) null else pkg
+                                    )
+                                },
+                                label = { Text(pkg.substringAfterLast("."), maxLines = 1) }
+                            )
                         }
-                    },
-                    label = { Text(option.label) }
+                    }
+                }
+
+                // Group mode toggle
+                LazyRow(
+                    contentPadding = PaddingValues(horizontal = 16.dp),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    item {
+                        FilterChip(
+                            selected = groupMode == TimelineGroupMode.DATE,
+                            onClick = { viewModel.setGroupMode(TimelineGroupMode.DATE) },
+                            label = { Text(stringResource(R.string.timeline_group_date)) }
+                        )
+                    }
+                    item {
+                        FilterChip(
+                            selected = groupMode == TimelineGroupMode.SCAN,
+                            onClick = { viewModel.setGroupMode(TimelineGroupMode.SCAN) },
+                            label = { Text(stringResource(R.string.timeline_group_scan)) }
+                        )
+                    }
+                }
+
+                // Date range filter chips
+                val dateRange by viewModel.dateRange.collectAsStateWithLifecycle()
+
+                data class RangeOption(val hoursBack: Int?, val label: String)
+                val rangeOptions = listOf(
+                    RangeOption(null, stringResource(R.string.timeline_filter_all)),
+                    RangeOption(24, stringResource(R.string.timeline_range_24h)),
+                    RangeOption(24 * 7, stringResource(R.string.timeline_range_7d)),
+                    RangeOption(24 * 30, stringResource(R.string.timeline_range_30d))
                 )
+                var activeRangeHours by remember { mutableStateOf<Int?>(null) }
+
+                if (dateRange == null) activeRangeHours = null
+
+                LazyRow(
+                    contentPadding = PaddingValues(horizontal = 16.dp),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    items(rangeOptions) { option ->
+                        FilterChip(
+                            selected = activeRangeHours == option.hoursBack,
+                            onClick = {
+                                if (option.hoursBack == null) {
+                                    activeRangeHours = null
+                                    viewModel.clearDateRange()
+                                } else {
+                                    activeRangeHours = option.hoursBack
+                                    val now = System.currentTimeMillis()
+                                    viewModel.setDateRange(
+                                        now - option.hoursBack * 3600_000L, now
+                                    )
+                                }
+                            },
+                            label = { Text(option.label) }
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(8.dp))
             }
         }
-
-        Spacer(modifier = Modifier.height(8.dp))
 
         if (events.isEmpty()) {
             // Empty state


### PR DESCRIPTION
## Summary
- **#54**: Delete individual scans or clear all history, with confirmation dialogs. Cascades to timeline events.
- **#55**: Timeline filter panel is now collapsible via a "Filters" header with expand/collapse chevron.

## Changes
### Scan history management
- `ScanResultDao`: `deleteById()`, `deleteAll()`
- `ForensicTimelineEventDao`: `deleteByScanId()`, `deleteAll()`
- `ScanRepository`: `deleteScan()` (cascades), `deleteAllScans()`
- `HistoryViewModel`: confirmation state flows for single/bulk delete
- `HistoryScreen`: delete button per card, "Clear All" button, AlertDialog confirmations

### Collapsible filter panel
- `TimelineScreen`: `rememberSaveable` toggle, clickable header, `AnimatedVisibility` wrapper

## Test plan
- [ ] Delete individual scan — verify scan and its timeline events are removed
- [ ] Clear all — verify empty state appears
- [ ] Collapse/expand filter panel — verify state persists across configuration changes
- [ ] Run scan after clearing history — verify new scan appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)