### PR TITLE
fix: eliminate false findings + skip inaccessible paths + dark theme card colors

### DIFF
--- a/app/src/main/java/com/androdr/data/model/FileArtifactTelemetry.kt
+++ b/app/src/main/java/com/androdr/data/model/FileArtifactTelemetry.kt
@@ -6,6 +6,7 @@ data class FileArtifactTelemetry(
     val fileSize: Long?,
     val fileModified: Long?,
     val source: TelemetrySource,
+    val accessible: Boolean = true,
 ) {
     fun toFieldMap(): Map<String, Any?> = mapOf(
         "file_path" to filePath,

--- a/app/src/main/java/com/androdr/scanner/FileArtifactScanner.kt
+++ b/app/src/main/java/com/androdr/scanner/FileArtifactScanner.kt
@@ -32,9 +32,16 @@ class FileArtifactScanner @Inject constructor(
      */
     @Suppress("TooGenericExceptionCaught")
     suspend fun collectTelemetry(): List<FileArtifactTelemetry> = withContext(Dispatchers.IO) {
-        knownSpywareArtifactsResolver.paths.map { path ->
+        var skipped = 0
+        val results = knownSpywareArtifactsResolver.paths.mapNotNull { path ->
             try {
                 val file = File(path)
+                val parentReadable = file.parentFile?.canRead() ?: false
+                if (!parentReadable) {
+                    Log.d(TAG, "Skipping inaccessible path: $path")
+                    skipped++
+                    return@mapNotNull null
+                }
                 val exists = file.exists()
                 FileArtifactTelemetry(
                     filePath = path,
@@ -42,22 +49,18 @@ class FileArtifactScanner @Inject constructor(
                     fileSize = if (exists) file.length() else null,
                     fileModified = if (exists) file.lastModified() else null,
                     source = TelemetrySource.LIVE_SCAN,
+                    accessible = true,
                 )
             } catch (e: Exception) {
-                // SecurityException or other access errors — treat as non-existent
+                // SecurityException or other access errors — skip entirely
                 Log.d(TAG, "Cannot access $path: ${e.message}")
-                FileArtifactTelemetry(
-                    filePath = path,
-                    fileExists = false,
-                    fileSize = null,
-                    fileModified = null,
-                    source = TelemetrySource.LIVE_SCAN,
-                )
+                skipped++
+                null
             }
-        }.also {
-            Log.d(TAG, "Checked ${it.size} artifact paths, " +
-                "${it.count { t -> t.fileExists }} found")
         }
+        Log.d(TAG, "Checked ${results.size} accessible paths, " +
+            "${results.count { t -> t.fileExists }} found, $skipped skipped (inaccessible)")
+        results
     }
 
     companion object {

--- a/app/src/main/java/com/androdr/sigma/SigmaRule.kt
+++ b/app/src/main/java/com/androdr/sigma/SigmaRule.kt
@@ -15,7 +15,8 @@ data class SigmaRule(
     val falsepositives: List<String>,
     val remediation: List<String>,
     val display: SigmaDisplay = SigmaDisplay(),
-    val enabled: Boolean = true
+    val enabled: Boolean = true,
+    val reportSafeState: Boolean = false
 )
 
 data class SigmaDetection(

--- a/app/src/main/java/com/androdr/sigma/SigmaRuleEvaluator.kt
+++ b/app/src/main/java/com/androdr/sigma/SigmaRuleEvaluator.kt
@@ -116,7 +116,7 @@ object SigmaRuleEvaluator {
                     } else {
                         findings.add(buildFinding(rule, category, true, record, null))
                     }
-                } else if (category == FindingCategory.DEVICE_POSTURE) {
+                } else if (rule.reportSafeState) {
                     findings.add(buildFinding(rule, category, false, record, null))
                 }
             }

--- a/app/src/main/java/com/androdr/sigma/SigmaRuleParser.kt
+++ b/app/src/main/java/com/androdr/sigma/SigmaRuleParser.kt
@@ -169,6 +169,7 @@ object SigmaRuleParser {
             }
 
             val enabled = (doc["enabled"] as? Boolean) ?: true
+            val reportSafeState = (doc["report_safe_state"] as? Boolean) ?: false
 
             SigmaRule(
                 id = ruleId,
@@ -184,7 +185,8 @@ object SigmaRuleParser {
                 falsepositives = (doc["falsepositives"] as? List<*>)?.map { it.toString() } ?: emptyList(),
                 remediation = (doc["remediation"] as? List<*>)?.map { it.toString() } ?: emptyList(),
                 display = parseDisplay(doc["display"] as? Map<*, *>),
-                enabled = enabled
+                enabled = enabled,
+                reportSafeState = reportSafeState
             )
         } catch (e: SigmaRuleParseException) {
             throw e

--- a/app/src/main/java/com/androdr/ui/timeline/TimelineEventCard.kt
+++ b/app/src/main/java/com/androdr/ui/timeline/TimelineEventCard.kt
@@ -192,12 +192,18 @@ private fun CategoryChip(category: FindingCategory) {
 }
 
 @Composable
-private fun severityBackgroundFor(level: String): Color = when (level.uppercase()) {
-    "CRITICAL" -> Color(0xFFFFEBEE)
-    "HIGH" -> Color(0xFFFBE9E7)
-    "MEDIUM" -> Color(0xFFFFF8E1)
-    "LOW" -> Color(0xFFE3F2FD)
-    else -> MaterialTheme.colorScheme.surface
+private fun severityBackgroundFor(level: String): Color {
+    // Dark-theme-appropriate severity tints: a faint wash of the severity color
+    // over the dark surface. The previous light-theme pastels (0xFFFFF8E1 etc.)
+    // produced bright backgrounds that made text unreadable on dark screens.
+    val tint = when (level.uppercase()) {
+        "CRITICAL" -> Color(0xFFCF6679) // Material dark error
+        "HIGH" -> Color(0xFFFF8A65)     // deep orange 300
+        "MEDIUM" -> Color(0xFFFFD54F)   // amber 300
+        "LOW" -> Color(0xFF64B5F6)      // blue 300
+        else -> return MaterialTheme.colorScheme.surface
+    }
+    return tint.copy(alpha = 0.10f) // 10% opacity over dark surface = subtle, readable
 }
 
 @Suppress("LongMethod") // Compose detail sheet renders header + all metadata sections + linked evidence

--- a/app/src/main/java/com/androdr/ui/timeline/TimelineViewModel.kt
+++ b/app/src/main/java/com/androdr/ui/timeline/TimelineViewModel.kt
@@ -102,7 +102,12 @@ class TimelineViewModel @Inject constructor(
      * [rows] stream so the UI can render them distinctly from telemetry.
      */
     private val latestFindings: StateFlow<List<Finding>> = scanRepository.allScans
-        .map { scans -> scans.firstOrNull()?.findings.orEmpty() }
+        .map { scans ->
+            // Only triggered findings belong in the timeline. Non-triggered
+            // "safe state" findings (e.g. "Unknown Sources Disabled") are for
+            // the Device Audit screen and report, not the timeline.
+            scans.firstOrNull()?.findings.orEmpty().filter { it.triggered }
+        }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
 
     /**

--- a/app/src/main/res/raw/sigma_androdr_040_adb_enabled.yml
+++ b/app/src/main/res/raw/sigma_androdr_040_adb_enabled.yml
@@ -14,6 +14,7 @@ detection:
     condition: selection
 level: medium
 category: device_posture
+report_safe_state: true
 display:
     category: device_posture
     icon: usb

--- a/app/src/main/res/raw/sigma_androdr_041_dev_options.yml
+++ b/app/src/main/res/raw/sigma_androdr_041_dev_options.yml
@@ -12,6 +12,7 @@ detection:
     condition: selection
 level: medium
 category: device_posture
+report_safe_state: true
 display:
     category: device_posture
     icon: settings

--- a/app/src/main/res/raw/sigma_androdr_042_unknown_sources.yml
+++ b/app/src/main/res/raw/sigma_androdr_042_unknown_sources.yml
@@ -14,6 +14,7 @@ detection:
     condition: selection
 level: medium
 category: device_posture
+report_safe_state: true
 display:
     category: device_posture
     icon: warning

--- a/app/src/main/res/raw/sigma_androdr_043_no_screen_lock.yml
+++ b/app/src/main/res/raw/sigma_androdr_043_no_screen_lock.yml
@@ -12,6 +12,7 @@ detection:
     condition: selection
 level: medium
 category: device_posture
+report_safe_state: true
 display:
     category: device_posture
     icon: lock_open

--- a/app/src/main/res/raw/sigma_androdr_044_stale_patch.yml
+++ b/app/src/main/res/raw/sigma_androdr_044_stale_patch.yml
@@ -12,6 +12,7 @@ detection:
     condition: selection
 level: medium
 category: device_posture
+report_safe_state: true
 display:
     category: device_posture
     icon: update

--- a/app/src/main/res/raw/sigma_androdr_045_bootloader_unlocked.yml
+++ b/app/src/main/res/raw/sigma_androdr_045_bootloader_unlocked.yml
@@ -12,6 +12,7 @@ detection:
     condition: selection
 level: medium
 category: device_posture
+report_safe_state: true
 display:
     category: device_posture
     icon: lock_open

--- a/app/src/main/res/raw/sigma_androdr_046_wifi_adb.yml
+++ b/app/src/main/res/raw/sigma_androdr_046_wifi_adb.yml
@@ -12,6 +12,7 @@ detection:
     condition: selection
 level: medium
 category: device_posture
+report_safe_state: true
 display:
     category: device_posture
     icon: wifi

--- a/app/src/main/res/raw/sigma_androdr_047_cve_exploit.yml
+++ b/app/src/main/res/raw/sigma_androdr_047_cve_exploit.yml
@@ -17,6 +17,7 @@ detection:
     condition: selection
 level: medium
 category: device_posture
+report_safe_state: true
 display:
     category: device_posture
     icon: shield_alert

--- a/app/src/main/res/raw/sigma_androdr_048_pegasus_cves.yml
+++ b/app/src/main/res/raw/sigma_androdr_048_pegasus_cves.yml
@@ -28,5 +28,6 @@ display:
     summary_template: "Pegasus spyware exploits {count} unpatched CVEs on this device"
 level: medium
 category: device_posture
+report_safe_state: true
 remediation:
     - "Go to Settings > Software Update > Download and Install immediately. Also check Play Store > Settings > About > Google Play system update. Your phone has vulnerabilities used by Pegasus spyware."

--- a/app/src/main/res/raw/sigma_androdr_049_predator_cves.yml
+++ b/app/src/main/res/raw/sigma_androdr_049_predator_cves.yml
@@ -28,5 +28,6 @@ display:
     summary_template: "Predator spyware exploits {count} unpatched CVEs on this device"
 level: medium
 category: device_posture
+report_safe_state: true
 remediation:
     - "Go to Settings > Software Update > Download and Install immediately. Also check Play Store > Settings > About > Google Play system update. Your phone has vulnerabilities used by Predator spyware."

--- a/app/src/main/res/raw/sigma_androdr_050_graphite_cves.yml
+++ b/app/src/main/res/raw/sigma_androdr_050_graphite_cves.yml
@@ -27,5 +27,6 @@ display:
     summary_template: "Graphite/Paragon spyware exploits {count} unpatched CVEs on this device"
 level: medium
 category: device_posture
+report_safe_state: true
 remediation:
     - "Go to Settings > Software Update > Download and Install immediately. Also check Play Store > Settings > About > Google Play system update. These CVEs are exploited by Graphite spyware."

--- a/app/src/test/java/com/androdr/scanner/FileArtifactScannerTest.kt
+++ b/app/src/test/java/com/androdr/scanner/FileArtifactScannerTest.kt
@@ -7,8 +7,10 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import java.io.File
 
 class FileArtifactScannerTest {
 
@@ -32,17 +34,30 @@ class FileArtifactScannerTest {
         scanner = FileArtifactScanner(resolver)
     }
 
-    // ── 1. Returns entries for all known paths ───────────────────────────────
+    // ── 1. Only accessible paths produce telemetry ──────────────────────────
 
     @Test
-    fun `returns entries for all known paths`() = runTest {
+    fun `only accessible paths produce telemetry`() = runTest {
         val result = scanner.collectTelemetry()
 
+        // Count how many fake paths have a readable parent directory on this JVM
+        val accessibleCount = fakePaths.count { path ->
+            File(path).parentFile?.canRead() ?: false
+        }
+
         assertEquals(
-            "Expected one entry per resolver path",
-            fakePaths.size,
+            "Expected one entry per accessible resolver path",
+            accessibleCount,
             result.size
         )
+
+        // Every returned entry must have accessible = true
+        result.forEach { telemetry ->
+            assertTrue(
+                "Returned telemetry must have accessible = true",
+                telemetry.accessible
+            )
+        }
     }
 
     // ── 2. Non-existent path returns fileExists false ────────────────────────
@@ -88,6 +103,22 @@ class FileArtifactScannerTest {
                     telemetry.fileModified
                 )
             }
+        }
+    }
+
+    // ── 4. Inaccessible paths are skipped entirely ──────────────────────────
+
+    @Test
+    fun `inaccessible paths are skipped entirely`() = runTest {
+        val result = scanner.collectTelemetry()
+
+        // Verify that no returned path has an unreadable parent
+        result.forEach { telemetry ->
+            val parentReadable = File(telemetry.filePath).parentFile?.canRead() ?: false
+            assertTrue(
+                "Returned path ${telemetry.filePath} should have a readable parent",
+                parentReadable
+            )
         }
     }
 }

--- a/app/src/test/java/com/androdr/sigma/SigmaRuleEvaluatorTest.kt
+++ b/app/src/test/java/com/androdr/sigma/SigmaRuleEvaluatorTest.kt
@@ -15,13 +15,15 @@ class SigmaRuleEvaluatorTest {
         condition: String = "selection",
         level: String = "high",
         category: RuleCategory = RuleCategory.INCIDENT,
+        reportSafeState: Boolean = false,
     ) = SigmaRule(
         id = id, title = "Test", status = "production", description = "",
         product = "androdr", service = service, level = level,
         category = category,
         tags = emptyList(), detection = SigmaDetection(selections, condition),
         falsepositives = emptyList(), remediation = listOf("Fix it"),
-        display = SigmaDisplay(category = if (service == "device_auditor") "device_posture" else "app_risk")
+        display = SigmaDisplay(category = if (service == "device_auditor") "device_posture" else "app_risk"),
+        reportSafeState = reportSafeState
     )
 
     @Test
@@ -257,9 +259,10 @@ class SigmaRuleEvaluatorTest {
     }
 
     @Test
-    fun `device posture rule emits safe finding when not matched`() {
+    fun `device posture rule emits safe finding when not matched and reportSafeState is true`() {
         val rule = makeRule(
             service = "device_auditor",
+            reportSafeState = true,
             selections = mapOf("selection" to SigmaSelection(listOf(
                 SigmaFieldMatcher("adb_enabled", SigmaModifier.EQUALS, listOf(true))
             )))
@@ -278,9 +281,29 @@ class SigmaRuleEvaluatorTest {
     }
 
     @Test
+    fun `device posture rule without reportSafeState does not emit when not matched`() {
+        val rule = makeRule(
+            service = "device_auditor",
+            reportSafeState = false,
+            selections = mapOf("selection" to SigmaSelection(listOf(
+                SigmaFieldMatcher("adb_enabled", SigmaModifier.EQUALS, listOf(true))
+            )))
+        ).copy(display = SigmaDisplay(
+            category = "device_posture",
+            triggeredTitle = "ADB Enabled",
+            safeTitle = "ADB Disabled",
+            evidenceType = "none"
+        ))
+        val record = mapOf<String, Any?>("adb_enabled" to false)
+        val findings = SigmaRuleEvaluator.evaluate(listOf(rule), listOf(record), "device_auditor")
+        assertEquals(0, findings.size)
+    }
+
+    @Test
     fun `device posture rule emits triggered finding with display title`() {
         val rule = makeRule(
             service = "device_auditor",
+            reportSafeState = true,
             selections = mapOf("selection" to SigmaSelection(listOf(
                 SigmaFieldMatcher("adb_enabled", SigmaModifier.EQUALS, listOf(true))
             )))
@@ -311,6 +334,7 @@ class SigmaRuleEvaluatorTest {
     fun `evidence provider called when evidence_type is set`() {
         val rule = makeRule(
             service = "device_auditor",
+            reportSafeState = true,
             selections = mapOf("selection" to SigmaSelection(listOf(
                 SigmaFieldMatcher("unpatched_cve_count", SigmaModifier.GTE, listOf(1))
             ))), level = "critical"


### PR DESCRIPTION
## Summary

Fixes bugs 1, 4, 5, 7 from the post-refactor device testing session.

**Tested on a Samsung S25 Ultra (SM-S938B) connected via USB** — screenshots verified each fix before committing.

## What changed

### Bug 7: FileArtifactScanner skips inaccessible paths

`File.parentFile.canRead()` check before probing each spyware artifact path. On non-rooted devices, `/data/local/tmp/` is inaccessible — the scanner now skips those paths instead of claiming "No artifact found" when it never actually checked. The Device screen count goes from "14/16 checks passed" (dishonest) to "8/11 checks passed" (honest).

### Bug 4+1: `triggered = false` findings scoped via `reportSafeState`

New `report_safe_state: true` field on SIGMA rules. Only the 11 device posture rules (040-050) declare it. All other rules: if the condition doesn't match, NO finding is produced. This eliminates the "Findings (18)" timeline noise on clean devices — now shows only the 3 real triggered issues.

The Device Audit screen's "Checks Passed" section and the report's "Pegasus: not detected" campaign status continue to work because posture rules still produce safe-state findings.

The timeline ViewModel also filters to `finding.triggered` only, so even posture safe-state findings don't pollute the timeline.

### Bug 5: Dark-theme card colors

Replaced light-theme pastel severity backgrounds (`Color(0xFFFFF8E1)` etc.) with 10% opacity tints over the dark surface. Text is now readable on AMOLED/dark screens. The app is dark-only (no light theme defined in `AndroDRTheme`), so these colors are always correct.

## Files changed (20)

- `SigmaRule.kt` — `reportSafeState: Boolean = false`
- `SigmaRuleParser.kt` — parses `report_safe_state:` from YAML
- `SigmaRuleEvaluator.kt` — gate: only produce triggered=false if reportSafeState
- `FileArtifactScanner.kt` — `parentFile.canRead()` accessibility check
- `FileArtifactTelemetry.kt` — `accessible: Boolean` field
- `TimelineViewModel.kt` — filter `findings.filter { it.triggered }`
- `TimelineEventCard.kt` — dark-appropriate severity tint colors
- 11 rule YAML files (040-050) — `report_safe_state: true`
- 2 test files updated

## Test plan

- [x] `./gradlew testDebugUnitTest` — 422 tests pass
- [x] `./gradlew lintDebug` — BUILD SUCCESSFUL
- [x] `./gradlew detekt` — BUILD SUCCESSFUL
- [x] Samsung S25 Ultra: Timeline shows 3 real findings (was 18)
- [x] Samsung S25 Ultra: Device screen shows "8/11 checks passed" (was "14/16")
- [x] Samsung S25 Ultra: Card text readable on dark background
- [x] Samsung S25 Ultra: No "CRITICAL OK No artifact" entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)