### PR TITLE
feat: notification listener fixture + sideload install fix

### DIFF
--- a/app/src/main/java/com/androdr/scanner/AppScanner.kt
+++ b/app/src/main/java/com/androdr/scanner/AppScanner.kt
@@ -147,12 +147,27 @@ class AppScanner @Inject constructor(
                 recv.permission == "android.permission.BIND_DEVICE_ADMIN"
             } == true
 
-            // Raw component lists — enables manifest-based detections as pure rule updates
-            val servicePermissions = pkg.services
+            // Raw component lists — enables manifest-based detections as pure rule updates.
+            // getInstalledPackages may truncate component arrays due to Binder size limits,
+            // so fall back to per-package getPackageInfo when services/receivers are null.
+            val pkgDetail = if (pkg.services == null || pkg.receivers == null) {
+                @Suppress("TooGenericExceptionCaught", "SwallowedException")
+                try {
+                    pm.getPackageInfo(
+                        packageName,
+                        PackageManager.GET_SERVICES or PackageManager.GET_RECEIVERS
+                    )
+                } catch (e: Exception) {
+                    null
+                }
+            } else {
+                null
+            }
+            val servicePermissions = (pkg.services ?: pkgDetail?.services)
                 ?.mapNotNull { it.permission }
                 ?.distinct()
                 ?: emptyList()
-            val receiverPermissions = pkg.receivers
+            val receiverPermissions = (pkg.receivers ?: pkgDetail?.receivers)
                 ?.mapNotNull { it.permission }
                 ?.distinct()
                 ?: emptyList()

--- a/test-adversary/fixtures/expected/mercenary_accessibility.patterns
+++ b/test-adversary/fixtures/expected/mercenary_accessibility.patterns
@@ -1,1 +1,2 @@
 Accessibility Abuse
+Hidden App (No Launcher Icon)

--- a/test-adversary/fixtures/expected/mercenary_device_admin.patterns
+++ b/test-adversary/fixtures/expected/mercenary_device_admin.patterns
@@ -1,1 +1,2 @@
 Device Admin Abuse
+Hidden App (No Launcher Icon)

--- a/test-adversary/fixtures/expected/multi_abuse_combo.patterns
+++ b/test-adversary/fixtures/expected/multi_abuse_combo.patterns
@@ -1,3 +1,4 @@
 Surveillance Permissions
 Accessibility Abuse
 Device Admin Abuse
+Hidden App (No Launcher Icon)

--- a/test-adversary/fixtures/expected/notification_listener_abuse.patterns
+++ b/test-adversary/fixtures/expected/notification_listener_abuse.patterns
@@ -1,2 +1,2 @@
-known threat developer
+Notification Listener
 Hidden App (No Launcher Icon)

--- a/test-adversary/fixtures/mercenary/build-fixtures.sh
+++ b/test-adversary/fixtures/mercenary/build-fixtures.sh
@@ -45,6 +45,7 @@ MODULES=(
     "impersonation-play-store"
     "multi-abuse-combo"
     "firmware-implant-sim"
+    "notification-listener-abuse"
 )
 
 echo ""

--- a/test-adversary/fixtures/mercenary/notification-listener-abuse/build.gradle.kts
+++ b/test-adversary/fixtures/mercenary/notification-listener-abuse/build.gradle.kts
@@ -1,0 +1,12 @@
+plugins { id("com.android.application") }
+android {
+    namespace = "com.androdr.fixture.notiflistener"
+    compileSdk = 34
+    defaultConfig {
+        applicationId = "com.androdr.fixture.notiflistener"
+        minSdk = 21
+        targetSdk = 34
+        versionCode = 1
+        versionName = "1.0"
+    }
+}

--- a/test-adversary/fixtures/mercenary/notification-listener-abuse/src/main/AndroidManifest.xml
+++ b/test-adversary/fixtures/mercenary/notification-listener-abuse/src/main/AndroidManifest.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application android:label="Notification Helper">
+        <service
+            android:name="com.androdr.fixture.notiflistener.Svc"
+            android:permission="android.permission.BIND_NOTIFICATION_LISTENER_SERVICE"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.service.notification.NotificationListenerService" />
+            </intent-filter>
+        </service>
+    </application>
+</manifest>

--- a/test-adversary/fixtures/mercenary/notification-listener-abuse/src/main/java/com/androdr/fixture/notiflistener/Svc.kt
+++ b/test-adversary/fixtures/mercenary/notification-listener-abuse/src/main/java/com/androdr/fixture/notiflistener/Svc.kt
@@ -1,0 +1,7 @@
+package com.androdr.fixture.notiflistener
+import android.service.notification.NotificationListenerService
+import android.service.notification.StatusBarNotification
+class Svc : NotificationListenerService() {
+    override fun onNotificationPosted(sbn: StatusBarNotification?) {}
+    override fun onNotificationRemoved(sbn: StatusBarNotification?) {}
+}

--- a/test-adversary/fixtures/mercenary/settings.gradle.kts
+++ b/test-adversary/fixtures/mercenary/settings.gradle.kts
@@ -20,5 +20,6 @@ include(
     ":system-name-disguise",
     ":impersonation-play-store",
     ":multi-abuse-combo",
-    ":firmware-implant-sim"
+    ":firmware-implant-sim",
+    ":notification-listener-abuse"
 )

--- a/test-adversary/manifest.yml
+++ b/test-adversary/manifest.yml
@@ -24,7 +24,7 @@ profiles:
 
   stalkerware:
     description: "Commercial surveillance / stalkerware"
-    scenarios: [thetruthspy_stalkerware, andrmonitor_stalkerware, tispy_stalkerware, cocospy_stalkerware, mspy_stalkerware, eyezy_stalkerware]
+    scenarios: [thetruthspy_stalkerware, andrmonitor_stalkerware, tispy_stalkerware, cocospy_stalkerware, mspy_stalkerware, eyezy_stalkerware, notification_listener_abuse]
 
   full:
     description: "All scenarios"
@@ -404,6 +404,21 @@ scenarios:
       - "surveillance capabilities"
       - "Accessibility Abuse"
       - "Device Admin Abuse"
+
+  - id: notification_listener_abuse
+    track: 3
+    risk: high
+    technique: T1629
+    tactic: defense-evasion
+    description: "Sideloaded app with NotificationListenerService to intercept notifications"
+    source: fixture
+    fixture: fixtures/mercenary/notification-listener-abuse.apk
+    sha256: "69ab48a8ed7aef60e4b821fa827ad569dfe8968b5a945d846b2be3d8da335b03"
+    tags: [android, notification-listener, stalkerware-pattern]
+    attack: [T1629]
+    expected_patterns:
+      - "Notification Listener"
+      - "Hidden App (No Launcher Icon)"
 
   - id: firmware_implant_sim
     track: 3

--- a/test-adversary/run.sh
+++ b/test-adversary/run.sh
@@ -206,6 +206,20 @@ get_pkg_name() {
     echo "$pkg"
 }
 
+# Install APK as sideloaded (no trusted installer).
+# ADB install sets initiatingPackageName=com.android.shell which is treated as
+# a trusted OEM installer. Push + pm install -i <real-pkg> uses a non-OEM
+# installer so AndroDR correctly marks the app as sideloaded.
+sideload_install() {
+    local apk="$1"
+    local remote="/data/local/tmp/$(basename "$apk")"
+    $ADB push "$apk" "$remote" </dev/null >/dev/null 2>&1 || return 1
+    $ADB shell pm install -t -i com.androdr.debug "$remote" </dev/null 2>&1 | tail -1 | grep -q "Success"
+    local rc=$?
+    $ADB shell rm -f "$remote" </dev/null 2>/dev/null
+    return $rc
+}
+
 # ── Per-scenario execution ────────────────────────────────────────────────────
 
 run_scenario() {
@@ -291,20 +305,11 @@ run_scenario() {
         echo "  Network isolated"
     fi
 
-    # Step 3: INSTALL
+    # Step 3: INSTALL (as sideloaded — no trusted installer)
     if [ -n "$apk_path" ]; then
         echo "  Installing $apk_path..."
-        if $ADB install -t "$apk_path" 2>&1 | tail -1 | grep -q "Success"; then
-            # Extract package name: use aapt2 if available, then grep pm list
-            pkg_name=$(aapt2 dump packagename "$apk_path" 2>/dev/null || true)
-            if [ -z "$pkg_name" ] && [ -n "${ANDROID_HOME:-}" ]; then
-                local aapt_bin="$ANDROID_HOME/build-tools/$(ls "$ANDROID_HOME/build-tools/" 2>/dev/null | sort -V | tail -1)/aapt2"
-                pkg_name=$("$aapt_bin" dump packagename "$apk_path" 2>/dev/null || true)
-            fi
-            if [ -z "$pkg_name" ]; then
-                # Last resort: diff pm list before/after install
-                pkg_name=$($ADB shell pm list packages 2>/dev/null | tail -1 | sed 's/package://' || true)
-            fi
+        if sideload_install "$apk_path"; then
+            pkg_name=$(get_pkg_name "$apk_path")
             if [ -n "$pkg_name" ]; then
                 INSTALLED_PACKAGES+=("$pkg_name")
             fi
@@ -466,7 +471,7 @@ if [ "$MODE" = "load" ] || [ "$MODE" = "guided" ]; then
 
         if [ -n "$apk_path" ]; then
             echo "  Installing $scenario_id..."
-            if $ADB install -t "$apk_path" </dev/null 2>&1 | tail -1 | grep -q "Success"; then
+            if sideload_install "$apk_path"; then
                 local_pkg=$(get_pkg_name "$apk_path")
                 [ -n "$local_pkg" ] && echo "$local_pkg" >> "$STATE_FILE"
                 INSTALLED_PACKAGES+=("${local_pkg:-unknown}")


### PR DESCRIPTION
## Summary
- New `notification-listener-abuse` fixture validating SIGMA rule androdr-067 (NotificationListenerService abuse detection)
- Fixed harness install method: `adb install` sets `initiatingPackageName=com.android.shell` which matches the `com.android.` OEM prefix, causing all fixture installs to appear as trusted. Now uses `pm install -i com.androdr.debug` to simulate realistic sideload conditions
- Added Binder truncation fallback in AppScanner: per-package `getPackageInfo` when `getInstalledPackages` returns null services/receivers arrays
- Updated 4 existing pattern files to assert Hidden App (No Launcher Icon) detection on launcher-less fixtures

## Test plan
- [x] Unit tests pass (`testDebugUnitTest`)
- [x] Lint passes (`lintDebug`)
- [x] Notification listener fixture builds and installs
- [x] Rule 067 fires with sideload install (verified: `Notification Listener (Sideloaded)` in report)
- [x] Rule 068 fires on launcher-less fixtures (verified: `Hidden App (No Launcher Icon)`)
- [x] Existing harness scenarios unaffected by install method change

🤖 Generated with [Claude Code](https://claude.com/claude-code)