### PR TITLE
perf(scanner): single-transaction scan persistence to stop Timeline Flow thrashing

### DIFF
--- a/app/src/main/java/com/androdr/data/repo/ScanRepository.kt
+++ b/app/src/main/java/com/androdr/data/repo/ScanRepository.kt
@@ -1,10 +1,13 @@
 package com.androdr.data.repo
 
+import androidx.room.withTransaction
+import com.androdr.data.db.AppDatabase
 import com.androdr.data.db.DnsEventDao
 import com.androdr.data.db.ForensicTimelineEventDao
 import com.androdr.data.db.ScanResultDao
 import com.androdr.data.db.toForensicTimelineEvent
 import com.androdr.data.model.DnsEvent
+import com.androdr.data.model.ForensicTimelineEvent
 import com.androdr.data.model.ScanResult
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
@@ -12,6 +15,7 @@ import javax.inject.Singleton
 
 @Singleton
 class ScanRepository @Inject constructor(
+    private val database: AppDatabase,
     private val scanResultDao: ScanResultDao,
     private val dnsEventDao: DnsEventDao,
     private val forensicTimelineEventDao: ForensicTimelineEventDao
@@ -31,6 +35,42 @@ class ScanRepository @Inject constructor(
     /** Persists a completed [ScanResult] to the database. */
     suspend fun saveScan(scan: ScanResult) {
         scanResultDao.insert(scan)
+    }
+
+    /**
+     * Atomically persists a completed scan along with all its timeline
+     * events in a single Room transaction. Room's [InvalidationTracker]
+     * fires one notification per transaction, so every Flow observing
+     * `ScanResult` or `forensic_timeline` recomposes exactly once per
+     * scan — instead of three times (scan insert + finding events insert
+     * + usage stats delete+insert), which caused visible "timeline state
+     * thrashing" during/after each scan.
+     *
+     * @param findingTimelineEvents events derived from SIGMA findings
+     *   (runtime scan) or the bug-report analysis path. May be empty.
+     * @param replaceUsageStatsEvents when non-null, the existing
+     *   `source = "usage_stats"` rows are replaced with this list inside
+     *   the same transaction. Pass `null` when usage stats are not
+     *   relevant to this scan (e.g. bug-report analyses don't produce
+     *   UsageStats timeline events).
+     */
+    suspend fun saveScanResults(
+        scan: ScanResult,
+        findingTimelineEvents: List<ForensicTimelineEvent>,
+        replaceUsageStatsEvents: List<ForensicTimelineEvent>? = null
+    ) {
+        database.withTransaction {
+            scanResultDao.insert(scan)
+            if (findingTimelineEvents.isNotEmpty()) {
+                forensicTimelineEventDao.insertAll(findingTimelineEvents)
+            }
+            if (replaceUsageStatsEvents != null) {
+                forensicTimelineEventDao.deleteBySource("usage_stats")
+                if (replaceUsageStatsEvents.isNotEmpty()) {
+                    forensicTimelineEventDao.insertAll(replaceUsageStatsEvents)
+                }
+            }
+        }
     }
 
     /**
@@ -81,12 +121,20 @@ class ScanRepository @Inject constructor(
     }
 
     suspend fun deleteScan(scanId: Long) {
-        forensicTimelineEventDao.deleteByScanId(scanId)
-        scanResultDao.deleteById(scanId)
+        // Single transaction so the History screen and Timeline screen
+        // both receive exactly one invalidation after the scan is gone,
+        // instead of rendering a half-deleted intermediate state between
+        // the timeline-event delete and the scan-row delete.
+        database.withTransaction {
+            forensicTimelineEventDao.deleteByScanId(scanId)
+            scanResultDao.deleteById(scanId)
+        }
     }
 
     suspend fun deleteAllScans() {
-        forensicTimelineEventDao.deleteAll()
-        scanResultDao.deleteAll()
+        database.withTransaction {
+            forensicTimelineEventDao.deleteAll()
+            scanResultDao.deleteAll()
+        }
     }
 }

--- a/app/src/main/java/com/androdr/scanner/ScanOrchestrator.kt
+++ b/app/src/main/java/com/androdr/scanner/ScanOrchestrator.kt
@@ -3,7 +3,6 @@ package com.androdr.scanner
 import android.net.Uri
 import android.util.Log
 import com.androdr.data.db.DnsEventDao
-import com.androdr.data.db.ForensicTimelineEventDao
 import com.androdr.data.db.toForensicTimelineEvent
 import com.androdr.data.model.ScanResult
 import com.androdr.data.model.ScannerFailure
@@ -48,7 +47,6 @@ class ScanOrchestrator @Inject constructor(
     private val bugReportAnalyzer: BugReportAnalyzer,
     private val scanRepository: ScanRepository,
     private val dnsEventDao: DnsEventDao,
-    private val forensicTimelineEventDao: ForensicTimelineEventDao,
     private val sigmaRuleEngine: SigmaRuleEngine,
     private val indicatorResolver: IndicatorResolver,
     private val sigmaRuleFeed: SigmaRuleFeed,
@@ -311,38 +309,35 @@ class ScanOrchestrator @Inject constructor(
                 snapshottedErrors.joinToString { "${it.scanner}(${it.exception})" })
         }
 
-        runCatching { scanRepository.saveScan(result) }
-            .onFailure { Log.e(TAG, "Failed to save scan result", it) }
-        runCatching {
-            // Build hash lookup from app telemetry for enrichment
-            val hashByPkg = appTelemetry.filter { !it.apkHash.isNullOrEmpty() }
-                .associateBy({ it.packageName }, { it.apkHash!! })
-            val timelineEvents = allFindings
-                .filter { it.triggered }
-                .map { finding ->
-                    val event = finding.toForensicTimelineEvent(result)
-                    // Enrich with APK hash from telemetry if not already set
-                    if (event.apkHash.isEmpty() && event.packageName.isNotEmpty()) {
-                        event.copy(apkHash = hashByPkg[event.packageName] ?: "")
-                    } else event
-                }
-            if (timelineEvents.isNotEmpty()) {
-                forensicTimelineEventDao.insertAll(timelineEvents)
-                Log.i(TAG, "Persisted ${timelineEvents.size} timeline events for scan ${result.id}")
+        // Build hash lookup from app telemetry for enrichment
+        val hashByPkg = appTelemetry.filter { !it.apkHash.isNullOrEmpty() }
+            .associateBy({ it.packageName }, { it.apkHash!! })
+        val findingTimelineEvents = allFindings
+            .filter { it.triggered }
+            .map { finding ->
+                val event = finding.toForensicTimelineEvent(result)
+                // Enrich with APK hash from telemetry if not already set
+                if (event.apkHash.isEmpty() && event.packageName.isNotEmpty()) {
+                    event.copy(apkHash = hashByPkg[event.packageName] ?: "")
+                } else event
             }
-        }.onFailure { Log.e(TAG, "Failed to persist timeline events", it) }
-
-        // Usage stats produce timeline events directly (observational data, not SIGMA telemetry)
+        // Usage stats produce timeline events directly (observational data,
+        // not SIGMA telemetry). Await the deferred before entering the save
+        // transaction so the whole save + finding events + usage event
+        // replacement is one atomic Room write — giving Flow observers a
+        // single invalidation per scan instead of three.
         val usageEvents = usageEventsDeferred.await()
-        if (usageEvents.isNotEmpty()) {
-            val tagged = usageEvents.map { it.copy(scanResultId = result.id) }
-            // Remove stale usage_stats events before inserting fresh ones
-            runCatching {
-                forensicTimelineEventDao.deleteBySource("usage_stats")
-            }.onFailure { Log.e(TAG, "Failed to delete stale usage events", it) }
-            runCatching { forensicTimelineEventDao.insertAll(tagged) }
-                .onFailure { Log.e(TAG, "Failed to persist usage events", it) }
-        }
+        val taggedUsageEvents = usageEvents.map { it.copy(scanResultId = result.id) }
+
+        runCatching {
+            scanRepository.saveScanResults(
+                scan = result,
+                findingTimelineEvents = findingTimelineEvents,
+                replaceUsageStatsEvents = taggedUsageEvents
+            )
+            Log.i(TAG, "Persisted scan ${result.id} with ${findingTimelineEvents.size} " +
+                "finding events and ${taggedUsageEvents.size} usage events (single transaction)")
+        }.onFailure { Log.e(TAG, "Failed to persist scan results", it) }
 
         // Progress is reset to Idle by the outer runFullScan() in its
         // `finally` block, which also handles the exception path.
@@ -423,47 +418,51 @@ class ScanOrchestrator @Inject constructor(
             },
             scannerErrors = bugReportScannerErrors
         )
-        runCatching { scanRepository.saveScan(scanResult) }
+        // Phase 1: finding-derived events. Each triggered finding becomes
+        // one ForensicTimelineEvent. Bug-report findings may inherit a
+        // real `event_time_ms` from their underlying telemetry record
+        // (see TimelineAdapter.Finding.toForensicTimelineEvent) — so a
+        // "Camera Access" finding now shows up at the actual time the
+        // AppOps access was recorded, not at 0L / "Unknown".
+        val findingEvents = result.findings.filter { it.triggered }
+            .map { finding ->
+                val event = finding.toForensicTimelineEvent(scanResult, isBugreport = true)
+                if (event.apkHash.isEmpty() && event.packageName.isNotEmpty()) {
+                    event.copy(apkHash = hashByPkg[event.packageName] ?: "")
+                } else event
+            }
+
+        // Phase 2: raw module-produced timeline events, **deduplicated**
+        // against finding-derived events that inherited the same
+        // (packageName, timestamp) tuple. Without this filter the
+        // Timeline would show a "Camera Access" finding row right next
+        // to a raw "com.X used CAMERA at ..." row with the identical
+        // time — two rows describing the same underlying evidence,
+        // which reads as a duplicate to the user. Raw events for
+        // unmatched AppOps records (packages whose dangerous-op usage
+        // didn't trigger any SIGMA rule) still appear as before.
+        val coveredByFinding = findingEvents
+            .filter { it.timestamp > 0L && it.packageName.isNotEmpty() }
+            .mapTo(HashSet()) { it.packageName to it.timestamp }
+        val rawEvents = result.timeline
+            .filterNot { raw ->
+                raw.packageName != null &&
+                    (raw.packageName to raw.timestamp) in coveredByFinding
+            }
+            .map { it.toForensicTimelineEvent(scanResult.id) }
+        val allBugReportTimelineEvents = findingEvents + rawEvents
+
+        // Single transaction: persist scan row + all timeline events in one
+        // write. Bug-report analysis does not produce usage_stats rows, so
+        // replaceUsageStatsEvents = null (leaves existing usage_stats rows
+        // untouched). See ScanRepository.saveScanResults docs.
         runCatching {
-            val timelineEvents = mutableListOf<com.androdr.data.model.ForensicTimelineEvent>()
-
-            // Phase 1: finding-derived events. Each triggered finding becomes
-            // one ForensicTimelineEvent. Bug-report findings may inherit a
-            // real `event_time_ms` from their underlying telemetry record
-            // (see TimelineAdapter.Finding.toForensicTimelineEvent) — so a
-            // "Camera Access" finding now shows up at the actual time the
-            // AppOps access was recorded, not at 0L / "Unknown".
-            val findingEvents = result.findings.filter { it.triggered }
-                .map { finding ->
-                    val event = finding.toForensicTimelineEvent(scanResult, isBugreport = true)
-                    if (event.apkHash.isEmpty() && event.packageName.isNotEmpty()) {
-                        event.copy(apkHash = hashByPkg[event.packageName] ?: "")
-                    } else event
-                }
-            timelineEvents.addAll(findingEvents)
-
-            // Phase 2: raw module-produced timeline events, **deduplicated**
-            // against finding-derived events that inherited the same
-            // (packageName, timestamp) tuple. Without this filter the
-            // Timeline would show a "Camera Access" finding row right next
-            // to a raw "com.X used CAMERA at ..." row with the identical
-            // time — two rows describing the same underlying evidence,
-            // which reads as a duplicate to the user. Raw events for
-            // unmatched AppOps records (packages whose dangerous-op usage
-            // didn't trigger any SIGMA rule) still appear as before.
-            val coveredByFinding = findingEvents
-                .filter { it.timestamp > 0L && it.packageName.isNotEmpty() }
-                .mapTo(HashSet()) { it.packageName to it.timestamp }
-            val rawEvents = result.timeline
-                .filterNot { raw ->
-                    raw.packageName != null &&
-                        (raw.packageName to raw.timestamp) in coveredByFinding
-                }
-                .map { it.toForensicTimelineEvent(scanResult.id) }
-            timelineEvents.addAll(rawEvents)
-
-            forensicTimelineEventDao.insertAll(timelineEvents)
-        }
+            scanRepository.saveScanResults(
+                scan = scanResult,
+                findingTimelineEvents = allBugReportTimelineEvents,
+                replaceUsageStatsEvents = null
+            )
+        }.onFailure { Log.e(TAG, "Failed to persist bug-report scan results", it) }
 
         return result
     }

--- a/app/src/test/java/com/androdr/scanner/ScanOrchestratorErrorHandlingTest.kt
+++ b/app/src/test/java/com/androdr/scanner/ScanOrchestratorErrorHandlingTest.kt
@@ -130,7 +130,6 @@ class ScanOrchestratorErrorHandlingTest {
             bugReportAnalyzer = bugReportAnalyzer,
             scanRepository = scanRepository,
             dnsEventDao = dnsEventDao,
-            forensicTimelineEventDao = forensicTimelineEventDao,
             sigmaRuleEngine = sigmaRuleEngine,
             indicatorResolver = indicatorResolver,
             sigmaRuleFeed = sigmaRuleFeed,


### PR DESCRIPTION
## Problem

Post-scan persistence fired **three separate Room writes** that each invalidated the \`forensic_timeline\` Flow:

1. \`scanRepository.saveScan(result)\` — scan row
2. \`forensicTimelineEventDao.insertAll(findingTimelineEvents)\`
3. \`forensicTimelineEventDao.deleteBySource(\"usage_stats\")\` + \`insertAll(taggedUsageEvents)\`

Every Flow observer (TimelineScreen, TimelineViewModel, History detail) recomposed three times per scan. Between the delete and re-insert of usage_stats rows, a user watching the Timeline briefly saw those rows vanish and reappear — visible flicker on every scan.

The parallelized AppScanner from #76 made this worse by firing the three-invalidation burst in a tighter window.

\`deleteScan(scanId)\` and \`deleteAllScans()\` had the same two-DAO thrashing pattern.

## Fix

New \`ScanRepository.saveScanResults(scan, findingTimelineEvents, replaceUsageStatsEvents)\` wraps all three operations in a single \`AppDatabase.withTransaction { ... }\` block. Room's \`InvalidationTracker\` batches notifications per transaction, so the whole scan save produces exactly one Flow invalidation and observers recompose once.

- \`replaceUsageStatsEvents\` is nullable: runtime scans pass tagged events to trigger delete+insert replacement; bug-report analyses pass \`null\` so they don't touch existing usage_stats rows.
- \`deleteScan\` and \`deleteAllScans\` now also use \`withTransaction { }\`.
- \`ScanOrchestrator\` no longer injects \`ForensicTimelineEventDao\` directly — all timeline persistence now flows through \`ScanRepository\`, which owns the transactional contract.

## Verification

- [x] \`./gradlew detekt assembleDebug testDebugUnitTest lintDebug\` — all green on fresh main
- [x] \`ScanOrchestratorErrorHandlingTest\` updated to match the reduced constructor; all 7 failure-path tests still pass
- [x] Finding/raw-event dedup from #76 preserved — it now happens before the single transactional persist call
- [ ] Manual on real device: confirm Timeline no longer flickers during a runtime scan

## Files

- \`data/repo/ScanRepository.kt\` — new \`saveScanResults\` + \`deleteScan\`/\`deleteAllScans\` in transactions
- \`scanner/ScanOrchestrator.kt\` — runtime scan + bug-report analysis both route through the new method
- \`test/.../ScanOrchestratorErrorHandlingTest.kt\` — constructor update

🤖 Generated with [Claude Code](https://claude.com/claude-code)