### PR TITLE
fix: normalize AppOps operation names to Android canonical format

### DIFF
--- a/app/src/main/java/com/androdr/scanner/bugreport/AppOpsModule.kt
+++ b/app/src/main/java/com/androdr/scanner/bugreport/AppOpsModule.kt
@@ -56,9 +56,11 @@ class AppOpsModule @Inject constructor() : BugreportModule {
                         val accessMatch = accessLineRegex.find(opBlock)
                         val rejectMatch = rejectLineRegex.find(opBlock)
 
+                        // Normalize to "android:<op>" format to match SIGMA rule conventions
+                        val normalizedOp = "android:${opName.lowercase()}"
                         telemetry.add(mapOf(
                             "package_name" to packageName,
-                            "operation" to opName,
+                            "operation" to normalizedOp,
                             "last_access_time" to (accessMatch?.groupValues?.get(1) ?: ""),
                             "last_reject_time" to (rejectMatch?.groupValues?.get(1) ?: ""),
                             "access_count" to 1,

--- a/app/src/test/java/com/androdr/scanner/bugreport/AppOpsModuleTest.kt
+++ b/app/src/test/java/com/androdr/scanner/bugreport/AppOpsModuleTest.kt
@@ -37,7 +37,7 @@ class AppOpsModuleTest {
         val result = module.analyze(section, mockIndicatorResolver)
         assertTrue(result.telemetry.any {
             it["package_name"] == "com.suspicious.installer" &&
-                it["operation"] == "REQUEST_INSTALL_PACKAGES" &&
+                it["operation"] == "android:request_install_packages" &&
                 it["is_system_app"] == false
         })
     }
@@ -54,7 +54,7 @@ class AppOpsModuleTest {
         val result = module.analyze(section, mockIndicatorResolver)
         assertTrue(result.telemetry.any {
             it["package_name"] == "com.android.shell" &&
-                it["operation"] == "CAMERA"
+                it["operation"] == "android:camera"
         })
     }
 
@@ -79,7 +79,7 @@ class AppOpsModuleTest {
         val result = module.analyze(section, mockIndicatorResolver)
         assertTrue(result.telemetry.any {
             it["package_name"] == "com.flexispy.android" &&
-                it["operation"] == "CAMERA" &&
+                it["operation"] == "android:camera" &&
                 it["is_system_app"] == false
         })
     }

--- a/app/src/test/java/com/androdr/scanner/bugreport/AppOpsRuleIntegrationTest.kt
+++ b/app/src/test/java/com/androdr/scanner/bugreport/AppOpsRuleIntegrationTest.kt
@@ -1,0 +1,205 @@
+package com.androdr.scanner.bugreport
+
+import com.androdr.ioc.IndicatorResolver
+import com.androdr.sigma.SigmaRuleEvaluator
+import com.androdr.sigma.SigmaRuleParser
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Integration test: feeds real AppOpsModule output through actual SIGMA rules
+ * to catch telemetry-to-rule dialect mismatches (e.g., "CAMERA" vs "android:camera").
+ */
+class AppOpsRuleIntegrationTest {
+
+    private val mockIndicatorResolver: IndicatorResolver = mockk()
+    private lateinit var module: AppOpsModule
+
+    // Actual SIGMA rule YAML matching what ships in res/raw
+    private val cameraRuleYaml = """
+        title: Non-system app accessed camera
+        id: androdr-064
+        status: production
+        description: test
+        author: test
+        date: 2026/01/01
+        tags:
+            - attack.t1429
+        logsource:
+            product: androdr
+            service: appops_audit
+        detection:
+            selection:
+                operation: "android:camera"
+                is_system_app: false
+            condition: selection
+        level: medium
+        display:
+            category: app_risk
+    """.trimIndent()
+
+    private val micRuleYaml = """
+        title: Non-system app accessed microphone
+        id: androdr-063
+        status: production
+        description: test
+        author: test
+        date: 2026/01/01
+        tags:
+            - attack.t1429
+        logsource:
+            product: androdr
+            service: appops_audit
+        detection:
+            selection:
+                operation: "android:record_audio"
+                is_system_app: false
+            condition: selection
+        level: medium
+        display:
+            category: app_risk
+    """.trimIndent()
+
+    private val installRuleYaml = """
+        title: Non-system app used install packages
+        id: androdr-065
+        status: production
+        description: test
+        author: test
+        date: 2026/01/01
+        tags:
+            - attack.t1407
+        logsource:
+            product: androdr
+            service: appops_audit
+        detection:
+            selection:
+                operation: "android:request_install_packages"
+                is_system_app: false
+            condition: selection
+        level: high
+        display:
+            category: app_risk
+    """.trimIndent()
+
+    @Before
+    fun setUp() {
+        every { mockIndicatorResolver.isKnownBadPackage(any()) } returns null
+        module = AppOpsModule()
+    }
+
+    @Test
+    fun `module camera output triggers camera SIGMA rule`() = runBlocking {
+        val section = """
+            Uid 10200:
+              Package com.suspicious.app:
+                CAMERA (allow):
+                  Access: [fg-s] 2026-03-27 14:30:00
+        """.trimIndent()
+
+        val result = module.analyze(section, mockIndicatorResolver)
+        val rule = SigmaRuleParser.parse(cameraRuleYaml)!!
+        val findings = SigmaRuleEvaluator.evaluate(
+            listOf(rule), result.telemetry, "appops_audit"
+        )
+        assertTrue(
+            "AppOpsModule camera output must trigger androdr-064 rule — " +
+                "check operation name format matches between module and rule",
+            findings.any { it.triggered && it.ruleId == "androdr-064" }
+        )
+    }
+
+    @Test
+    fun `module microphone output triggers microphone SIGMA rule`() = runBlocking {
+        val section = """
+            Uid 10200:
+              Package com.suspicious.app:
+                RECORD_AUDIO (allow):
+                  Access: [fg-s] 2026-03-27 14:35:00
+        """.trimIndent()
+
+        val result = module.analyze(section, mockIndicatorResolver)
+        val rule = SigmaRuleParser.parse(micRuleYaml)!!
+        val findings = SigmaRuleEvaluator.evaluate(
+            listOf(rule), result.telemetry, "appops_audit"
+        )
+        assertTrue(
+            "AppOpsModule mic output must trigger androdr-063 rule — " +
+                "check operation name format matches between module and rule",
+            findings.any { it.triggered && it.ruleId == "androdr-063" }
+        )
+    }
+
+    @Test
+    fun `module install packages output triggers install SIGMA rule`() = runBlocking {
+        val section = """
+            Uid 10200:
+              Package com.suspicious.installer:
+                REQUEST_INSTALL_PACKAGES (allow):
+                  Access: [fg-s] 2026-03-27 14:40:00
+        """.trimIndent()
+
+        val result = module.analyze(section, mockIndicatorResolver)
+        val rule = SigmaRuleParser.parse(installRuleYaml)!!
+        val findings = SigmaRuleEvaluator.evaluate(
+            listOf(rule), result.telemetry, "appops_audit"
+        )
+        assertTrue(
+            "AppOpsModule install output must trigger androdr-065 rule — " +
+                "check operation name format matches between module and rule",
+            findings.any { it.triggered && it.ruleId == "androdr-065" }
+        )
+    }
+
+    @Test
+    fun `system app camera usage does not trigger rule`() = runBlocking {
+        val section = """
+            Uid 1000:
+              Package com.android.systemui:
+                CAMERA (allow):
+                  Access: [fg-s] 2026-03-27 14:30:00
+        """.trimIndent()
+
+        val result = module.analyze(section, mockIndicatorResolver)
+        val rule = SigmaRuleParser.parse(cameraRuleYaml)!!
+        val findings = SigmaRuleEvaluator.evaluate(
+            listOf(rule), result.telemetry, "appops_audit"
+        )
+        assertTrue(
+            "System app camera usage must not trigger rule",
+            findings.none { it.triggered }
+        )
+    }
+
+    @Test
+    fun `all dangerous ops normalize to android colon lowercase format`() = runBlocking {
+        val allOps = listOf(
+            "CAMERA", "RECORD_AUDIO", "READ_SMS", "RECEIVE_SMS", "SEND_SMS",
+            "READ_CONTACTS", "READ_CALL_LOG", "ACCESS_FINE_LOCATION",
+            "READ_EXTERNAL_STORAGE", "REQUEST_INSTALL_PACKAGES"
+        )
+
+        for (op in allOps) {
+            val section = """
+                Uid 10200:
+                  Package com.test.app:
+                    $op (allow):
+                      Access: [fg-s] 2026-03-27 14:30:00
+            """.trimIndent()
+
+            val result = module.analyze(section, mockIndicatorResolver)
+            val telemetry = result.telemetry.first()
+            val operation = telemetry["operation"] as String
+
+            assertTrue(
+                "Operation '$op' must normalize to 'android:${op.lowercase()}' " +
+                    "but was '$operation'",
+                operation == "android:${op.lowercase()}"
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- AppOpsModule emitted dumpsys display names (`CAMERA`) but SIGMA rules expected Android `OPSTR_*` constants (`android:camera`) — bugreport capability-usage detection was silently broken
- Added `android:` prefix + lowercase normalization at the module boundary
- Added integration tests that feed real module output through actual SIGMA rules to catch dialect mismatches

## Test plan
- [x] All unit tests pass
- [x] 5 new integration tests verify module→rule pipeline for camera, mic, install, system app, and all-ops normalization
- [x] Existing AppOpsModuleTest updated to expect canonical format

🤖 Generated with [Claude Code](https://claude.com/claude-code)