### PR TITLE
feat: report quality -- forensic verdict, display names, action guidance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,9 @@ node_modules/
 *.class
 .kotlin/
 
+# Exported reports (may contain real device data)
+docs/play-store/androdr_*.txt
+
 # Virtual machine crash logs
 hs_err_pid*
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -22,6 +22,12 @@ android {
         versionCode = buildNumber
         versionName = "0.9.0.$buildNumber"
 
+        buildConfigField(
+            "String",
+            "RELEASE_NOTE",
+            "\"Report quality: forensic verdict, display names, action guidance\""
+        )
+
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
         vectorDrawables {

--- a/app/src/main/java/com/androdr/reporting/ReportExporter.kt
+++ b/app/src/main/java/com/androdr/reporting/ReportExporter.kt
@@ -33,7 +33,10 @@ class ReportExporter @Inject constructor(
         val inventory = scanOrchestrator.lastAppTelemetry.ifEmpty {
             runCatching { appScanner.collectTelemetry() }.getOrDefault(emptyList())
         }
-        val text      = ReportFormatter.formatScanReport(scan, dnsEvents, logLines, inventory)
+        val displayNames = inventory
+            .associate { it.packageName to it.appName }
+            .filterValues { it.isNotEmpty() }
+        val text      = ReportFormatter.formatScanReport(scan, dnsEvents, logLines, inventory, displayNames)
 
         val reportsDir = File(context.cacheDir, "reports").apply { mkdirs() }
         val filename = "androdr_report_${filenameFmt.format(Date(scan.timestamp))}.txt"

--- a/app/src/main/java/com/androdr/reporting/ReportFormatter.kt
+++ b/app/src/main/java/com/androdr/reporting/ReportFormatter.kt
@@ -253,15 +253,12 @@ object ReportFormatter {
         appendLine()
 
         // Action guidance (only if something actionable)
-        appendActionGuidance(scan, displayNames)
+        appendActionGuidance(scan)
     }
 
     // Collects action guidance from Finding.guidance (rule-driven) and device posture summary.
     // Ordered: CRITICAL-prefixed first, then others, then device posture.
-    private fun StringBuilder.appendActionGuidance(
-        scan: ScanResult,
-        displayNames: Map<String, String>
-    ) {
+    private fun StringBuilder.appendActionGuidance(scan: ScanResult) {
         val actions = mutableListOf<String>()
 
         // Collect rule-driven guidance from triggered app risk findings

--- a/app/src/main/java/com/androdr/reporting/ReportFormatter.kt
+++ b/app/src/main/java/com/androdr/reporting/ReportFormatter.kt
@@ -12,6 +12,7 @@ import java.util.Locale
 /**
  * Produces human-readable plaintext security reports from scan data.
  * All methods are pure (no I/O) so they can be unit-tested without a device.
+ * Output is strictly ASCII -- no Unicode characters.
  */
 object ReportFormatter {
 
@@ -22,7 +23,8 @@ object ReportFormatter {
         scan: ScanResult,
         dnsEvents: List<DnsEvent>,
         logLines: List<String>,
-        appInventory: List<AppTelemetry> = emptyList()
+        appInventory: List<AppTelemetry> = emptyList(),
+        displayNames: Map<String, String> = emptyMap()
     ): String = buildString {
         val timestampFmt = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.US)
         val dnsFmt = SimpleDateFormat("HH:mm:ss", Locale.US)
@@ -41,23 +43,10 @@ object ReportFormatter {
         appendLine(RULE)
         appendLine()
         appendLine("  OVERALL RISK: ${scan.overallRiskLevel.name}")
+        appendLine()
 
-        appendLine()
-        val appRiskCount = scan.appRisks.count {
-            it.triggered && it.level.lowercase() != "informational"
-        }
-        val deviceIssueCount = scan.deviceFlags.count { it.triggered }
-        val verdict = when {
-            appRiskCount == 0 && deviceIssueCount == 0 ->
-                "No threats detected. Your phone appears secure."
-            appRiskCount == 0 && deviceIssueCount > 0 ->
-                "No suspicious apps found. $deviceIssueCount device setting(s) need attention."
-            else ->
-                "$appRiskCount app issue(s) and $deviceIssueCount device setting(s) found. " +
-                    "Review the details below."
-        }
-        appendLine("  $verdict")
-        appendLine()
+        // -- Verdict + Summary + Action Guidance ----------------------------------
+        appendVerdict(scan, dnsEvents, appInventory, displayNames)
 
         // -- Device checks --------------------------------------------------------
         val allDeviceFlags = scan.deviceFlags
@@ -93,10 +82,10 @@ object ReportFormatter {
             val detected = campaignFindings.filter { it.triggered }
 
             clear.forEach { finding ->
-                appendLine("  [\u2713]  ${campaignLabel(finding)}: not detected")
+                appendLine("  [OK]  ${campaignLabel(finding)}: not detected")
             }
             detected.forEach { finding ->
-                appendLine("  [\u2717]  ${campaignLabel(finding)}: DETECTED \u2014 ${finding.title}")
+                appendLine("  [!!]  ${campaignLabel(finding)}: DETECTED -- ${finding.title}")
             }
 
             // DNS-based campaign hits from IOC domain matches
@@ -110,7 +99,7 @@ object ReportFormatter {
                 appendLine()
                 appendLine("  DNS IOC matches linked to:")
                 dnsCampaigns.forEach { campaign ->
-                    appendLine("  [\u2717]  $campaign (domain indicator)")
+                    appendLine("  [!!]  $campaign (domain indicator)")
                 }
             }
             appendLine()
@@ -127,12 +116,12 @@ object ReportFormatter {
                 it.matchContext["package_name"]?.toString() ?: "unknown"
             }
             appendLine("  ${byPackage.size} application(s) flagged")
-            appendLine("  ${scan.knownMalwareCount} known malware \u00b7 ${scan.riskySideloadCount} risky sideloads")
+            appendLine("  ${scan.knownMalwareCount} known malware / ${scan.riskySideloadCount} risky sideloads")
             appendLine()
             byPackage.entries
                 .sortedByDescending { (_, findings) -> findings.maxOf { severityOrdinal(it.level) } }
                 .forEach { (pkg, findings) ->
-                    appendGroupedAppFindings(pkg, findings)
+                    appendGroupedAppFindings(pkg, findings, displayNames)
                 }
         }
 
@@ -142,14 +131,14 @@ object ReportFormatter {
             appendLine("  No DNS events recorded.")
         } else {
             val matched = dnsEvents.count { it.reason != null }
-            appendLine("  ${dnsEvents.size} events \u00b7 $matched matched")
+            appendLine("  ${dnsEvents.size} events / $matched matched")
             appendLine()
             dnsEvents.take(500).forEach { event ->
                 val time = dnsFmt.format(Date(event.timestamp))
                 val state = if (event.reason != null) "[MATCHED]" else "[ALLOWED]"
                 val app = event.appName
                     ?: if (event.appUid == -1) "unknown" else "uid:${event.appUid}"
-                appendLine("  $state  $time  ${event.domain.padEnd(50)}  \u2190 $app")
+                appendLine("  $state  $time  ${event.domain.padEnd(50)}  <- $app")
                 if (event.reason != null) {
                     appendLine("           reason: ${event.reason}")
                 }
@@ -159,7 +148,7 @@ object ReportFormatter {
         // -- Bug-report findings --------------------------------------------------
         if (scan.bugReportFindings.isNotEmpty()) {
             section("BUG REPORT FINDINGS")
-            scan.bugReportFindings.forEach { finding -> appendLine("  \u2022 $finding") }
+            scan.bugReportFindings.forEach { finding -> appendLine("  * $finding") }
         }
 
         // -- App hash inventory ---------------------------------------------------
@@ -168,7 +157,10 @@ object ReportFormatter {
             if (appsWithHashes.isNotEmpty()) {
                 section("APP HASH INVENTORY (${appsWithHashes.size} apps)")
                 appsWithHashes.sortedBy { it.packageName }.forEach { app ->
-                    appendLine("  ${app.appName}")
+                    val name = app.appName.ifEmpty {
+                        displayNames[app.packageName] ?: app.packageName
+                    }
+                    appendLine("  $name")
                     appendLine("     Package    : ${app.packageName}")
                     appendLine("     APK SHA-256: ${app.apkHash}")
                     if (!app.certHash.isNullOrEmpty()) {
@@ -190,7 +182,7 @@ object ReportFormatter {
         // -- Footer ---------------------------------------------------------------
         appendLine()
         appendLine(RULE)
-        appendLine("  End of report \u00b7 AndroDR \u00b7 scan id ${scan.id}")
+        appendLine("  End of report / AndroDR / scan id ${scan.id}")
         appendLine(RULE)
     }
 
@@ -202,8 +194,101 @@ object ReportFormatter {
         appendLine(THIN)
     }
 
+    @Suppress("CyclomaticComplexMethod") // Verdict assembles summary, device posture, campaign,
+    // and action guidance in a structured block -- splitting would fragment the output logic.
+    private fun StringBuilder.appendVerdict(
+        scan: ScanResult,
+        dnsEvents: List<DnsEvent>,
+        appInventory: List<AppTelemetry>,
+        displayNames: Map<String, String>
+    ) {
+        val appRiskCount = scan.appRisks.count {
+            it.triggered && it.level.lowercase() != "informational"
+        }
+        val deviceIssueCount = scan.deviceFlags.count { it.triggered }
+
+        // One-liner verdict
+        val verdict = when {
+            appRiskCount == 0 && deviceIssueCount == 0 ->
+                "No threats detected. Your phone appears secure."
+            appRiskCount == 0 && deviceIssueCount > 0 ->
+                "No suspicious apps found. $deviceIssueCount device setting(s) need attention."
+            else ->
+                "$appRiskCount app issue(s) and $deviceIssueCount device setting(s) found."
+        }
+        appendLine("  $verdict")
+        appendLine()
+
+        // Summary block
+        appendLine("  SUMMARY:")
+        val totalApps = if (appInventory.isNotEmpty()) appInventory.size.toString() else "N/A"
+        appendLine("    Apps scanned: $totalApps -- Flagged: $appRiskCount")
+        if (scan.knownMalwareCount > 0) {
+            appendLine("    Known malware: ${scan.knownMalwareCount}")
+        }
+        if (scan.riskySideloadCount > 0) {
+            appendLine("    Risky sideloads: ${scan.riskySideloadCount}")
+        }
+
+        // Device posture issues
+        val triggeredDeviceFlags = scan.deviceFlags
+            .filter { it.triggered && it.level.lowercase() in listOf("high", "critical") }
+        if (triggeredDeviceFlags.isNotEmpty()) {
+            val titles = triggeredDeviceFlags.take(3).map { it.title }
+            val suffix = if (triggeredDeviceFlags.size > 3) ", ..." else ""
+            appendLine("    Device posture: ${titles.joinToString(", ")}$suffix")
+        }
+
+        // Campaign detections
+        val campaigns = scan.deviceFlags
+            .filter { f -> f.triggered && f.tags.any { it.startsWith("campaign.") } }
+        if (campaigns.isNotEmpty()) {
+            val labels = campaigns.map { campaignLabel(it) }.distinct()
+            appendLine("    Campaign detections: ${labels.joinToString(", ")}")
+        }
+
+        // DNS IOC
+        val dnsIocCount = dnsEvents.count { it.reason != null }
+        appendLine("    DNS IOC matches: $dnsIocCount")
+        appendLine()
+
+        // Action guidance (only if something actionable)
+        appendActionGuidance(scan, displayNames)
+    }
+
+    // Collects action guidance from Finding.guidance (rule-driven) and device posture summary.
+    // Ordered: CRITICAL-prefixed first, then others, then device posture.
+    private fun StringBuilder.appendActionGuidance(
+        scan: ScanResult,
+        displayNames: Map<String, String>
+    ) {
+        val actions = mutableListOf<String>()
+
+        // Collect rule-driven guidance from triggered app risk findings
+        val appGuidance = scan.appRisks
+            .filter { it.triggered && it.guidance.isNotEmpty() }
+            .map { it.guidance }
+            .distinct()
+        // Sort so CRITICAL-prefixed items come first
+        appGuidance.sortedByDescending { guidancePriority(it) }.forEach { actions.add(it) }
+
+        // Device posture issues (summarized, not per-rule)
+        val deviceIssues = scan.deviceFlags.filter { it.triggered }
+        if (deviceIssues.isNotEmpty()) {
+            val titles = deviceIssues.take(3).map { it.title }
+            val suffix = if (deviceIssues.size > 3) ", ..." else ""
+            actions.add("DEVICE: ${titles.joinToString(", ")}$suffix")
+        }
+
+        if (actions.isNotEmpty()) {
+            appendLine("  ACTION REQUIRED:")
+            actions.forEach { appendLine("    $it") }
+            appendLine()
+        }
+    }
+
     private fun StringBuilder.appendFinding(finding: Finding) {
-        val icon = if (finding.triggered) "[\u2717]" else "[\u2713]"
+        val icon = if (finding.triggered) "[!!]" else "[OK]"
         val sev = finding.level.uppercase().padEnd(8)
         val mitre = finding.tags.filter { it.startsWith("attack.t") }
             .joinToString(", ") { it.removePrefix("attack.").uppercase() }
@@ -214,27 +299,33 @@ object ReportFormatter {
         }
         if (finding.triggered && finding.remediation.isNotEmpty()) {
             finding.remediation.forEach { step ->
-                appendLine("           \u2192 $step")
+                appendLine("           -> $step")
             }
         }
     }
 
-    private fun StringBuilder.appendGroupedAppFindings(pkg: String, findings: List<Finding>) {
+    private fun StringBuilder.appendGroupedAppFindings(
+        pkg: String,
+        findings: List<Finding>,
+        displayNames: Map<String, String>
+    ) {
         val highest = findings.maxByOrNull { severityOrdinal(it.level) } ?: return
         val risk = highest.level.uppercase().padEnd(8)
-        val appName = highest.matchContext["app_name"]?.toString() ?: pkg
+        val appName = highest.matchContext["app_name"]?.toString()?.takeIf { it.isNotEmpty() }
+            ?: displayNames[pkg]
+            ?: pkg
         val isKnownMalware = findings.any { it.ruleId.startsWith("androdr-00") }
         val isSideloaded = findings.any { it.ruleId == "androdr-010" }
 
         val flags = buildList {
-            if (isKnownMalware) add("\u26a0 Known Malware")
+            if (isKnownMalware) add("[!] Known Malware")
             if (isSideloaded) add("Sideloaded")
         }
 
-        appendLine("  \u25cf  $risk  $appName")
+        appendLine("  *  $risk  $appName")
         appendLine("     Package : $pkg")
         if (flags.isNotEmpty()) {
-            appendLine("     Flags   : ${flags.joinToString(" \u00b7 ")}")
+            appendLine("     Flags   : ${flags.joinToString(" / ")}")
         }
         val apkHash = highest.matchContext["apk_hash"]?.toString()
         if (!apkHash.isNullOrEmpty()) {
@@ -257,6 +348,12 @@ object ReportFormatter {
         if (allRemediation.isNotEmpty()) {
             appendLine("     Action  : ${allRemediation.first()}")
         }
+
+        // Per-app guidance from rules
+        val guidance = findings.firstOrNull { it.guidance.isNotEmpty() }?.guidance
+        if (guidance != null) {
+            appendLine("     Guidance: $guidance")
+        }
         appendLine()
     }
 
@@ -265,6 +362,17 @@ object ReportFormatter {
             .joinToString(" / ") { tag ->
                 tag.removePrefix("campaign.").replaceFirstChar { c -> c.uppercase() }
             }
+
+    private fun guidancePriority(guidance: String): Int {
+        val upper = guidance.uppercase()
+        return when {
+            upper.startsWith("CRITICAL") -> 4
+            upper.startsWith("UNINSTALL IMMEDIATELY") -> 3
+            upper.startsWith("UNINSTALL") -> 2
+            upper.startsWith("INVESTIGATE") -> 1
+            else -> 0
+        }
+    }
 
     private fun severityOrdinal(level: String): Int = when (level.lowercase()) {
         "critical" -> 3

--- a/app/src/main/java/com/androdr/reporting/ReportFormatter.kt
+++ b/app/src/main/java/com/androdr/reporting/ReportFormatter.kt
@@ -46,7 +46,7 @@ object ReportFormatter {
         appendLine()
 
         // -- Verdict + Summary + Action Guidance ----------------------------------
-        appendVerdict(scan, dnsEvents, appInventory, displayNames)
+        appendVerdict(scan, dnsEvents, appInventory)
 
         // -- Device checks --------------------------------------------------------
         val allDeviceFlags = scan.deviceFlags
@@ -199,8 +199,7 @@ object ReportFormatter {
     private fun StringBuilder.appendVerdict(
         scan: ScanResult,
         dnsEvents: List<DnsEvent>,
-        appInventory: List<AppTelemetry>,
-        displayNames: Map<String, String>
+        appInventory: List<AppTelemetry>
     ) {
         val appRiskCount = scan.appRisks.count {
             it.triggered && it.level.lowercase() != "informational"

--- a/app/src/main/java/com/androdr/reporting/TimelineExporter.kt
+++ b/app/src/main/java/com/androdr/reporting/TimelineExporter.kt
@@ -6,13 +6,20 @@ import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 
+/**
+ * Exports forensic timeline events as plaintext or CSV.
+ * Output is strictly ASCII -- no Unicode characters.
+ */
 object TimelineExporter {
 
     private const val RULE = "============================================================"
     private const val THIN = "------------------------------------------------------------"
 
-    @Suppress("LongMethod") // Report formatting assembles header, filters, date groups, and footer
-    fun formatPlaintext(events: List<ForensicTimelineEvent>): String = buildString {
+    @Suppress("LongMethod") // Report formatting assembles header, assessment, date groups, and footer
+    fun formatPlaintext(
+        events: List<ForensicTimelineEvent>,
+        displayNames: Map<String, String> = emptyMap()
+    ): String = buildString {
         appendLine(RULE)
         appendLine("  AndroDR Forensic Timeline")
         appendLine("  Version: ${com.androdr.BuildConfig.VERSION_NAME}")
@@ -44,6 +51,19 @@ object TimelineExporter {
         if (infoCount > 0) {
             appendLine("  Informational: $infoCount")
         }
+
+        // Assessment
+        val assessment = when {
+            filtered.any { it.severity.equals("CRITICAL", true) } -> "CRITICAL ACTIVITY DETECTED"
+            significantCount > 0 -> "REVIEW RECOMMENDED"
+            else -> "NO CONCERNS"
+        }
+        appendLine()
+        appendLine("  ASSESSMENT: $assessment")
+        val pkgCount = filtered.map { it.packageName }.filter { it.isNotEmpty() }.distinct().size
+        if (significantCount > 0) {
+            appendLine("  $significantCount event(s) across $pkgCount package(s) require attention.")
+        }
         appendLine()
 
         val sorted = filtered.sortedByDescending { it.timestamp }
@@ -68,7 +88,12 @@ object TimelineExporter {
             if (event.appName.isNotEmpty() && event.appName != event.packageName) {
                 appendLine("             App: ${event.appName} (${event.packageName})")
             } else if (event.packageName.isNotEmpty()) {
-                appendLine("             Package: ${event.packageName}")
+                val resolved = displayNames[event.packageName]
+                if (resolved != null) {
+                    appendLine("             App: $resolved (${event.packageName})")
+                } else {
+                    appendLine("             Package: ${event.packageName}")
+                }
             }
             if (event.iocIndicator.isNotEmpty()) {
                 appendLine("             IOC: ${event.iocIndicator} (${event.iocType})")
@@ -86,7 +111,7 @@ object TimelineExporter {
 
         appendLine()
         appendLine(RULE)
-        appendLine("  End of timeline \u00b7 AndroDR")
+        appendLine("  End of timeline / AndroDR")
         appendLine(RULE)
     }
 

--- a/app/src/main/java/com/androdr/reporting/TimelineFormatter.kt
+++ b/app/src/main/java/com/androdr/reporting/TimelineFormatter.kt
@@ -11,19 +11,21 @@ import java.util.Locale
 /**
  * Formats bug report analysis results (SIGMA findings, legacy findings,
  * and timeline events) into a human-readable plaintext report suitable
- * for sharing.
+ * for sharing. Output is strictly ASCII.
  */
 object TimelineFormatter {
 
     private const val RULE = "============================================================"
     private const val THIN = "------------------------------------------------------------"
 
-    @Suppress("LongMethod") // Report formatting assembles header, grouped findings, legacy, and timeline
+    @Suppress("LongMethod") // Report formatting assembles header, verdict, grouped findings,
+    // legacy, timeline, and inventory in a specific order.
     fun formatTimeline(
         timeline: List<TimelineEvent>,
         legacyFindings: List<BugReportFinding>,
         findings: List<Finding>,
-        hashByPkg: Map<String, String> = emptyMap()
+        hashByPkg: Map<String, String> = emptyMap(),
+        displayNames: Map<String, String> = emptyMap()
     ): String = buildString {
         val generated = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.US).format(Date())
 
@@ -37,8 +39,26 @@ object TimelineFormatter {
         appendLine(RULE)
         appendLine()
 
-        // SIGMA findings section
+        // -- Verdict --------------------------------------------------------------
         val triggeredFindings = findings.filter { it.triggered }
+        val critical = triggeredFindings.count { it.level.equals("critical", true) }
+        val high = triggeredFindings.count { it.level.equals("high", true) }
+        val medium = triggeredFindings.count { it.level.equals("medium", true) }
+        val verdict = when {
+            critical > 0 -> "CRITICAL THREATS DETECTED"
+            high > 0 -> "ISSUES FOUND"
+            medium > 0 -> "ISSUES FOUND"
+            triggeredFindings.isNotEmpty() -> "INFORMATIONAL ONLY"
+            else -> "CLEAN"
+        }
+        appendLine("  ANALYSIS VERDICT: $verdict")
+        appendLine("  SIGMA findings: $critical critical, $high high, $medium medium")
+        if (legacyFindings.isNotEmpty()) {
+            appendLine("  Pattern scan: ${legacyFindings.size} findings")
+        }
+        appendLine()
+
+        // -- SIGMA findings section -----------------------------------------------
         appendLine(THIN)
         appendLine("  FINDINGS (${triggeredFindings.size})")
         appendLine(THIN)
@@ -58,13 +78,17 @@ object TimelineFormatter {
                 if (packages.isNotEmpty()) {
                     if (packages.size <= 3) {
                         packages.forEach { pkg ->
-                            appendLine("    Package: $pkg")
+                            val name = displayNames[pkg]
+                            if (name != null) {
+                                appendLine("    Package: $name ($pkg)")
+                            } else {
+                                appendLine("    Package: $pkg")
+                            }
                             hashByPkg[pkg]?.let { appendLine("    APK SHA-256: $it") }
                         }
                     } else {
                         appendLine("    ${packages.size} apps: ${packages.take(5).joinToString(", ")}" +
                             if (packages.size > 5) ", ..." else "")
-                        // Show hashes for multi-package groups in inventory
                     }
                 }
                 if (f.description.isNotEmpty()) {
@@ -106,7 +130,13 @@ object TimelineFormatter {
             appendLine("  APP HASH INVENTORY (${hashByPkg.size} apps)")
             appendLine(THIN)
             hashByPkg.entries.sortedBy { it.key }.forEach { (pkg, hash) ->
-                appendLine("  $pkg")
+                val name = displayNames[pkg]
+                if (name != null) {
+                    appendLine("  $name")
+                    appendLine("    Package: $pkg")
+                } else {
+                    appendLine("  $pkg")
+                }
                 appendLine("    SHA-256: $hash")
             }
             appendLine()

--- a/app/src/main/java/com/androdr/sigma/SigmaRule.kt
+++ b/app/src/main/java/com/androdr/sigma/SigmaRule.kt
@@ -50,5 +50,6 @@ data class SigmaDisplay(
     val triggeredTitle: String = "",
     val safeTitle: String = "",
     val evidenceType: String = "none",
-    val summaryTemplate: String = ""
+    val summaryTemplate: String = "",
+    val guidance: String = ""
 )

--- a/app/src/main/java/com/androdr/sigma/SigmaRuleEvaluator.kt
+++ b/app/src/main/java/com/androdr/sigma/SigmaRuleEvaluator.kt
@@ -12,6 +12,7 @@ data class Finding(
     val remediation: List<String> = emptyList(),
     val iconHint: String = "",
     val safeTitle: String = "",
+    val guidance: String = "",
     val triggered: Boolean = true,
     val evidence: Evidence = Evidence.None,
     val matchContext: Map<String, String> = emptyMap()
@@ -130,6 +131,7 @@ object SigmaRuleEvaluator {
             remediation = TemplateResolver.resolveAll(rule.remediation, remediationVars),
             iconHint = rule.display.icon,
             safeTitle = TemplateResolver.resolve(rule.display.safeTitle, titleVars),
+            guidance = if (triggered) rule.display.guidance else "",
             triggered = triggered,
             evidence = evidenceResult?.evidence ?: Evidence.None,
             matchContext = record.filterValues { it !is List<*> && it !is Map<*, *> }

--- a/app/src/main/java/com/androdr/sigma/SigmaRuleParser.kt
+++ b/app/src/main/java/com/androdr/sigma/SigmaRuleParser.kt
@@ -134,7 +134,8 @@ object SigmaRuleParser {
             triggeredTitle = displayMap["triggered_title"]?.toString() ?: "",
             safeTitle = displayMap["safe_title"]?.toString() ?: "",
             evidenceType = displayMap["evidence_type"]?.toString() ?: "none",
-            summaryTemplate = displayMap["summary_template"]?.toString() ?: ""
+            summaryTemplate = displayMap["summary_template"]?.toString() ?: "",
+            guidance = displayMap["guidance"]?.toString() ?: ""
         )
     }
 

--- a/app/src/main/java/com/androdr/ui/bugreport/BugReportViewModel.kt
+++ b/app/src/main/java/com/androdr/ui/bugreport/BugReportViewModel.kt
@@ -110,14 +110,19 @@ class BugReportViewModel @Inject constructor(
         viewModelScope.launch {
             _exporting.value = true
             try {
-                val hashByPkg = orchestrator.lastAppTelemetry
+                val telemetry = orchestrator.lastAppTelemetry
+                val hashByPkg = telemetry
                     .filter { !it.apkHash.isNullOrEmpty() }
                     .associateBy({ it.packageName }, { it.apkHash!! })
+                val displayNames = telemetry
+                    .associate { it.packageName to it.appName }
+                    .filterValues { it.isNotEmpty() }
                 val text = TimelineFormatter.formatTimeline(
                     _timeline.value,
                     _legacyFindings.value,
                     _findings.value,
-                    hashByPkg
+                    hashByPkg,
+                    displayNames
                 )
                 _shareUri.value = withContext(Dispatchers.IO) {
                     val reportsDir = File(appContext.cacheDir, "reports").apply { mkdirs() }

--- a/app/src/main/java/com/androdr/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/androdr/ui/settings/SettingsScreen.kt
@@ -268,6 +268,10 @@ fun SettingsScreen(viewModel: SettingsViewModel = hiltViewModel()) {
                         value = com.androdr.BuildConfig.VERSION_CODE.toString()
                     )
                     StatRow(
+                        label = "What's New",
+                        value = com.androdr.BuildConfig.RELEASE_NOTE
+                    )
+                    StatRow(
                         label = "Android",
                         value = "${Build.VERSION.RELEASE} (API ${Build.VERSION.SDK_INT})"
                     )

--- a/app/src/main/java/com/androdr/ui/timeline/TimelineViewModel.kt
+++ b/app/src/main/java/com/androdr/ui/timeline/TimelineViewModel.kt
@@ -27,6 +27,7 @@ import java.io.File
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
+import com.androdr.ioc.KnownAppResolver
 import javax.inject.Inject
 
 enum class TimelineGroupMode { DATE, SCAN }
@@ -45,7 +46,8 @@ data class ScanGroup(
 class TimelineViewModel @Inject constructor(
     @ApplicationContext private val appContext: Context,
     private val dao: ForensicTimelineEventDao,
-    private val correlationEngine: CorrelationEngine
+    private val correlationEngine: CorrelationEngine,
+    private val knownAppResolver: KnownAppResolver
 ) : ViewModel() {
 
     private val _groupMode = MutableStateFlow(TimelineGroupMode.DATE)
@@ -216,11 +218,16 @@ class TimelineViewModel @Inject constructor(
     fun generateReport() {
         viewModelScope.launch {
             val allEvents = withContext(Dispatchers.IO) { dao.getAllForExport() }
-            _reportText.value = TimelineExporter.formatPlaintext(allEvents)
+            _reportText.value = withContext(Dispatchers.Default) {
+                val names = buildDisplayNames(allEvents)
+                TimelineExporter.formatPlaintext(allEvents, names)
+            }
         }
     }
 
-    fun exportPlaintext() = export("txt") { TimelineExporter.formatPlaintext(it) }
+    fun exportPlaintext() = export("txt") {
+        TimelineExporter.formatPlaintext(it, buildDisplayNames(it))
+    }
     fun exportCsv() = export("csv") { TimelineExporter.formatCsv(it) }
 
     @Suppress("TooGenericExceptionCaught") // Export can throw IOException (disk full, no
@@ -232,7 +239,7 @@ class TimelineViewModel @Inject constructor(
             _exporting.value = true
             try {
                 val allEvents = withContext(Dispatchers.IO) { dao.getAllForExport() }
-                val text = formatter(allEvents)
+                val text = withContext(Dispatchers.Default) { formatter(allEvents) }
                 _shareUri.value = withContext(Dispatchers.IO) {
                     val reportsDir = File(appContext.cacheDir, "reports").apply { mkdirs() }
                     val ts = SimpleDateFormat("yyyyMMdd_HHmmss", Locale.US).format(Date())
@@ -249,4 +256,18 @@ class TimelineViewModel @Inject constructor(
     }
 
     fun onShareConsumed() { _shareUri.value = null }
+
+    private fun buildDisplayNames(events: List<ForensicTimelineEvent>): Map<String, String> {
+        val fromEvents = events
+            .filter { it.appName.isNotEmpty() && it.appName != it.packageName }
+            .associateBy({ it.packageName }, { it.appName })
+        val needLookup = events
+            .map { it.packageName }
+            .filter { it.isNotEmpty() && it !in fromEvents }
+            .distinct()
+        val fromResolver = needLookup.mapNotNull { pkg ->
+            knownAppResolver.lookup(pkg)?.let { pkg to it.displayName }
+        }.toMap()
+        return fromResolver + fromEvents
+    }
 }

--- a/app/src/main/res/raw/sigma_androdr_001_package_ioc.yml
+++ b/app/src/main/res/raw/sigma_androdr_001_package_ioc.yml
@@ -21,5 +21,6 @@ display:
     icon: warning
     triggered_title: "Known Malicious Package"
     evidence_type: ioc_match
+    guidance: "UNINSTALL IMMEDIATELY -- matches known malware signatures"
 remediation:
     - "Uninstall this app immediately."

--- a/app/src/main/res/raw/sigma_androdr_002_cert_hash_ioc.yml
+++ b/app/src/main/res/raw/sigma_androdr_002_cert_hash_ioc.yml
@@ -19,5 +19,6 @@ display:
     icon: warning
     triggered_title: "Malicious Certificate"
     evidence_type: ioc_match
+    guidance: "UNINSTALL IMMEDIATELY -- signed by a known threat developer"
 remediation:
     - "This app is signed by a known threat developer. Uninstall it even if the name looks legitimate."

--- a/app/src/main/res/raw/sigma_androdr_003_domain_ioc.yml
+++ b/app/src/main/res/raw/sigma_androdr_003_domain_ioc.yml
@@ -19,5 +19,6 @@ display:
     icon: warning
     triggered_title: "Malicious Domain"
     evidence_type: ioc_match
+    guidance: "INVESTIGATE -- device contacted a known C2 server"
 remediation:
     - "A connection to a known command-and-control server was blocked."

--- a/app/src/main/res/raw/sigma_androdr_004_apk_hash_ioc.yml
+++ b/app/src/main/res/raw/sigma_androdr_004_apk_hash_ioc.yml
@@ -21,5 +21,6 @@ display:
     icon: warning
     triggered_title: "Known Malware APK"
     evidence_type: none
+    guidance: "UNINSTALL IMMEDIATELY -- file hash matches known malware sample"
 remediation:
     - "This app's file hash matches a known malware sample. Uninstall it immediately: go to Settings > Apps > find the app > Uninstall."

--- a/app/src/main/res/raw/sigma_androdr_005_graphite_paragon.yml
+++ b/app/src/main/res/raw/sigma_androdr_005_graphite_paragon.yml
@@ -23,6 +23,7 @@ display:
     icon: warning
     triggered_title: "Graphite/Paragon Spyware"
     evidence_type: none
+    guidance: "CRITICAL -- nation-state spyware indicators; seek expert forensic assistance"
 falsepositives:
     - Domains may be repurposed after takedown
 remediation:

--- a/app/src/main/res/raw/sigma_androdr_010_sideloaded_app.yml
+++ b/app/src/main/res/raw/sigma_androdr_010_sideloaded_app.yml
@@ -23,5 +23,6 @@ display:
     icon: download
     triggered_title: "Sideloaded Application"
     evidence_type: none
+    guidance: "REVIEW -- sideloaded app with elevated permissions; verify intentional"
 remediation:
     - "This app was not installed from a trusted app store. Verify you intended to install it."

--- a/app/src/main/res/raw/sigma_androdr_011_surveillance_permissions.yml
+++ b/app/src/main/res/raw/sigma_androdr_011_surveillance_permissions.yml
@@ -26,5 +26,6 @@ display:
     icon: visibility
     triggered_title: "Surveillance Permissions"
     evidence_type: none
+    guidance: "REVIEW -- app has extensive surveillance capabilities"
 remediation:
     - "This app has extensive surveillance capabilities. If you did not install it intentionally, uninstall it."

--- a/app/src/main/res/raw/sigma_androdr_012_accessibility_abuse.yml
+++ b/app/src/main/res/raw/sigma_androdr_012_accessibility_abuse.yml
@@ -23,5 +23,6 @@ display:
     icon: accessibility
     triggered_title: "Accessibility Abuse"
     evidence_type: none
+    guidance: "UNINSTALL -- accessibility service abuse indicates stalkerware"
 remediation:
     - "This app can read your screen content. Go to Settings > Accessibility and disable its service before uninstalling."

--- a/app/src/main/res/raw/sigma_androdr_013_device_admin_abuse.yml
+++ b/app/src/main/res/raw/sigma_androdr_013_device_admin_abuse.yml
@@ -23,5 +23,6 @@ display:
     icon: admin_panel_settings
     triggered_title: "Device Admin Abuse"
     evidence_type: none
+    guidance: "UNINSTALL -- device admin abuse indicates stalkerware; revoke admin first"
 remediation:
     - "Go to Settings > Security > Device Admin Apps and remove this app first, then uninstall."

--- a/app/src/main/res/raw/sigma_androdr_014_app_impersonation.yml
+++ b/app/src/main/res/raw/sigma_androdr_014_app_impersonation.yml
@@ -21,5 +21,6 @@ display:
     icon: content_copy
     triggered_title: "App Impersonation"
     evidence_type: none
+    guidance: "UNINSTALL -- impersonates a legitimate app; likely malicious"
 remediation:
     - "This app impersonates a well-known app but was not installed from a trusted store."

--- a/app/src/main/res/raw/sigma_androdr_015_firmware_implant.yml
+++ b/app/src/main/res/raw/sigma_androdr_015_firmware_implant.yml
@@ -20,5 +20,6 @@ display:
     icon: memory
     triggered_title: "Firmware Implant"
     evidence_type: none
+    guidance: "CRITICAL -- possible firmware-level implant; seek expert forensic assistance"
 remediation:
     - "This app has system privileges but does not match any known manufacturer package."

--- a/app/src/main/res/raw/sigma_androdr_017_accessibility_surveillance_combo.yml
+++ b/app/src/main/res/raw/sigma_androdr_017_accessibility_surveillance_combo.yml
@@ -26,6 +26,7 @@ display:
     icon: visibility
     triggered_title: "Stalkerware Pattern"
     evidence_type: none
+    guidance: "UNINSTALL IMMEDIATELY -- stalkerware pattern (accessibility + surveillance)"
 remediation:
     - "This app combines screen reading with surveillance permissions."
     - "Disable its accessibility service in Settings, then uninstall."

--- a/app/src/test/java/com/androdr/reporting/ReportFormatterTest.kt
+++ b/app/src/test/java/com/androdr/reporting/ReportFormatterTest.kt
@@ -1,0 +1,128 @@
+package com.androdr.reporting
+
+import com.androdr.data.model.ScanResult
+import com.androdr.sigma.Finding
+import com.androdr.sigma.FindingCategory
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ReportFormatterTest {
+
+    private fun buildScan(
+        appRisks: List<Finding> = emptyList(),
+        deviceFlags: List<Finding> = emptyList(),
+        knownMalwareCount: Int = 0,
+        riskySideloadCount: Int = 0
+    ): ScanResult = ScanResult(
+        id = 1L,
+        timestamp = 1711900800000,
+        findings = deviceFlags + appRisks,
+        bugReportFindings = emptyList(),
+        riskySideloadCount = riskySideloadCount,
+        knownMalwareCount = knownMalwareCount
+    )
+
+    private val cleanScan = buildScan()
+
+    private val malwareFinding = Finding(
+        ruleId = "androdr-001",
+        title = "Known Malicious Package",
+        level = "critical",
+        category = FindingCategory.APP_RISK,
+        triggered = true,
+        guidance = "UNINSTALL IMMEDIATELY -- matches known malware signatures",
+        matchContext = mapOf("package_name" to "com.evil.spy", "app_name" to "EvilSpy")
+    )
+
+    private val sideloadFinding = Finding(
+        ruleId = "androdr-010",
+        title = "Sideloaded App",
+        level = "high",
+        category = FindingCategory.APP_RISK,
+        triggered = true,
+        guidance = "REVIEW -- sideloaded app with elevated permissions; verify intentional",
+        matchContext = mapOf("package_name" to "com.unknown.app")
+    )
+
+    private val deviceFinding = Finding(
+        ruleId = "androdr-040",
+        title = "USB Debugging Enabled",
+        level = "high",
+        category = FindingCategory.DEVICE_POSTURE,
+        triggered = true,
+        remediation = listOf("Disable USB debugging in Developer Options")
+    )
+
+    @Test
+    fun `verdict shows no threats when clean`() {
+        val text = ReportFormatter.formatScanReport(cleanScan, emptyList(), emptyList())
+        assertTrue(text.contains("No threats detected"))
+        assertTrue(text.contains("SUMMARY:"))
+        assertTrue(text.contains("Flagged: 0"))
+    }
+
+    @Test
+    fun `verdict shows device settings when only device issues`() {
+        val scan = buildScan(deviceFlags = listOf(deviceFinding))
+        val text = ReportFormatter.formatScanReport(scan, emptyList(), emptyList())
+        assertTrue(text.contains("device setting(s) need attention"))
+        assertTrue(text.contains("Device posture: USB Debugging Enabled"))
+    }
+
+    @Test
+    fun `action guidance from rule guidance field for malware`() {
+        val scan = buildScan(appRisks = listOf(malwareFinding), knownMalwareCount = 1)
+        val text = ReportFormatter.formatScanReport(scan, emptyList(), emptyList())
+        assertTrue(text.contains("ACTION REQUIRED:"))
+        assertTrue("Guidance from rule", text.contains("UNINSTALL IMMEDIATELY"))
+    }
+
+    @Test
+    fun `action guidance from rule guidance field for sideloads`() {
+        val scan = buildScan(appRisks = listOf(sideloadFinding), riskySideloadCount = 1)
+        val text = ReportFormatter.formatScanReport(scan, emptyList(), emptyList())
+        assertTrue("Guidance from rule", text.contains("REVIEW -- sideloaded app"))
+    }
+
+    @Test
+    fun `display names resolve in app findings`() {
+        val scan = buildScan(appRisks = listOf(sideloadFinding))
+        val names = mapOf("com.unknown.app" to "Mystery App")
+        val text = ReportFormatter.formatScanReport(
+            scan, emptyList(), emptyList(), displayNames = names
+        )
+        assertTrue("Display name should appear", text.contains("Mystery App"))
+    }
+
+    @Test
+    fun `per-app guidance labels present`() {
+        val scan = buildScan(
+            appRisks = listOf(malwareFinding, sideloadFinding),
+            knownMalwareCount = 1,
+            riskySideloadCount = 1
+        )
+        val text = ReportFormatter.formatScanReport(scan, emptyList(), emptyList())
+        assertTrue(text.contains("UNINSTALL IMMEDIATELY"))
+        assertTrue(text.contains("REVIEW -- sideloaded app"))
+    }
+
+    @Test
+    fun `output is ASCII only`() {
+        val scan = buildScan(
+            appRisks = listOf(malwareFinding, sideloadFinding),
+            deviceFlags = listOf(deviceFinding),
+            knownMalwareCount = 1,
+            riskySideloadCount = 1
+        )
+        val text = ReportFormatter.formatScanReport(scan, emptyList(), emptyList())
+        val nonAscii = text.filter { it.code > 127 }
+        assertTrue("Non-ASCII characters found: $nonAscii", nonAscii.isEmpty())
+    }
+
+    @Test
+    fun `no action block when scan is clean`() {
+        val text = ReportFormatter.formatScanReport(cleanScan, emptyList(), emptyList())
+        assertFalse(text.contains("ACTION REQUIRED:"))
+    }
+}

--- a/app/src/test/java/com/androdr/reporting/TimelineExporterTest.kt
+++ b/app/src/test/java/com/androdr/reporting/TimelineExporterTest.kt
@@ -65,4 +65,46 @@ class TimelineExporterTest {
         val csv = TimelineExporter.formatCsv(emptyList())
         assertTrue(csv.lines().first().contains("timestamp"))
     }
+
+    @Test
+    fun `display names resolve when appName is empty`() {
+        val eventsNoName = listOf(
+            ForensicTimelineEvent(
+                id = 4, timestamp = 1711900800000, source = "appops",
+                category = "permission_use", description = "com.whatsapp used CAMERA",
+                severity = "INFO", packageName = "com.whatsapp"
+            )
+        )
+        val names = mapOf("com.whatsapp" to "WhatsApp")
+        val text = TimelineExporter.formatPlaintext(eventsNoName, names)
+        assertTrue("Should resolve display name", text.contains("App: WhatsApp (com.whatsapp)"))
+    }
+
+    @Test
+    fun `assessment line present for significant events`() {
+        val text = TimelineExporter.formatPlaintext(events)
+        assertTrue("Should have assessment", text.contains("ASSESSMENT:"))
+        assertTrue("Critical events -> critical assessment",
+            text.contains("CRITICAL ACTIVITY DETECTED"))
+    }
+
+    @Test
+    fun `assessment shows no concerns for informational events`() {
+        val infoEvents = listOf(
+            ForensicTimelineEvent(
+                id = 5, timestamp = 1711900800000, source = "appops",
+                category = "permission_use", description = "test",
+                severity = "INFORMATIONAL", packageName = "com.test"
+            )
+        )
+        val text = TimelineExporter.formatPlaintext(infoEvents)
+        assertTrue(text.contains("NO CONCERNS"))
+    }
+
+    @Test
+    fun `output is ASCII only`() {
+        val text = TimelineExporter.formatPlaintext(events)
+        val nonAscii = text.filter { it.code > 127 }
+        assertTrue("Non-ASCII characters found: $nonAscii", nonAscii.isEmpty())
+    }
 }

--- a/app/src/test/java/com/androdr/reporting/TimelineFormatterTest.kt
+++ b/app/src/test/java/com/androdr/reporting/TimelineFormatterTest.kt
@@ -1,0 +1,90 @@
+package com.androdr.reporting
+
+import com.androdr.scanner.BugReportAnalyzer.BugReportFinding
+import com.androdr.sigma.Finding
+import com.androdr.sigma.FindingCategory
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TimelineFormatterTest {
+
+    private val criticalFinding = Finding(
+        ruleId = "androdr-001",
+        title = "Known Malicious Package",
+        level = "critical",
+        category = FindingCategory.APP_RISK,
+        triggered = true,
+        matchContext = mapOf("package_name" to "com.evil.spy")
+    )
+
+    private val mediumFinding = Finding(
+        ruleId = "androdr-063",
+        title = "Microphone Access",
+        level = "medium",
+        category = FindingCategory.APP_RISK,
+        triggered = true,
+        matchContext = mapOf("package_name" to "com.test.app"),
+        description = "App used microphone",
+        remediation = listOf("Review if expected")
+    )
+
+    @Test
+    fun `verdict shows CLEAN when no triggered findings`() {
+        val text = TimelineFormatter.formatTimeline(
+            emptyList(), emptyList(), emptyList()
+        )
+        assertTrue(text.contains("ANALYSIS VERDICT: CLEAN"))
+    }
+
+    @Test
+    fun `verdict shows CRITICAL THREATS when critical findings present`() {
+        val text = TimelineFormatter.formatTimeline(
+            emptyList(), emptyList(), listOf(criticalFinding)
+        )
+        assertTrue(text.contains("ANALYSIS VERDICT: CRITICAL THREATS DETECTED"))
+        assertTrue(text.contains("1 critical"))
+    }
+
+    @Test
+    fun `verdict shows ISSUES FOUND for medium findings`() {
+        val text = TimelineFormatter.formatTimeline(
+            emptyList(), emptyList(), listOf(mediumFinding)
+        )
+        assertTrue(text.contains("ANALYSIS VERDICT: ISSUES FOUND"))
+        assertTrue(text.contains("1 medium"))
+    }
+
+    @Test
+    fun `display names resolve in findings section`() {
+        val names = mapOf("com.test.app" to "Test App")
+        val text = TimelineFormatter.formatTimeline(
+            emptyList(), emptyList(), listOf(mediumFinding),
+            displayNames = names
+        )
+        assertTrue("Display name should appear", text.contains("Test App (com.test.app)"))
+    }
+
+    @Test
+    fun `display names resolve in hash inventory`() {
+        val hashes = mapOf("com.whatsapp" to "abc123")
+        val names = mapOf("com.whatsapp" to "WhatsApp")
+        val text = TimelineFormatter.formatTimeline(
+            emptyList(), emptyList(), emptyList(),
+            hashByPkg = hashes, displayNames = names
+        )
+        assertTrue("Display name in inventory", text.contains("WhatsApp"))
+        assertTrue("Package name in inventory", text.contains("Package: com.whatsapp"))
+    }
+
+    @Test
+    fun `output is ASCII only`() {
+        val text = TimelineFormatter.formatTimeline(
+            emptyList(),
+            listOf(BugReportFinding("HIGH", "test", "test finding")),
+            listOf(criticalFinding, mediumFinding),
+            mapOf("com.test" to "hash123")
+        )
+        val nonAscii = text.filter { it.code > 127 }
+        assertTrue("Non-ASCII characters found: $nonAscii", nonAscii.isEmpty())
+    }
+}


### PR DESCRIPTION
## Summary
- Enhanced verdict with forensic summary (apps scanned, malware count, device posture, campaign detections, DNS IOCs) + assessment blocks in timeline/bugreport reports
- Display name resolution (`com.whatsapp` -> `WhatsApp`) in all three report formatters via `displayNames: Map<String, String>` parameter
- Severity-ordered action guidance: CRITICAL > IMMEDIATE > REVIEW > DEVICE with per-app tier labels
- ASCII-only enforcement across all formatters (no Unicode leakage)
- Release note in BuildConfig + Settings screen "What's New" line
- Threading fix: report formatting moved off main thread in TimelineViewModel
- Gitignore for exported report files (privacy)

## Test plan
- [x] New ReportFormatterTest: verdict, action guidance, display names, ASCII-only (7 tests)
- [x] New TimelineFormatterTest: verdict levels, display names, ASCII-only (6 tests)
- [x] Updated TimelineExporterTest: display names, assessment, ASCII-only (4 new tests)
- [x] All existing tests pass
- [x] `./gradlew assembleDebug` builds clean
- [ ] CI pass
- [ ] Manual: install on device, export scan report -- verify verdict/guidance/names
- [ ] Manual: export bugreport timeline -- verify assessment/names

🤖 Generated with [Claude Code](https://claude.com/claude-code)