### PR TITLE
fix: eliminate duplicate CI runs

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -2,7 +2,7 @@ name: Android Build
 
 on:
   push:
-    branches: [ "**" ]
+    branches: [ main ]
   pull_request:
     branches: [ main ]
 


### PR DESCRIPTION
## Summary
- CI workflow had `push: branches: ["**"]` which triggered on every branch push, duplicating the `pull_request` trigger
- Changed to `push: branches: [main]` — PRs get CI via `pull_request`, main gets post-merge validation via `push`

🤖 Generated with [Claude Code](https://claude.com/claude-code)