### PR TITLE
fix: severity recalibration -- device posture medium, rule-driven guidance

### DIFF
--- a/app/src/main/java/com/androdr/data/model/ScanResult.kt
+++ b/app/src/main/java/com/androdr/data/model/ScanResult.kt
@@ -23,17 +23,21 @@ data class ScanResult(
     val riskySideloadCount: Int,
     val knownMalwareCount: Int
 ) {
+    // Overall risk driven by app threats with guidance. Device posture is a condition
+    // (not an incident) and caps at MEDIUM regardless of the rule's level field.
     @get:Ignore
     @Transient
     val overallRiskLevel: RiskLevel
         get() {
-            val maxLevel = findings
-                .filter { it.triggered }
+            val appMax = findings
+                .filter { it.triggered && it.category == FindingCategory.APP_RISK }
                 .maxOfOrNull { levelToScore(it.level) } ?: 0
+            val hasDeviceIssues = findings
+                .any { it.triggered && it.category == FindingCategory.DEVICE_POSTURE }
             return when {
-                maxLevel >= RiskLevel.CRITICAL.score -> RiskLevel.CRITICAL
-                maxLevel >= RiskLevel.HIGH.score -> RiskLevel.HIGH
-                maxLevel >= RiskLevel.MEDIUM.score -> RiskLevel.MEDIUM
+                appMax >= RiskLevel.CRITICAL.score -> RiskLevel.CRITICAL
+                appMax >= RiskLevel.HIGH.score -> RiskLevel.HIGH
+                appMax >= RiskLevel.MEDIUM.score || hasDeviceIssues -> RiskLevel.MEDIUM
                 else -> RiskLevel.LOW
             }
         }

--- a/app/src/main/java/com/androdr/data/model/ScanResult.kt
+++ b/app/src/main/java/com/androdr/data/model/ScanResult.kt
@@ -23,14 +23,16 @@ data class ScanResult(
     val riskySideloadCount: Int,
     val knownMalwareCount: Int
 ) {
-    // Overall risk driven by app threats with guidance. Device posture is a condition
-    // (not an incident) and caps at MEDIUM regardless of the rule's level field.
+    // Overall risk driven by app threats. Device posture is a condition (not an incident)
+    // and caps at MEDIUM. NETWORK findings are included with APP_RISK since DNS IOC rules
+    // (androdr-003) use app_risk category; if future NETWORK-category rules are added,
+    // include them here.
     @get:Ignore
     @Transient
     val overallRiskLevel: RiskLevel
         get() {
             val appMax = findings
-                .filter { it.triggered && it.category == FindingCategory.APP_RISK }
+                .filter { it.triggered && it.category != FindingCategory.DEVICE_POSTURE }
                 .maxOfOrNull { levelToScore(it.level) } ?: 0
             val hasDeviceIssues = findings
                 .any { it.triggered && it.category == FindingCategory.DEVICE_POSTURE }

--- a/app/src/main/java/com/androdr/reporting/GuidanceUtils.kt
+++ b/app/src/main/java/com/androdr/reporting/GuidanceUtils.kt
@@ -1,0 +1,27 @@
+package com.androdr.reporting
+
+/**
+ * Shared utility for computing action guidance priority from rule-authored
+ * guidance strings. Used by both ReportFormatter and TimelineExporter to
+ * determine assessment severity from the guidance field.
+ */
+object GuidanceUtils {
+
+    /**
+     * Returns a priority score for a guidance string based on its prefix.
+     * Higher = more severe. Used for sorting and assessment thresholds.
+     *
+     * Thresholds: >= 3 → CRITICAL assessment, >= 1 → REVIEW, 0 → no action
+     */
+    fun guidancePriority(guidance: String): Int {
+        val upper = guidance.uppercase()
+        return when {
+            upper.startsWith("CRITICAL") -> 4
+            upper.startsWith("UNINSTALL IMMEDIATELY") -> 3
+            upper.startsWith("UNINSTALL") -> 2
+            upper.startsWith("INVESTIGATE") -> 1
+            upper.startsWith("REVIEW") -> 1
+            else -> 0
+        }
+    }
+}

--- a/app/src/main/java/com/androdr/reporting/ReportFormatter.kt
+++ b/app/src/main/java/com/androdr/reporting/ReportFormatter.kt
@@ -42,17 +42,17 @@ object ReportFormatter {
         appendLine("  Patch     : ${Build.VERSION.SECURITY_PATCH}")
         appendLine(RULE)
         appendLine()
-        // Overall risk driven by rule guidance: CRITICAL only for app threats with
-        // guidance, device posture caps at HIGH. Falls back to computed level otherwise.
-        val hasAppCriticalGuidance = scan.appRisks.any {
-            it.triggered && it.guidance.isNotEmpty() &&
-                it.guidance.uppercase().let { g ->
-                    g.startsWith("CRITICAL") || g.startsWith("UNINSTALL IMMEDIATELY")
-                }
+        // Overall risk driven by app threats with rule guidance. Device posture is a
+        // condition (not an incident) so it caps at MEDIUM -- nothing has happened yet.
+        val maxAppGuidancePriority = scan.appRisks
+            .filter { it.triggered && it.guidance.isNotEmpty() }
+            .maxOfOrNull { guidancePriority(it.guidance) } ?: 0
+        val reportedRisk = when {
+            maxAppGuidancePriority >= 3 -> "CRITICAL"
+            maxAppGuidancePriority >= 1 -> "HIGH"
+            scan.deviceFlags.any { it.triggered } -> "MEDIUM"
+            else -> "LOW"
         }
-        val reportedRisk = if (!hasAppCriticalGuidance &&
-            scan.overallRiskLevel.name == "CRITICAL"
-        ) "HIGH" else scan.overallRiskLevel.name
         appendLine("  OVERALL RISK: $reportedRisk")
         appendLine()
 

--- a/app/src/main/java/com/androdr/reporting/ReportFormatter.kt
+++ b/app/src/main/java/com/androdr/reporting/ReportFormatter.kt
@@ -42,7 +42,18 @@ object ReportFormatter {
         appendLine("  Patch     : ${Build.VERSION.SECURITY_PATCH}")
         appendLine(RULE)
         appendLine()
-        appendLine("  OVERALL RISK: ${scan.overallRiskLevel.name}")
+        // Overall risk driven by rule guidance: CRITICAL only for app threats with
+        // guidance, device posture caps at HIGH. Falls back to computed level otherwise.
+        val hasAppCriticalGuidance = scan.appRisks.any {
+            it.triggered && it.guidance.isNotEmpty() &&
+                it.guidance.uppercase().let { g ->
+                    g.startsWith("CRITICAL") || g.startsWith("UNINSTALL IMMEDIATELY")
+                }
+        }
+        val reportedRisk = if (!hasAppCriticalGuidance &&
+            scan.overallRiskLevel.name == "CRITICAL"
+        ) "HIGH" else scan.overallRiskLevel.name
+        appendLine("  OVERALL RISK: $reportedRisk")
         appendLine()
 
         // -- Verdict + Summary + Action Guidance ----------------------------------

--- a/app/src/main/java/com/androdr/reporting/ReportFormatter.kt
+++ b/app/src/main/java/com/androdr/reporting/ReportFormatter.kt
@@ -240,9 +240,8 @@ object ReportFormatter {
             appendLine("    Risky sideloads: ${scan.riskySideloadCount}")
         }
 
-        // Device posture issues
-        val triggeredDeviceFlags = scan.deviceFlags
-            .filter { it.triggered && it.level.lowercase() in listOf("high", "critical") }
+        // Device posture issues (all severity levels — these are conditions, not incidents)
+        val triggeredDeviceFlags = scan.deviceFlags.filter { it.triggered }
         if (triggeredDeviceFlags.isNotEmpty()) {
             val titles = triggeredDeviceFlags.take(3).map { it.title }
             val suffix = if (triggeredDeviceFlags.size > 3) ", ..." else ""

--- a/app/src/main/java/com/androdr/reporting/ReportFormatter.kt
+++ b/app/src/main/java/com/androdr/reporting/ReportFormatter.kt
@@ -369,16 +369,8 @@ object ReportFormatter {
                 tag.removePrefix("campaign.").replaceFirstChar { c -> c.uppercase() }
             }
 
-    private fun guidancePriority(guidance: String): Int {
-        val upper = guidance.uppercase()
-        return when {
-            upper.startsWith("CRITICAL") -> 4
-            upper.startsWith("UNINSTALL IMMEDIATELY") -> 3
-            upper.startsWith("UNINSTALL") -> 2
-            upper.startsWith("INVESTIGATE") -> 1
-            else -> 0
-        }
-    }
+    private fun guidancePriority(guidance: String): Int =
+        GuidanceUtils.guidancePriority(guidance)
 
     private fun severityOrdinal(level: String): Int = when (level.lowercase()) {
         "critical" -> 3

--- a/app/src/main/java/com/androdr/reporting/TimelineExporter.kt
+++ b/app/src/main/java/com/androdr/reporting/TimelineExporter.kt
@@ -163,17 +163,8 @@ object TimelineExporter {
         }
     }
 
-    private fun guidancePriority(guidance: String): Int {
-        val upper = guidance.uppercase()
-        return when {
-            upper.startsWith("CRITICAL") -> 4
-            upper.startsWith("UNINSTALL IMMEDIATELY") -> 3
-            upper.startsWith("UNINSTALL") -> 2
-            upper.startsWith("INVESTIGATE") -> 1
-            upper.startsWith("REVIEW") -> 1
-            else -> 0
-        }
-    }
+    private fun guidancePriority(guidance: String): Int =
+        GuidanceUtils.guidancePriority(guidance)
 
     private fun csvEscape(value: String): String {
         // Prevent CSV formula injection (cells starting with =, +, -, @, \t, \r)

--- a/app/src/main/java/com/androdr/reporting/TimelineExporter.kt
+++ b/app/src/main/java/com/androdr/reporting/TimelineExporter.kt
@@ -63,8 +63,21 @@ object TimelineExporter {
             maxGuidancePriority >= 1 || significantCount > 0 -> "REVIEW RECOMMENDED"
             else -> "NO CONCERNS"
         }
+        // Severity breakdown
+        val criticalCount = filtered.count { it.severity.equals("CRITICAL", true) }
+        val highCount = filtered.count { it.severity.equals("HIGH", true) }
+        val mediumCount = filtered.count { it.severity.equals("MEDIUM", true) }
+        val severityParts = buildList {
+            if (criticalCount > 0) add("$criticalCount critical")
+            if (highCount > 0) add("$highCount high")
+            if (mediumCount > 0) add("$mediumCount medium")
+        }
+
         appendLine()
         appendLine("  ASSESSMENT: $assessment")
+        if (severityParts.isNotEmpty()) {
+            appendLine("  Severity: ${severityParts.joinToString(", ")}")
+        }
         val pkgCount = filtered.map { it.packageName }.filter { it.isNotEmpty() }.distinct().size
         if (significantCount > 0) {
             appendLine("  $significantCount event(s) across $pkgCount package(s) require attention.")

--- a/app/src/main/java/com/androdr/reporting/TimelineExporter.kt
+++ b/app/src/main/java/com/androdr/reporting/TimelineExporter.kt
@@ -18,7 +18,8 @@ object TimelineExporter {
     @Suppress("LongMethod") // Report formatting assembles header, assessment, date groups, and footer
     fun formatPlaintext(
         events: List<ForensicTimelineEvent>,
-        displayNames: Map<String, String> = emptyMap()
+        displayNames: Map<String, String> = emptyMap(),
+        ruleGuidance: Map<String, String> = emptyMap()
     ): String = buildString {
         appendLine(RULE)
         appendLine("  AndroDR Forensic Timeline")
@@ -52,10 +53,14 @@ object TimelineExporter {
             appendLine("  Informational: $infoCount")
         }
 
-        // Assessment
+        // Assessment derived from rule guidance — the rules define threat severity,
+        // not hardcoded category/severity checks in the formatter.
+        val maxGuidancePriority = filtered
+            .mapNotNull { ruleGuidance[it.ruleId].takeIf { g -> !g.isNullOrEmpty() } }
+            .maxOfOrNull { guidancePriority(it) } ?: 0
         val assessment = when {
-            filtered.any { it.severity.equals("CRITICAL", true) } -> "CRITICAL ACTIVITY DETECTED"
-            significantCount > 0 -> "REVIEW RECOMMENDED"
+            maxGuidancePriority >= 3 -> "CRITICAL ACTIVITY DETECTED"
+            maxGuidancePriority >= 1 || significantCount > 0 -> "REVIEW RECOMMENDED"
             else -> "NO CONCERNS"
         }
         appendLine()
@@ -142,6 +147,18 @@ object TimelineExporter {
             val details = csvEscape(event.details)
             @Suppress("MaxLineLength") // CSV row must be a single appendLine call
             appendLine("$ts,$iso,$module,$eventType,$data,$pkg,$sev,$ioc,$iocType,$iocSrc,$campaign,$mitre,$hash,$details")
+        }
+    }
+
+    private fun guidancePriority(guidance: String): Int {
+        val upper = guidance.uppercase()
+        return when {
+            upper.startsWith("CRITICAL") -> 4
+            upper.startsWith("UNINSTALL IMMEDIATELY") -> 3
+            upper.startsWith("UNINSTALL") -> 2
+            upper.startsWith("INVESTIGATE") -> 1
+            upper.startsWith("REVIEW") -> 1
+            else -> 0
         }
     }
 

--- a/app/src/main/java/com/androdr/sigma/SigmaRuleEvaluator.kt
+++ b/app/src/main/java/com/androdr/sigma/SigmaRuleEvaluator.kt
@@ -121,11 +121,17 @@ object SigmaRuleEvaluator {
             .mapValues { (_, v) -> v?.toString() ?: "" }
         val titleVars = recordVars + (evidenceResult?.titleVars ?: emptyMap())
         val remediationVars = recordVars + (evidenceResult?.remediationVars ?: emptyMap())
+        // Device posture findings are conditions (not incidents) — cap at medium regardless
+        // of the rule's level field. This is the single structural chokepoint for the cap.
+        val effectiveLevel = if (category == FindingCategory.DEVICE_POSTURE &&
+            rule.level.lowercase() in listOf("high", "critical")
+        ) "medium" else rule.level
+
         return Finding(
             ruleId = rule.id,
             title = TemplateResolver.resolve(titleTemplate, titleVars),
             description = rule.description,
-            level = rule.level,
+            level = effectiveLevel,
             category = category,
             tags = rule.tags,
             remediation = TemplateResolver.resolveAll(rule.remediation, remediationVars),

--- a/app/src/main/java/com/androdr/ui/timeline/TimelineViewModel.kt
+++ b/app/src/main/java/com/androdr/ui/timeline/TimelineViewModel.kt
@@ -47,7 +47,8 @@ class TimelineViewModel @Inject constructor(
     @ApplicationContext private val appContext: Context,
     private val dao: ForensicTimelineEventDao,
     private val correlationEngine: CorrelationEngine,
-    private val knownAppResolver: KnownAppResolver
+    private val knownAppResolver: KnownAppResolver,
+    private val sigmaRuleEngine: com.androdr.sigma.SigmaRuleEngine
 ) : ViewModel() {
 
     private val _groupMode = MutableStateFlow(TimelineGroupMode.DATE)
@@ -219,14 +220,13 @@ class TimelineViewModel @Inject constructor(
         viewModelScope.launch {
             val allEvents = withContext(Dispatchers.IO) { dao.getAllForExport() }
             _reportText.value = withContext(Dispatchers.Default) {
-                val names = buildDisplayNames(allEvents)
-                TimelineExporter.formatPlaintext(allEvents, names)
+                TimelineExporter.formatPlaintext(allEvents, buildDisplayNames(allEvents), buildRuleGuidance())
             }
         }
     }
 
     fun exportPlaintext() = export("txt") {
-        TimelineExporter.formatPlaintext(it, buildDisplayNames(it))
+        TimelineExporter.formatPlaintext(it, buildDisplayNames(it), buildRuleGuidance())
     }
     fun exportCsv() = export("csv") { TimelineExporter.formatCsv(it) }
 
@@ -270,4 +270,9 @@ class TimelineViewModel @Inject constructor(
         }.toMap()
         return fromResolver + fromEvents
     }
+
+    private fun buildRuleGuidance(): Map<String, String> =
+        sigmaRuleEngine.getRules()
+            .filter { it.display.guidance.isNotEmpty() }
+            .associate { it.id to it.display.guidance }
 }

--- a/app/src/main/java/com/androdr/ui/timeline/TimelineViewModel.kt
+++ b/app/src/main/java/com/androdr/ui/timeline/TimelineViewModel.kt
@@ -42,6 +42,8 @@ data class ScanGroup(
     val standaloneEvents: List<ForensicTimelineEvent>
 )
 
+@Suppress("TooManyFunctions") // ViewModel exposes filter setters, export methods, and report
+// generation — splitting would fragment the timeline feature's cohesive state management.
 @HiltViewModel
 class TimelineViewModel @Inject constructor(
     @ApplicationContext private val appContext: Context,

--- a/app/src/main/res/raw/sigma_androdr_040_adb_enabled.yml
+++ b/app/src/main/res/raw/sigma_androdr_040_adb_enabled.yml
@@ -12,7 +12,7 @@ detection:
     selection:
         adb_enabled: true
     condition: selection
-level: high
+level: medium
 display:
     category: device_posture
     icon: usb

--- a/app/src/main/res/raw/sigma_androdr_042_unknown_sources.yml
+++ b/app/src/main/res/raw/sigma_androdr_042_unknown_sources.yml
@@ -12,7 +12,7 @@ detection:
     selection:
         unknown_sources_enabled: true
     condition: selection
-level: high
+level: medium
 display:
     category: device_posture
     icon: warning

--- a/app/src/main/res/raw/sigma_androdr_043_no_screen_lock.yml
+++ b/app/src/main/res/raw/sigma_androdr_043_no_screen_lock.yml
@@ -10,7 +10,7 @@ detection:
     selection:
         screen_lock_enabled: false
     condition: selection
-level: critical
+level: medium
 display:
     category: device_posture
     icon: lock_open

--- a/app/src/main/res/raw/sigma_androdr_044_stale_patch.yml
+++ b/app/src/main/res/raw/sigma_androdr_044_stale_patch.yml
@@ -10,7 +10,7 @@ detection:
     selection:
         patch_age_days|gte: 90
     condition: selection
-level: high
+level: medium
 display:
     category: device_posture
     icon: update

--- a/app/src/main/res/raw/sigma_androdr_045_bootloader_unlocked.yml
+++ b/app/src/main/res/raw/sigma_androdr_045_bootloader_unlocked.yml
@@ -10,7 +10,7 @@ detection:
     selection:
         bootloader_unlocked: true
     condition: selection
-level: critical
+level: medium
 display:
     category: device_posture
     icon: lock_open

--- a/app/src/main/res/raw/sigma_androdr_046_wifi_adb.yml
+++ b/app/src/main/res/raw/sigma_androdr_046_wifi_adb.yml
@@ -10,7 +10,7 @@ detection:
     selection:
         wifi_adb_enabled: true
     condition: selection
-level: high
+level: medium
 display:
     category: device_posture
     icon: wifi

--- a/app/src/main/res/raw/sigma_androdr_047_cve_exploit.yml
+++ b/app/src/main/res/raw/sigma_androdr_047_cve_exploit.yml
@@ -15,7 +15,7 @@ detection:
     selection:
         unpatched_cve_count|gte: 1
     condition: selection
-level: critical
+level: medium
 display:
     category: device_posture
     icon: shield_alert

--- a/app/src/main/res/raw/sigma_androdr_048_pegasus_cves.yml
+++ b/app/src/main/res/raw/sigma_androdr_048_pegasus_cves.yml
@@ -26,6 +26,6 @@ display:
     safe_title: "No Pegasus-linked CVEs"
     evidence_type: cve_list
     summary_template: "Pegasus spyware exploits {count} unpatched CVEs on this device"
-level: critical
+level: medium
 remediation:
     - "Go to Settings > Software Update > Download and Install immediately. Also check Play Store > Settings > About > Google Play system update. Your phone has vulnerabilities used by Pegasus spyware."

--- a/app/src/main/res/raw/sigma_androdr_049_predator_cves.yml
+++ b/app/src/main/res/raw/sigma_androdr_049_predator_cves.yml
@@ -26,6 +26,6 @@ display:
     safe_title: "No Predator-linked CVEs"
     evidence_type: cve_list
     summary_template: "Predator spyware exploits {count} unpatched CVEs on this device"
-level: critical
+level: medium
 remediation:
     - "Go to Settings > Software Update > Download and Install immediately. Also check Play Store > Settings > About > Google Play system update. Your phone has vulnerabilities used by Predator spyware."

--- a/app/src/main/res/raw/sigma_androdr_068_hidden_launcher.yml
+++ b/app/src/main/res/raw/sigma_androdr_068_hidden_launcher.yml
@@ -19,7 +19,9 @@ detection:
         is_known_oem_app: false
     filter_known_good:
         package_name|ioc_lookup: known_good_app_db
-    condition: selection and not filter_known_good
+    filter_trusted_store:
+        from_trusted_store: true
+    condition: selection and not filter_known_good and not filter_trusted_store
 level: high
 display:
     category: app_risk

--- a/app/src/test/java/com/androdr/reporting/TimelineExporterTest.kt
+++ b/app/src/test/java/com/androdr/reporting/TimelineExporterTest.kt
@@ -81,11 +81,21 @@ class TimelineExporterTest {
     }
 
     @Test
-    fun `assessment line present for significant events`() {
-        val text = TimelineExporter.formatPlaintext(events)
+    fun `assessment driven by rule guidance`() {
+        val guidance = mapOf("androdr-001" to "UNINSTALL IMMEDIATELY -- known malware")
+        val text = TimelineExporter.formatPlaintext(events, ruleGuidance = guidance)
         assertTrue("Should have assessment", text.contains("ASSESSMENT:"))
-        assertTrue("Critical events -> critical assessment",
+        assertTrue("Rule guidance drives critical assessment",
             text.contains("CRITICAL ACTIVITY DETECTED"))
+    }
+
+    @Test
+    fun `assessment without guidance caps at review`() {
+        // Same events but no rule guidance -> no CRITICAL, just REVIEW
+        val text = TimelineExporter.formatPlaintext(events)
+        assertTrue(text.contains("ASSESSMENT:"))
+        assertTrue("Without guidance, significant events -> REVIEW",
+            text.contains("REVIEW RECOMMENDED"))
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Device posture rules (040-050) recalibrated from critical/high to **medium** -- conditions not incidents
- `ScanResult.overallRiskLevel` now excludes device posture from CRITICAL/HIGH threshold
- Timeline assessment driven by `ruleGuidance` map from `SigmaRuleEngine`, not hardcoded severity checks
- Severity breakdown line added to timeline assessment block
- Hidden launcher rule (068) excludes trusted store apps (Samsung Cloud restore false positive)
- Remote rules repo (`android-sigma-rules/rules`) synced with all changes + guidance fields

## Severity model
| Trigger | OVERALL RISK |
|---------|-------------|
| App threats with CRITICAL/UNINSTALL IMMEDIATELY guidance | CRITICAL |
| App threats with REVIEW/INVESTIGATE guidance | HIGH |
| Device posture only (CVEs, USB debug, bootloader) | MEDIUM |
| Clean | LOW |

## Test plan
- [x] All unit tests pass
- [x] Verified on S25 Ultra: MEDIUM risk for device posture only
- [x] Collins dictionary no longer triggers hidden launcher rule
- [x] Remote rules repo updated and fetched successfully (32 rules)
- [ ] CI pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)