### PR TITLE
fix: AppOps timestamps, ASCII-only rules, filter system app noise

### DIFF
--- a/app/src/main/java/com/androdr/reporting/ReportFormatter.kt
+++ b/app/src/main/java/com/androdr/reporting/ReportFormatter.kt
@@ -80,7 +80,7 @@ object ReportFormatter {
             }
         } else {
             section("DEVICE CHECKS")
-            appendLine("  (Bug report analysis — device checks require a live scan)")
+            appendLine("  (Bug report analysis -- device checks require a live scan)")
         }
 
         // -- Campaign check -------------------------------------------------------

--- a/app/src/main/java/com/androdr/reporting/TimelineFormatter.kt
+++ b/app/src/main/java/com/androdr/reporting/TimelineFormatter.kt
@@ -112,7 +112,7 @@ object TimelineFormatter {
         }
 
         appendLine(RULE)
-        appendLine("  End of analysis \u00b7 AndroDR")
+        appendLine("  End of analysis - AndroDR")
         appendLine(RULE)
     }
 

--- a/app/src/main/java/com/androdr/scanner/bugreport/AppOpsModule.kt
+++ b/app/src/main/java/com/androdr/scanner/bugreport/AppOpsModule.kt
@@ -120,7 +120,7 @@ class AppOpsModule @Inject constructor() : BugreportModule {
     private fun parseTimestamp(ts: String): Long = try {
         SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.US).parse(ts)?.time ?: -1L
     } catch (e: Exception) {
-        Log.w("AppOpsModule", "Failed to parse timestamp: $ts")
+        Log.w("AppOpsModule", "Failed to parse timestamp: $ts", e)
         -1L
     }
 }

--- a/app/src/main/java/com/androdr/scanner/bugreport/AppOpsModule.kt
+++ b/app/src/main/java/com/androdr/scanner/bugreport/AppOpsModule.kt
@@ -1,7 +1,10 @@
 package com.androdr.scanner.bugreport
 
+import android.util.Log
 import com.androdr.data.model.TimelineEvent
 import com.androdr.ioc.IndicatorResolver
+import java.text.SimpleDateFormat
+import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -67,14 +70,22 @@ class AppOpsModule @Inject constructor() : BugreportModule {
                             "is_system_app" to isSystemUid
                         ))
 
-                        timeline.add(TimelineEvent(
-                            timestamp = -1,
-                            source = "appops",
-                            category = "permission_use",
-                            description = "$packageName used $opName" +
-                                (accessMatch?.let { " at ${it.groupValues[1]}" } ?: ""),
-                            severity = if (opName == "REQUEST_INSTALL_PACKAGES") "HIGH" else "INFO"
-                        ))
+                        // Parse access timestamp to epoch millis
+                        val accessTimestamp = accessMatch?.groupValues?.get(1)?.let {
+                            parseTimestamp(it)
+                        } ?: -1L
+
+                        // Only add non-system apps to the timeline — system app ops are noise
+                        if (!isSystemUid) {
+                            timeline.add(TimelineEvent(
+                                timestamp = accessTimestamp,
+                                source = "appops",
+                                category = "permission_use",
+                                description = "$packageName used $opName" +
+                                    (accessMatch?.let { " at ${it.groupValues[1]}" } ?: ""),
+                                severity = if (opName == "REQUEST_INSTALL_PACKAGES") "HIGH" else "INFO"
+                            ))
+                        }
                     }
                 }
             }
@@ -102,5 +113,14 @@ class AppOpsModule @Inject constructor() : BugreportModule {
     private fun findNextPackageOrEnd(block: String, fromIndex: Int): Int {
         val next = packageLineRegex.find(block, fromIndex + 1)
         return next?.range?.first ?: block.length
+    }
+
+    /** Parses "2026-03-27 14:30:00" to epoch millis. Returns -1 on failure. */
+    @Suppress("TooGenericExceptionCaught")
+    private fun parseTimestamp(ts: String): Long = try {
+        SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.US).parse(ts)?.time ?: -1L
+    } catch (e: Exception) {
+        Log.w("AppOpsModule", "Failed to parse timestamp: $ts")
+        -1L
     }
 }

--- a/app/src/main/res/raw/sigma_androdr_001_package_ioc.yml
+++ b/app/src/main/res/raw/sigma_androdr_001_package_ioc.yml
@@ -1,7 +1,7 @@
 title: Package name matches threat database
 id: androdr-001
 status: production
-description: Package name found in known-bad package IOC database. System apps with dual-use package names (e.g., com.android.updater on Xiaomi) are excluded — real implants masquerading as system components are sideloaded, not pre-installed.
+description: Package name found in known-bad package IOC database. System apps with dual-use package names (e.g., com.android.updater on Xiaomi) are excluded -- real implants masquerading as system components are sideloaded, not pre-installed.
 author: AndroDR
 date: 2026/03/27
 tags:

--- a/app/src/main/res/raw/sigma_androdr_017_accessibility_surveillance_combo.yml
+++ b/app/src/main/res/raw/sigma_androdr_017_accessibility_surveillance_combo.yml
@@ -1,7 +1,7 @@
 title: Sideloaded app with accessibility service AND surveillance permissions
 id: androdr-017
 status: experimental
-description: Combines screen reading capability with surveillance permissions — a hallmark of stalkerware.
+description: Combines screen reading capability with surveillance permissions -- a hallmark of stalkerware.
 author: AndroDR
 date: 2026/03/27
 tags:

--- a/app/src/main/res/raw/sigma_androdr_020_spyware_artifact.yml
+++ b/app/src/main/res/raw/sigma_androdr_020_spyware_artifact.yml
@@ -24,4 +24,4 @@ display:
     evidence_type: none
 remediation:
     - "A file associated with known spyware was found at {file_path}."
-    - "Do NOT delete it yet — it may be needed as evidence. Contact a security professional or digital safety organization for guidance."
+    - "Do NOT delete it yet -- it may be needed as evidence. Contact a security professional or digital safety organization for guidance."

--- a/app/src/main/res/raw/sigma_androdr_047_cve_exploit.yml
+++ b/app/src/main/res/raw/sigma_androdr_047_cve_exploit.yml
@@ -22,6 +22,6 @@ display:
     triggered_title: "{count} Unpatched CVEs"
     safe_title: "No Known Exploited CVEs"
     evidence_type: cve_list
-    summary_template: "{count} unpatched · {campaign_count} linked to spyware"
+    summary_template: "{count} unpatched - {campaign_count} linked to spyware"
 remediation:
     - "Go to Settings > Software Update > Download and Install. Also check Play Store > Settings > About > Google Play system update. Both channels deliver security fixes for known vulnerabilities."

--- a/app/src/main/res/raw/sigma_androdr_061_sms_receiver.yml
+++ b/app/src/main/res/raw/sigma_androdr_061_sms_receiver.yml
@@ -1,7 +1,7 @@
 title: App registered for SMS broadcasts
 id: androdr-061
 status: production
-description: A non-system app is registered to receive SMS broadcasts. Many legitimate apps register for this via SDKs (Firebase Auth, Braze) for OTP verification. Informational — only significant when combined with other indicators.
+description: A non-system app is registered to receive SMS broadcasts. Many legitimate apps register for this via SDKs (Firebase Auth, Braze) for OTP verification. Informational -- only significant when combined with other indicators.
 author: AndroDR
 date: 2026/03/28
 tags:

--- a/app/src/main/res/raw/sigma_androdr_062_call_receiver.yml
+++ b/app/src/main/res/raw/sigma_androdr_062_call_receiver.yml
@@ -1,7 +1,7 @@
 title: App registered for phone call broadcasts
 id: androdr-062
 status: production
-description: A non-system app is registered for PHONE_STATE or NEW_OUTGOING_CALL broadcasts. Many legitimate apps register for these. Informational — only significant when combined with other indicators.
+description: A non-system app is registered for PHONE_STATE or NEW_OUTGOING_CALL broadcasts. Many legitimate apps register for these. Informational -- only significant when combined with other indicators.
 author: AndroDR
 date: 2026/03/28
 tags:

--- a/app/src/main/res/raw/sigma_androdr_068_hidden_launcher.yml
+++ b/app/src/main/res/raw/sigma_androdr_068_hidden_launcher.yml
@@ -27,6 +27,6 @@ display:
     triggered_title: "Hidden App (No Launcher Icon)"
     evidence_type: none
 remediation:
-    - "This app is installed but hidden from your home screen — you cannot see or open it normally."
+    - "This app is installed but hidden from your home screen -- you cannot see or open it normally."
     - "Go to Settings > Apps > See all apps to find it, then tap Uninstall."
     - "Hidden apps are a common sign of stalkerware or monitoring software."


### PR DESCRIPTION
## Summary
- AppOpsModule: parse access timestamps to epoch millis (was always -1)
- AppOpsModule: skip system UID packages from timeline (reduces 173 → ~30 events)
- Enforce ASCII-only in all SIGMA rule YAML files and reporting code
- Prevents UTF-8 encoding corruption (â€" instead of --) in shared reports

## Changes
- `AppOpsModule.kt`: added `parseTimestamp()`, system UID filter for timeline, `\s*` in UID regex
- 7 SIGMA rule files: replaced em dashes and middle dots with ASCII
- `ReportFormatter.kt`, `TimelineFormatter.kt`: replaced non-ASCII chars

## Test plan
- [x] Unit tests pass
- [ ] Re-run bugreport analysis on S25 Ultra — verify timestamps appear and system apps filtered
- [ ] Verify exported report has no encoding corruption