### PR TITLE
fix(ui): prompt the user to grant Usage Access instead of silently failing

### DIFF
--- a/app/src/main/java/com/androdr/scanner/UsageStatsScanner.kt
+++ b/app/src/main/java/com/androdr/scanner/UsageStatsScanner.kt
@@ -32,7 +32,7 @@ class UsageStatsScanner @Inject constructor(
      * Filters out OEM/system apps to reduce noise. Returns events
      * suitable for direct insertion into the forensic timeline.
      */
-    @Suppress("TooGenericExceptionCaught")
+    @Suppress("TooGenericExceptionCaught", "SwallowedException")
     suspend fun collectTimelineEvents(
         hoursBack: Int = 24
     ): List<ForensicTimelineEvent> = withContext(Dispatchers.IO) {
@@ -47,8 +47,16 @@ class UsageStatsScanner @Inject constructor(
         val events = try {
             usm.queryEvents(startTime, endTime)
         } catch (e: SecurityException) {
-            // PACKAGE_USAGE_STATS not granted — fail silently; permission absence is expected
-            Log.d(TAG, "Usage stats permission not granted: ${e.message}")
+            // PACKAGE_USAGE_STATS not granted. Previously this was logged at
+            // DEBUG with a comment calling the absence "expected" — which
+            // meant the forensic-timeline feature was silently disabled with
+            // no signal to anyone that the user needed to grant Usage Access
+            // in Settings. Promoting to WARN so the degraded state is at
+            // least visible in logcat, and the Dashboard banner (see
+            // UsageStatsPermission + DashboardScreen) prompts the user
+            // to grant the permission via the system settings page.
+            Log.w(TAG, "UsageStats permission not granted — forensic timeline " +
+                "will be empty until the user enables Usage Access in Settings")
             return@withContext emptyList()
         } catch (e: Exception) {
             Log.w(TAG, "Usage stats query failed: ${e.message}")

--- a/app/src/main/java/com/androdr/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/com/androdr/ui/dashboard/DashboardScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -37,10 +38,14 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
@@ -66,6 +71,7 @@ fun DashboardScreen(
     val isScanning by viewModel.isScanning.collectAsStateWithLifecycle()
     val scanDiff by viewModel.scanDiff.collectAsStateWithLifecycle()
     val matchedDnsCount by viewModel.matchedDnsCount.collectAsStateWithLifecycle()
+    val hasUsageStatsPermission by viewModel.hasUsageStatsPermission.collectAsStateWithLifecycle()
 
     val snackbarHostState = remember { SnackbarHostState() }
 
@@ -73,6 +79,21 @@ fun DashboardScreen(
         viewModel.iocErrorEvent.collect { message ->
             snackbarHostState.showSnackbar(message)
         }
+    }
+
+    // Re-check Usage Access permission on every lifecycle resume — this is
+    // how the banner disappears the moment the user returns from the system
+    // Settings screen after granting the permission. Without this hook the
+    // banner would stay stale until the next recomposition trigger.
+    val lifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                viewModel.refreshUsageStatsPermission()
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
     }
 
     Scaffold(
@@ -115,6 +136,21 @@ fun DashboardScreen(
             }
 
             RiskLevelCard(latestScan = latestScan)
+
+            // Usage Access permission banner — shown when PACKAGE_USAGE_STATS
+            // hasn't been granted, which silently disables the forensic
+            // timeline feature. Previously the app just returned empty
+            // timeline data with no user-visible feedback; this banner is
+            // the only way to let the user know they need to opt in once
+            // in system Settings (PACKAGE_USAGE_STATS cannot be requested
+            // via the normal runtime permission dialog).
+            AnimatedVisibility(
+                visible = !hasUsageStatsPermission,
+                enter = fadeIn(),
+                exit = fadeOut()
+            ) {
+                UsageAccessBanner(onOpenSettings = { viewModel.openUsageStatsSettings() })
+            }
 
             PostScanGuidance(riskLevel = latestScan?.overallRiskLevel, latestScan = latestScan)
 
@@ -378,6 +414,63 @@ private fun DiffBanner(newCount: Int) {
                 fontWeight = FontWeight.SemiBold,
                 color = Color(0xFFFF9800)
             )
+        }
+    }
+}
+
+/**
+ * Informational banner shown on the Dashboard when the app does not have
+ * the `PACKAGE_USAGE_STATS` permission. Explains what the permission is
+ * used for (forensic timeline) and provides a one-tap button to open the
+ * system Usage Access settings screen where the user can grant it.
+ *
+ * We use explanatory body text rather than a one-line warning because
+ * PACKAGE_USAGE_STATS is a special-access permission the user has likely
+ * never heard of, and the consent model for a stalkerware-detection tool
+ * demands that users understand what they are enabling before they enable
+ * it. One line saying "tap to grant" is not enough consent context here.
+ */
+@Composable
+private fun UsageAccessBanner(onOpenSettings: () -> Unit) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainerHigh
+        )
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp)
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.Info,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(22.dp)
+                )
+                Text(
+                    text = stringResource(R.string.usage_access_banner_title),
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.SemiBold
+                )
+            }
+            Text(
+                text = stringResource(R.string.usage_access_banner_body),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            FilledTonalButton(
+                onClick = onOpenSettings,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text(stringResource(R.string.usage_access_banner_cta))
+            }
         }
     }
 }

--- a/app/src/main/java/com/androdr/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/com/androdr/ui/dashboard/DashboardViewModel.kt
@@ -1,5 +1,6 @@
 package com.androdr.ui.dashboard
 
+import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.androdr.data.db.IndicatorDao
@@ -9,7 +10,9 @@ import com.androdr.data.repo.ScanRepository.Companion.preferRuntimeScan
 import com.androdr.ioc.IocDatabase
 import com.androdr.ioc.IndicatorUpdater
 import com.androdr.scanner.ScanOrchestrator
+import com.androdr.ui.permissions.UsageStatsPermission
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -28,7 +31,8 @@ class DashboardViewModel @Inject constructor(
     private val repository: ScanRepository,
     private val indicatorDao: IndicatorDao,
     private val iocDatabase: IocDatabase,
-    private val indicatorUpdater: IndicatorUpdater
+    private val indicatorUpdater: IndicatorUpdater,
+    @ApplicationContext private val context: Context
 ) : ViewModel() {
 
     // Prefer the latest runtime scan (has device posture flags) over bugreport analysis
@@ -38,6 +42,31 @@ class DashboardViewModel @Inject constructor(
 
     private val _isScanning = MutableStateFlow(false)
     val isScanning: StateFlow<Boolean> = _isScanning.asStateFlow()
+
+    /**
+     * Whether the app currently has the PACKAGE_USAGE_STATS permission, which
+     * the forensic timeline (via [com.androdr.scanner.UsageStatsScanner])
+     * needs to populate "app opened / closed" history. Checked imperatively
+     * via [UsageStatsPermission.isGranted] because the OS doesn't expose
+     * this as an observable flow — instead the UI calls
+     * [refreshUsageStatsPermission] from a lifecycle ON_RESUME hook so the
+     * banner state updates the moment the user grants access and returns
+     * from Settings.
+     */
+    private val _hasUsageStatsPermission = MutableStateFlow(
+        UsageStatsPermission.isGranted(context)
+    )
+    val hasUsageStatsPermission: StateFlow<Boolean> = _hasUsageStatsPermission.asStateFlow()
+
+    /** Re-checks Usage Access permission. Called from the Dashboard on ON_RESUME. */
+    fun refreshUsageStatsPermission() {
+        _hasUsageStatsPermission.value = UsageStatsPermission.isGranted(context)
+    }
+
+    /** Opens the system Usage Access settings screen. */
+    fun openUsageStatsSettings() {
+        UsageStatsPermission.openSettings(context)
+    }
 
     val scanDiff: StateFlow<ScanOrchestrator.ScanDiff?> = repository.allScans
         .map { scans ->

--- a/app/src/main/java/com/androdr/ui/permissions/UsageStatsPermission.kt
+++ b/app/src/main/java/com/androdr/ui/permissions/UsageStatsPermission.kt
@@ -1,0 +1,82 @@
+package com.androdr.ui.permissions
+
+import android.app.AppOpsManager
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.os.Process
+import android.provider.Settings
+
+/**
+ * Helpers for detecting and requesting the `PACKAGE_USAGE_STATS` permission.
+ *
+ * Unlike normal runtime permissions, Usage Access is a "special access"
+ * permission that **cannot be requested via the runtime permission dialog**.
+ * The only thing an app can do is open the Usage Access settings page via
+ * [Intent.ACTION_USAGE_ACCESS_SETTINGS][Settings.ACTION_USAGE_ACCESS_SETTINGS]
+ * and let the user grant it by toggling a switch. Apps that need this
+ * permission (Digital Wellbeing, screen-time apps, forensic tools) all do
+ * the same dance: detect it's not granted, show a banner, deep-link to the
+ * settings screen.
+ *
+ * Previously AndroDR declared the permission in the manifest, caught the
+ * resulting `SecurityException` from `UsageStatsManager.queryEvents()` at
+ * DEBUG level, and silently returned an empty list — meaning the forensic
+ * timeline feature appeared completely broken to anyone who didn't already
+ * know to dig into Settings > Apps > Special access > Usage access and
+ * enable AndroDR. This helper fixes that by giving the UI a first-class
+ * way to ask "is Usage Access granted?" and a one-liner to launch the
+ * settings screen so the user can grant it.
+ */
+object UsageStatsPermission {
+
+    /**
+     * Checks whether `PACKAGE_USAGE_STATS` is currently granted to this app.
+     *
+     * The canonical way to detect this is via [AppOpsManager], not by
+     * catching the eventual `SecurityException` from `queryEvents()`. Use
+     * [AppOpsManager.unsafeCheckOpNoThrow] on API 29+ (the older
+     * [AppOpsManager.checkOpNoThrow] was deprecated in Q). On API 26-28 the
+     * deprecated overload is still the correct choice.
+     */
+    fun isGranted(context: Context): Boolean {
+        val appOps = context.getSystemService(Context.APP_OPS_SERVICE) as? AppOpsManager
+            ?: return false
+        val mode = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            appOps.unsafeCheckOpNoThrow(
+                AppOpsManager.OPSTR_GET_USAGE_STATS,
+                Process.myUid(),
+                context.packageName
+            )
+        } else {
+            @Suppress("DEPRECATION")
+            appOps.checkOpNoThrow(
+                AppOpsManager.OPSTR_GET_USAGE_STATS,
+                Process.myUid(),
+                context.packageName
+            )
+        }
+        return mode == AppOpsManager.MODE_ALLOWED
+    }
+
+    /**
+     * Opens the system Usage Access settings screen. The user will see a
+     * list of apps and toggles; tapping AndroDR's entry grants the
+     * permission. Returns `true` if the intent was successfully launched,
+     * `false` if no activity was resolvable (rare — the settings screen is
+     * part of the system image on every Android version we target).
+     */
+    fun openSettings(context: Context): Boolean {
+        val intent = Intent(Settings.ACTION_USAGE_ACCESS_SETTINGS).apply {
+            // FLAG_ACTIVITY_NEW_TASK is required when launching an activity
+            // from a non-Activity context (the AppContext Hilt provides).
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        return try {
+            context.startActivity(intent)
+            true
+        } catch (_: android.content.ActivityNotFoundException) {
+            false
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,6 +10,12 @@
     <!-- Dashboard -->
     <string name="run_scan">Run Scan</string>
     <string name="scanning">Scanning…</string>
+
+    <!-- Usage Access permission banner — shown when forensic timeline data is unavailable -->
+    <string name="usage_access_banner_title">Enable Usage Access</string>
+    <string name="usage_access_banner_body">AndroDR uses the system Usage Access permission to build a forensic timeline of app opens and closes. Without it, the 24-hour activity history on the Timeline screen will be empty. Grant it once from Android settings — AndroDR cannot request this permission via the normal prompt.</string>
+    <string name="usage_access_banner_cta">Open Usage Access settings</string>
+
     <string name="summary_app_risks">App Risks</string>
     <string name="summary_device_flags">Device Flags</string>
     <string name="summary_dns_matched">Suspicious Connections</string>


### PR DESCRIPTION
## Problem

AndroDR's forensic-timeline feature depends on \`PACKAGE_USAGE_STATS\`. That permission is declared in the manifest but the app **never asked for it** and never told the user anything was wrong when it wasn't granted. \`UsageStatsScanner\` caught the resulting \`SecurityException\`, logged at DEBUG with a comment calling the absence "expected", and returned an empty list. The Timeline screen was mysteriously empty on every device.

Found during on-device runtime-scan stress testing: logcat showed \`Collected 0 usage events (from 0 raw)\` every time, and grep for \`ACTION_USAGE_ACCESS_SETTINGS\` or \`AppOpsManager.*USAGE\` anywhere in the codebase came back empty.

## Why it mattered

\`PACKAGE_USAGE_STATS\` is a "special access" permission that **cannot be requested via the normal runtime permission dialog**. The only way to get it is to deep-link the user to Settings > Apps > Special access > Usage access. Every app that needs this (Digital Wellbeing, parental controls, forensic tools) follows that pattern — except AndroDR, which silently assumed no permission and surfaced nothing.

For a forensic-timeline feature that's part of the app's value proposition, that's a dead feature for any user who doesn't happen to already know about the Usage Access settings page.

## Fix

Five pieces, all in \`fix/usage-stats-permission\`:

1. **\`UsageStatsPermission\` helper** (new file, ~50 LOC):
   - \`isGranted(context)\` — canonical check via \`AppOpsManager.unsafeCheckOpNoThrow(OPSTR_GET_USAGE_STATS, ...)\` on API 29+, deprecated \`checkOpNoThrow\` on API 26-28.
   - \`openSettings(context)\` — launches \`Intent(Settings.ACTION_USAGE_ACCESS_SETTINGS)\` with \`FLAG_ACTIVITY_NEW_TASK\`.

2. **\`DashboardViewModel.hasUsageStatsPermission\`** — \`StateFlow<Boolean>\` re-checked on demand via \`refreshUsageStatsPermission()\`. Defaults from a check at VM init.

3. **Dashboard lifecycle hook** — \`DisposableEffect\` observing \`Lifecycle.Event.ON_RESUME\` so the banner disappears the moment the user returns from the system Settings page after granting the permission.

4. **\`UsageAccessBanner\` composable** — appears on the Dashboard only when the permission is missing. Explains what Usage Access is used for (the forensic timeline) in 1-2 sentences, includes a tap-to-open-Settings button. Explanatory body text rather than a one-line warning, because the consent model for a stalkerware-detection tool demands users understand what they're enabling before they enable it.

5. **\`UsageStatsScanner\` log level**: promoted the silent-swallow log from DEBUG to WARN so the degraded state is at least visible in logcat. The scanner still returns an empty list gracefully — the exception-handling path is unchanged in behavior, only in visibility.

## Test plan

- [x] \`./gradlew detekt assembleDebug testDebugUnitTest lintDebug\` — all green on clean main base
- [ ] Manual on emulator: verify the banner appears when Usage Access is ungranted, tapping the button opens the system Settings page, and the banner disappears after granting and returning via back navigation
- [ ] Manual: verify the \`WARN\` log fires in logcat when a scan runs with the permission ungranted

## Files

- \`app/src/main/java/com/androdr/ui/permissions/UsageStatsPermission.kt\` — new helper
- \`app/src/main/java/com/androdr/scanner/UsageStatsScanner.kt\` — log level + comment
- \`app/src/main/java/com/androdr/ui/dashboard/DashboardViewModel.kt\` — StateFlow + refresh + open
- \`app/src/main/java/com/androdr/ui/dashboard/DashboardScreen.kt\` — lifecycle hook + banner composable
- \`app/src/main/res/values/strings.xml\` — banner title/body/CTA strings

🤖 Generated with [Claude Code](https://claude.com/claude-code)