### PR TITLE
fix: rename Last Scan card to Scans with tap hint

### DIFF
--- a/app/src/main/java/com/androdr/MainActivity.kt
+++ b/app/src/main/java/com/androdr/MainActivity.kt
@@ -181,7 +181,14 @@ private fun AndroDRApp() {
                     type = NavType.StringType; nullable = true; defaultValue = null
                 })
             ) { entry ->
-                TimelineScreen(initialPackage = entry.arguments?.getString("pkg"))
+                TimelineScreen(
+                    initialPackage = entry.arguments?.getString("pkg"),
+                    onNavigateToHistory = {
+                        navController.navigate("history") {
+                            launchSingleTop = true
+                        }
+                    }
+                )
             }
             composable("bugreport") {
                 BugReportScreen()

--- a/app/src/main/java/com/androdr/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/com/androdr/ui/dashboard/DashboardScreen.kt
@@ -189,6 +189,7 @@ fun DashboardScreen(
                     modifier = Modifier.weight(1f),
                     title = stringResource(R.string.summary_last_scan),
                     value = lastScanTime,
+                    subtitle = if (latestScan != null) "Tap to manage" else null,
                     onClick = { onNavigate("history") }
                 )
             }
@@ -386,7 +387,8 @@ private fun SummaryCard(
     title: String,
     value: String,
     onClick: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    subtitle: String? = null
 ) {
     Card(
         modifier = modifier
@@ -413,6 +415,13 @@ private fun SummaryCard(
                 fontWeight = FontWeight.Bold,
                 color = MaterialTheme.colorScheme.onSurface
             )
+            if (subtitle != null) {
+                Text(
+                    text = subtitle,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/androdr/ui/timeline/TimelineScreen.kt
+++ b/app/src/main/java/com/androdr/ui/timeline/TimelineScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.Description
+import androidx.compose.material.icons.filled.History
 import androidx.compose.material.icons.filled.ExpandLess
 import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.filled.MoreVert
@@ -80,6 +81,7 @@ private data class DateEntry(
 @Composable
 fun TimelineScreen(
     initialPackage: String? = null,
+    onNavigateToHistory: (() -> Unit)? = null,
     viewModel: TimelineViewModel = hiltViewModel()
 ) {
     // Apply deep-link filter once on first composition
@@ -135,6 +137,12 @@ fun TimelineScreen(
         TopAppBar(
             title = { Text(stringResource(R.string.timeline_title)) },
             actions = {
+                // Manage scan history
+                if (onNavigateToHistory != null) {
+                    IconButton(onClick = onNavigateToHistory) {
+                        Icon(Icons.Filled.History, contentDescription = "Manage scans")
+                    }
+                }
                 // View report
                 IconButton(
                     onClick = {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,7 +13,7 @@
     <string name="summary_app_risks">App Risks</string>
     <string name="summary_device_flags">Device Flags</string>
     <string name="summary_dns_matched">Suspicious Connections</string>
-    <string name="summary_last_scan">Last Scan</string>
+    <string name="summary_last_scan">Scans</string>
     <string name="never">Never</string>
     <!-- PluralsCandidate: "risk(s)" is intentional shorthand for a single UI banner;
          a full plurals resource would add overhead with no real i18n benefit for this string. -->


### PR DESCRIPTION
## Summary
- Renamed dashboard card from "Last Scan" to "Scans" — makes it clear this leads to scan history management
- Added "Tap to manage" subtitle so users discover the delete/clear controls
- Added optional `subtitle` parameter to `SummaryCard` composable

🤖 Generated with [Claude Code](https://claude.com/claude-code)