### PR TITLE
fix: suppress LongMethod detekt violation on evaluateFieldMatcher

### DIFF
--- a/app/src/main/java/com/androdr/sigma/SigmaRuleEvaluator.kt
+++ b/app/src/main/java/com/androdr/sigma/SigmaRuleEvaluator.kt
@@ -165,7 +165,9 @@ object SigmaRuleEvaluator {
         }
     }
 
-    @Suppress("CyclomaticComplexMethod", "ReturnCount")
+    @Suppress("CyclomaticComplexMethod", "ReturnCount", "LongMethod")
+    // LongMethod: list-aware matching adds element-wise branches for each string modifier;
+    // splitting would fragment tightly coupled matching logic.
     private fun evaluateFieldMatcher(
         matcher: SigmaFieldMatcher,
         record: Map<String, Any?>,


### PR DESCRIPTION
## Summary
Adds `LongMethod` suppression to `evaluateFieldMatcher` after the list-aware matching refactor expanded it beyond 60 lines.

## Context
The function grew from 55 to 79 lines due to the element-wise list matching branches added in the previous commit. Splitting would fragment tightly coupled matching logic.

## Test plan
- [x] `./gradlew detekt` passes
- [x] `./gradlew testDebugUnitTest` passes (including 4 new list matching tests)
- [x] `./gradlew lintDebug` passes