### PR TITLE
fix(test): harness cleanup quirks found during PR #89 verification

### DIFF
--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -20,11 +20,31 @@ if [[ ! -x "$EMULATOR" ]]; then
   exit 1
 fi
 
-# ── Start AVD headlessly ──────────────────────────────────────────────────────
-echo "Starting AVD: $AVD_NAME"
-"$EMULATOR" -avd "$AVD_NAME" -no-window -no-audio -no-snapshot &
-EMULATOR_PID=$!
-trap '"$ADB" -e emu kill 2>/dev/null; wait $EMULATOR_PID 2>/dev/null' EXIT
+# ── Emulator: reuse existing or start fresh ──────────────────────────────────
+# Check whether an emulator is already booted. If so, reuse it and leave it
+# running on exit. If not, boot a fresh one and kill it on exit.
+#
+# Reusing avoids the "Running multiple emulators with the same AVD is an
+# experimental feature" failure when a developer already has the target AVD
+# open during interactive work.
+REUSED_EMULATOR=false
+EMULATOR_PID=""
+if "$ADB" devices 2>/dev/null | awk 'NR>1 && /emulator-[0-9]+\tdevice/' | grep -q .; then
+  echo "Reusing running emulator."
+  REUSED_EMULATOR=true
+else
+  echo "Starting AVD: $AVD_NAME"
+  "$EMULATOR" -avd "$AVD_NAME" -no-window -no-audio -no-snapshot &
+  EMULATOR_PID=$!
+fi
+
+cleanup() {
+  if ! $REUSED_EMULATOR && [[ -n "$EMULATOR_PID" ]]; then
+    "$ADB" -e emu kill 2>/dev/null || true
+    wait "$EMULATOR_PID" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
 
 # ── Wait for boot ─────────────────────────────────────────────────────────────
 echo "Waiting for device..."

--- a/test-adversary/cleanup.sh
+++ b/test-adversary/cleanup.sh
@@ -4,6 +4,8 @@
 set -euo pipefail
 
 SERIAL="${1:?Usage: $0 <emulator-serial>}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+MANIFEST="$SCRIPT_DIR/manifest.yml"
 STATE_FILE="/tmp/androdr-loaded-packages.txt"
 
 # Resolve adb
@@ -16,28 +18,58 @@ else
     exit 1
 fi
 
-if [ ! -f "$STATE_FILE" ]; then
-    echo "No state file found at $STATE_FILE. Nothing to clean up."
-    exit 0
-fi
-
 echo "=== AndroDR Adversary Cleanup ==="
 echo ""
 
+# ── Uninstall packages tracked in state file ──────────────────────────────────
 count=0
-while IFS= read -r pkg || [ -n "$pkg" ]; do
-    [ -z "$pkg" ] && continue
-    if $ADB uninstall "$pkg" 2>/dev/null | grep -q "Success"; then
-        echo "  Uninstalled: $pkg"
-        ((count++)) || true
-    else
-        echo "  Skip (not installed): $pkg"
+if [ -f "$STATE_FILE" ]; then
+    while IFS= read -r pkg || [ -n "$pkg" ]; do
+        [ -z "$pkg" ] && continue
+        if $ADB uninstall "$pkg" 2>/dev/null | grep -q "Success"; then
+            echo "  Uninstalled: $pkg"
+            ((count++)) || true
+        else
+            echo "  Skip (not installed): $pkg"
+        fi
+    done < "$STATE_FILE"
+    rm -f "$STATE_FILE"
+else
+    echo "  No state file — skipping package uninstall step."
+fi
+
+# ── Remove every adb_inject artifact defined in the manifest ──────────────────
+# Previously this was hardcoded to /data/local/tmp/.raptor and .stat, which
+# silently broke whenever a new inject scenario was added. Instead, read the
+# manifest and reverse every inject scenario's cleanup commands. Commands are
+# idempotent (rm -f), so running them on a device that never had the artifact
+# installed is harmless.
+if [ ! -f "$MANIFEST" ]; then
+    echo "  WARNING: manifest not found at $MANIFEST — cannot reverse inject scenarios."
+else
+    # Collect every cleanup: command from every adb_inject scenario
+    cleanup_cmds=$(python3 - "$MANIFEST" <<'PY'
+import sys, yaml
+with open(sys.argv[1]) as f:
+    m = yaml.safe_load(f)
+for s in m.get('scenarios', []):
+    if s.get('source') == 'adb_inject':
+        for inj in s.get('inject', []):
+            c = inj.get('cleanup', '')
+            if c:
+                print(c)
+PY
+)
+    artifact_count=0
+    while IFS= read -r cmd; do
+        [ -z "$cmd" ] && continue
+        $ADB $cmd 2>/dev/null || true
+        ((artifact_count++)) || true
+    done <<< "$cleanup_cmds"
+    if [ "$artifact_count" -gt 0 ]; then
+        echo "  Reversed $artifact_count inject-scenario artifacts from manifest."
     fi
-done < "$STATE_FILE"
+fi
 
-# Remove injected artifacts
-$ADB shell rm -f /data/local/tmp/.raptor /data/local/tmp/.stat 2>/dev/null || true
-
-rm -f "$STATE_FILE"
 echo ""
 echo "Cleanup complete. Removed $count packages."

--- a/test-adversary/run.sh
+++ b/test-adversary/run.sh
@@ -48,14 +48,25 @@ WORKDIR=$(mktemp -d /tmp/androdr-adversary-XXXXXX)
 # Track results for summary
 declare -A RESULTS
 
-# Cleanup trap — always restore network and uninstall test APKs
+# Cleanup trap — always restore network, uninstall test APKs, and remove
+# injected artifacts (files, properties, etc.) that adb_inject scenarios created.
 INSTALLED_PACKAGES=()
+INJECTED_SCENARIOS=()
 
 cleanup() {
     echo ""
     echo ">>> Cleaning up..."
     for pkg in "${INSTALLED_PACKAGES[@]+"${INSTALLED_PACKAGES[@]}"}"; do
         $ADB uninstall "$pkg" 2>/dev/null || true
+    done
+    # Reverse every adb_inject scenario's cleanup commands from the manifest.
+    # Without this, files like /data/local/tmp/.raptor persist across runs
+    # and trip the spyware artifact rule on the next scan.
+    for scenario_id in "${INJECTED_SCENARIOS[@]+"${INJECTED_SCENARIOS[@]}"}"; do
+        while IFS= read -r cmd; do
+            [ -z "$cmd" ] && continue
+            $ADB $cmd </dev/null 2>/dev/null || true
+        done < <(get_cleanup_cmds "$scenario_id")
     done
     # Restore network inside emulator
     if ! ${SKIP_ISOLATION:-true}; then
@@ -321,6 +332,7 @@ run_scenario() {
 
     # Step 4: INJECT (adb_inject scenarios)
     if [ "$source" = "adb_inject" ]; then
+        INJECTED_SCENARIOS+=("$id")
         while IFS= read -r cmd; do
             [ -z "$cmd" ] && continue
             echo "  Injecting: adb $cmd"
@@ -482,6 +494,7 @@ if [ "$MODE" = "load" ] || [ "$MODE" = "guided" ]; then
         fi
 
         if [ "$source" = "adb_inject" ]; then
+            INJECTED_SCENARIOS+=("$scenario_id")
             while IFS= read -r cmd; do
                 [ -z "$cmd" ] && continue
                 echo "  Injecting ($scenario_id): adb $cmd"


### PR DESCRIPTION
## Summary

Two small fixes to the test infrastructure surfaced during the full testing + stress testing run for PR #89 (unified telemetry/findings refactor).

## The problems

**1. `scripts/smoke-test.sh` unconditionally boots a second emulator**

The script tries to start `Medium_Phone_API_36.1` even when a developer already has that AVD open. Android complains "Running multiple emulators with the same AVD is an experimental feature," the second boot fails, and the trap at the end of the script kills **both** emulators on exit — silently wiping the developer's existing interactive session.

**2. `test-adversary/run.sh` cleanup trap only uninstalls packages**

The `adb_inject` scenarios (e.g. `spyware_artifact_raptor` → `shell touch /data/local/tmp/.raptor`) create files on the device. The cleanup trap in `run.sh` previously only iterated `INSTALLED_PACKAGES` and did NOT reverse any inject scenarios. Result: files like `/data/local/tmp/.raptor` and `.stat` persisted across harness runs and tripped the `sigma_androdr_020_spyware_artifact` rule on the next scan — producing confusing \"CRITICAL spyware artifact detected\" findings that looked like real detections but were actually leftover state.

**3. `test-adversary/cleanup.sh` hardcoded two paths**

The standalone cleanup script had `$ADB shell rm -f /data/local/tmp/.raptor /data/local/tmp/.stat` as a literal. Any future inject scenario with a different artifact path would not be cleaned up by this script unless someone remembered to add a line here.

## The fixes

- **smoke-test.sh** now checks `adb devices` for a running emulator first. If one is found, it reuses that emulator and skips the trap that kills emulators on exit. If none is running, behavior is unchanged (start fresh, kill on exit).
- **run.sh** has a new `INJECTED_SCENARIOS` array tracked alongside `INSTALLED_PACKAGES`. The inject loop (in both regression mode and load mode) appends the scenario ID to it. The cleanup trap iterates the array and runs every scenario's `cleanup:` commands from the manifest via the existing `get_cleanup_cmds()` helper.
- **cleanup.sh** replaces the hardcoded `rm -f .raptor .stat` with a manifest-driven loop: for every scenario in `manifest.yml` with `source: adb_inject`, iterate its `inject:` list and run every `cleanup:` command. Any future inject scenario is automatically covered without touching this script.

## Scope

Pure test infrastructure. No product code touched. No behavior change to any scan, rule, or app feature.

- `scripts/smoke-test.sh` — 30 lines changed
- `test-adversary/run.sh` — 15 lines changed (2 insertions for array tracking + 1 expanded trap)
- `test-adversary/cleanup.sh` — 66 lines changed (hardcoded paths → manifest iteration)

## Test plan

- [x] `bash -n` syntax check on all three scripts passes
- [ ] `scripts/smoke-test.sh` with a running emulator reuses it (smoke test passes without boot step)
- [ ] `scripts/smoke-test.sh` with no emulator boots fresh (existing behavior preserved)
- [ ] `test-adversary/run.sh --load --track 3` followed by Ctrl-C triggers the trap and cleans up `.raptor` and `.stat`
- [ ] Second run of `run.sh` starts from a clean device (no residual spyware artifact findings from prior run)
- [ ] `test-adversary/cleanup.sh` works with a missing state file (cleans inject artifacts, skips package uninstall gracefully)

Manual verification items to be ticked by the next person running the harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)