### PR TITLE
feat(export): include all telemetry types in report export

### DIFF
--- a/app/src/main/java/com/androdr/reporting/ReportExporter.kt
+++ b/app/src/main/java/com/androdr/reporting/ReportExporter.kt
@@ -54,11 +54,23 @@ class ReportExporter @Inject constructor(
         val inventory = scanOrchestrator.lastAppTelemetry.ifEmpty {
             runCatching { appScanner.collectTelemetry() }.getOrDefault(emptyList())
         }
+        val deviceTelemetry = scanOrchestrator.lastDeviceTelemetry
+        val processTelemetry = scanOrchestrator.lastProcessTelemetry
+        val fileTelemetry = scanOrchestrator.lastFileArtifactTelemetry
+        val accessibilityTelemetry = scanOrchestrator.lastAccessibilityTelemetry
+        val receiverTelemetry = scanOrchestrator.lastReceiverTelemetry
+        val appOpsTelemetry = scanOrchestrator.lastAppOpsTelemetry
         val displayNames = inventory
             .associate { it.packageName to it.appName }
             .filterValues { it.isNotEmpty() }
         val text = ReportFormatter.formatScanReport(
-            scan, dnsEvents, logLines, inventory, displayNames, mode
+            scan, dnsEvents, logLines, inventory, displayNames, mode,
+            deviceTelemetry = deviceTelemetry,
+            processTelemetry = processTelemetry,
+            fileTelemetry = fileTelemetry,
+            accessibilityTelemetry = accessibilityTelemetry,
+            receiverTelemetry = receiverTelemetry,
+            appOpsTelemetry = appOpsTelemetry,
         )
 
         val reportsDir = File(context.cacheDir, "reports").apply { mkdirs() }

--- a/app/src/main/java/com/androdr/reporting/ReportFormatter.kt
+++ b/app/src/main/java/com/androdr/reporting/ReportFormatter.kt
@@ -1,8 +1,14 @@
 package com.androdr.reporting
 
 import android.os.Build
+import com.androdr.data.model.AccessibilityTelemetry
+import com.androdr.data.model.AppOpsTelemetry
 import com.androdr.data.model.AppTelemetry
+import com.androdr.data.model.DeviceTelemetry
 import com.androdr.data.model.DnsEvent
+import com.androdr.data.model.FileArtifactTelemetry
+import com.androdr.data.model.ProcessTelemetry
+import com.androdr.data.model.ReceiverTelemetry
 import com.androdr.data.model.ScanResult
 import com.androdr.sigma.Finding
 import java.text.SimpleDateFormat
@@ -16,16 +22,22 @@ import java.util.Locale
  */
 object ReportFormatter {
 
-    @Suppress("LongMethod", "CyclomaticComplexMethod") // Report formatting requires assembling all
-    // sections (header, device flags, app risks, DNS events, logs) in a specific order; the
-    // branching reflects the conditional severity/status display logic per section.
+    @Suppress("LongMethod", "CyclomaticComplexMethod", "LongParameterList") // Report formatting
+    // requires assembling all sections in a specific order; the branching reflects the conditional
+    // severity/status display logic per section. All telemetry types needed for complete rendering.
     fun formatScanReport(
         scan: ScanResult,
         dnsEvents: List<DnsEvent>,
         logLines: List<String>,
         appInventory: List<AppTelemetry> = emptyList(),
         displayNames: Map<String, String> = emptyMap(),
-        mode: ExportMode = ExportMode.BOTH
+        mode: ExportMode = ExportMode.BOTH,
+        deviceTelemetry: List<DeviceTelemetry> = emptyList(),
+        processTelemetry: List<ProcessTelemetry> = emptyList(),
+        fileTelemetry: List<FileArtifactTelemetry> = emptyList(),
+        accessibilityTelemetry: List<AccessibilityTelemetry> = emptyList(),
+        receiverTelemetry: List<ReceiverTelemetry> = emptyList(),
+        appOpsTelemetry: List<AppOpsTelemetry> = emptyList(),
     ): String = buildString {
         val includeFindings = mode != ExportMode.TELEMETRY_ONLY
         val includeTelemetry = mode != ExportMode.FINDINGS_ONLY
@@ -65,7 +77,11 @@ object ReportFormatter {
 
         if (includeTelemetry) {
             section("TELEMETRY SECTION")
-            appendTelemetrySections(dnsEvents, logLines, appInventory, displayNames)
+            appendTelemetrySections(
+                dnsEvents, logLines, appInventory, displayNames,
+                deviceTelemetry, processTelemetry, fileTelemetry,
+                accessibilityTelemetry, receiverTelemetry, appOpsTelemetry
+            )
         }
 
         // -- Footer ---------------------------------------------------------------
@@ -177,7 +193,13 @@ object ReportFormatter {
         dnsEvents: List<DnsEvent>,
         logLines: List<String>,
         appInventory: List<AppTelemetry>,
-        displayNames: Map<String, String>
+        displayNames: Map<String, String>,
+        deviceTelemetry: List<DeviceTelemetry> = emptyList(),
+        processTelemetry: List<ProcessTelemetry> = emptyList(),
+        fileTelemetry: List<FileArtifactTelemetry> = emptyList(),
+        accessibilityTelemetry: List<AccessibilityTelemetry> = emptyList(),
+        receiverTelemetry: List<ReceiverTelemetry> = emptyList(),
+        appOpsTelemetry: List<AppOpsTelemetry> = emptyList(),
     ) {
         val dnsFmt = SimpleDateFormat("HH:mm:ss", Locale.US)
 
@@ -221,12 +243,114 @@ object ReportFormatter {
             }
         }
 
+        // -- Extended telemetry sections -----------------------------------------
+        appendExtendedTelemetry(
+            deviceTelemetry, processTelemetry, fileTelemetry,
+            accessibilityTelemetry, receiverTelemetry, appOpsTelemetry
+        )
+
         // -- App log --------------------------------------------------------------
         section("APPLICATION LOG  (${logLines.size} lines)")
         if (logLines.isEmpty()) {
             appendLine("  (no log lines captured)")
         } else {
             logLines.forEach { line -> appendLine("  $line") }
+        }
+    }
+
+    @Suppress("LongMethod", "LongParameterList") // Renders 6 telemetry sub-sections sequentially;
+    // splitting further would scatter related rendering logic across many tiny methods.
+    private fun StringBuilder.appendExtendedTelemetry(
+        deviceTelemetry: List<DeviceTelemetry>,
+        processTelemetry: List<ProcessTelemetry>,
+        fileTelemetry: List<FileArtifactTelemetry>,
+        accessibilityTelemetry: List<AccessibilityTelemetry>,
+        receiverTelemetry: List<ReceiverTelemetry>,
+        appOpsTelemetry: List<AppOpsTelemetry>,
+    ) {
+        // -- Device posture telemetry ---------------------------------------------
+        if (deviceTelemetry.isNotEmpty()) {
+            section("DEVICE POSTURE TELEMETRY")
+            deviceTelemetry.forEach { d ->
+                appendLine("  ADB Enabled       : ${d.adbEnabled}")
+                appendLine("  Dev Options        : ${d.devOptionsEnabled}")
+                appendLine("  Unknown Sources    : ${d.unknownSourcesEnabled}")
+                appendLine("  Screen Lock        : ${d.screenLockEnabled}")
+                appendLine("  Patch Level        : ${d.patchLevel.ifEmpty { "unknown" }}")
+                appendLine("  Patch Age (days)   : ${d.patchAgeDays}")
+                appendLine("  Bootloader Unlocked: ${d.bootloaderUnlocked}")
+                appendLine("  WiFi ADB           : ${d.wifiAdbEnabled}")
+                appendLine("  Unpatched CVEs     : ${d.unpatchedCveCount}")
+                appendLine()
+            }
+        }
+
+        // -- Accessibility services ----------------------------------------------
+        if (accessibilityTelemetry.isNotEmpty()) {
+            section("ACCESSIBILITY SERVICES (${accessibilityTelemetry.size})")
+            accessibilityTelemetry.forEach { a ->
+                val sysFlag = if (a.isSystemApp) "system" else "non-system"
+                appendLine("  ${a.packageName} / ${a.serviceName} ($sysFlag)")
+            }
+            appendLine()
+        }
+
+        // -- Broadcast receivers -------------------------------------------------
+        if (receiverTelemetry.isNotEmpty()) {
+            section("BROADCAST RECEIVERS (${receiverTelemetry.size})")
+            receiverTelemetry.forEach { r ->
+                appendLine("  ${r.packageName} / ${r.intentAction} (system: ${r.isSystemApp})")
+            }
+            appendLine()
+        }
+
+        // -- App operations ------------------------------------------------------
+        if (appOpsTelemetry.isNotEmpty()) {
+            val timeFmt = SimpleDateFormat("HH:mm", Locale.US)
+            section("APP OPERATIONS (${appOpsTelemetry.size})")
+            appOpsTelemetry.forEach { op ->
+                val lastAccess = if (op.lastAccessTime > 0)
+                    timeFmt.format(Date(op.lastAccessTime)) else "never"
+                appendLine("  ${op.packageName} / ${op.operation} / last access: $lastAccess")
+            }
+            appendLine()
+        }
+
+        // -- Running processes ---------------------------------------------------
+        if (processTelemetry.isNotEmpty()) {
+            section("RUNNING PROCESSES (${processTelemetry.size})")
+            processTelemetry.forEach { p ->
+                val state = if (p.isForeground) "foreground" else "background"
+                val pkg = p.packageName ?: p.processName
+                appendLine("  $pkg ($state)")
+            }
+            appendLine()
+        }
+
+        // -- File artifact checks ------------------------------------------------
+        if (fileTelemetry.isNotEmpty()) {
+            val checked = fileTelemetry.filter { it.accessible }
+            val skipped = fileTelemetry.filter { !it.accessible }
+            section("FILE ARTIFACT CHECKS")
+            if (checked.isNotEmpty()) {
+                checked.forEach { f ->
+                    val status = if (f.fileExists) {
+                        "FOUND (${f.fileSize ?: 0} bytes) — investigate immediately"
+                    } else {
+                        "clear"
+                    }
+                    appendLine("  ${f.filePath} : $status")
+                }
+            }
+            if (skipped.isNotEmpty()) {
+                appendLine()
+                appendLine("  ${skipped.size} path(s) could not be checked (requires root/ADB access):")
+                skipped.forEach { f ->
+                    appendLine("    ${f.filePath}")
+                }
+                appendLine("  For a complete check: adb shell ls -la <path>")
+            }
+            appendLine()
         }
     }
 

--- a/app/src/main/java/com/androdr/scanner/ScanOrchestrator.kt
+++ b/app/src/main/java/com/androdr/scanner/ScanOrchestrator.kt
@@ -66,6 +66,20 @@ class ScanOrchestrator @Inject constructor(
     @Volatile var lastAppTelemetry: List<com.androdr.data.model.AppTelemetry> = emptyList()
         private set
 
+    /** Cached telemetry from the most recent scan, for report export. */
+    @Volatile var lastDeviceTelemetry: List<com.androdr.data.model.DeviceTelemetry> = emptyList()
+        private set
+    @Volatile var lastProcessTelemetry: List<com.androdr.data.model.ProcessTelemetry> = emptyList()
+        private set
+    @Volatile var lastFileArtifactTelemetry: List<com.androdr.data.model.FileArtifactTelemetry> = emptyList()
+        private set
+    @Volatile var lastAccessibilityTelemetry: List<com.androdr.data.model.AccessibilityTelemetry> = emptyList()
+        private set
+    @Volatile var lastReceiverTelemetry: List<com.androdr.data.model.ReceiverTelemetry> = emptyList()
+        private set
+    @Volatile var lastAppOpsTelemetry: List<com.androdr.data.model.AppOpsTelemetry> = emptyList()
+        private set
+
     /**
      * Wall-clock timestamp of the last successful [AppScanner.collectTelemetry]
      * call, used by [analyzeBugReport] to decide whether the cached
@@ -254,6 +268,12 @@ class ScanOrchestrator @Inject constructor(
         val accessibilityTelemetry = accessibilityTelemetryDeferred.await()
         val receiverTelemetry = receiverTelemetryDeferred.await()
         val appOpsTelemetry = appOpsTelemetryDeferred.await()
+        lastDeviceTelemetry = deviceTelemetry
+        lastProcessTelemetry = processTelemetry
+        lastFileArtifactTelemetry = fileTelemetry
+        lastAccessibilityTelemetry = accessibilityTelemetry
+        lastReceiverTelemetry = receiverTelemetry
+        lastAppOpsTelemetry = appOpsTelemetry
 
         // Phase 2: SIGMA rule evaluation — all detection via rules
         _scanProgress.value = ScanProgress.Running(

--- a/app/src/main/java/com/androdr/ui/common/ExportModeDialog.kt
+++ b/app/src/main/java/com/androdr/ui/common/ExportModeDialog.kt
@@ -1,0 +1,73 @@
+package com.androdr.ui.common
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.androdr.reporting.ExportMode
+
+@Composable
+fun ExportModeDialog(
+    onDismiss: () -> Unit,
+    onConfirm: (ExportMode) -> Unit,
+) {
+    var selectedMode by remember { mutableStateOf(ExportMode.BOTH) }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Export report") },
+        text = {
+            Column {
+                ExportMode.values().forEach { mode ->
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .selectable(
+                                selected = selectedMode == mode,
+                                onClick = { selectedMode = mode },
+                            )
+                            .padding(vertical = 8.dp),
+                    ) {
+                        RadioButton(
+                            selected = selectedMode == mode,
+                            onClick = { selectedMode = mode },
+                        )
+                        Spacer(Modifier.width(8.dp))
+                        Text(exportModeLabel(mode))
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = { onConfirm(selectedMode) }) {
+                Text("Export")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("Cancel")
+            }
+        },
+    )
+}
+
+fun exportModeLabel(mode: ExportMode): String = when (mode) {
+    ExportMode.TELEMETRY_ONLY -> "Telemetry only (for analyst handoff)"
+    ExportMode.FINDINGS_ONLY -> "Findings only"
+    ExportMode.BOTH -> "Both (full report)"
+}

--- a/app/src/main/java/com/androdr/ui/history/HistoryScreen.kt
+++ b/app/src/main/java/com/androdr/ui/history/HistoryScreen.kt
@@ -70,6 +70,7 @@ import com.androdr.R
 import com.androdr.data.model.ScanResult
 import com.androdr.reporting.ExportMode
 import com.androdr.scanner.ScanOrchestrator
+import com.androdr.ui.common.ExportModeDialog
 import com.androdr.ui.common.severityColor
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -542,56 +543,7 @@ private fun ScanHistoryItem(
     }
 }
 
-@Composable
-private fun ExportModeDialog(
-    onDismiss: () -> Unit,
-    onConfirm: (ExportMode) -> Unit,
-) {
-    var selectedMode by remember { mutableStateOf(ExportMode.BOTH) }
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        title = { Text("Export report") },
-        text = {
-            Column {
-                ExportMode.values().forEach { mode ->
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .selectable(
-                                selected = selectedMode == mode,
-                                onClick = { selectedMode = mode },
-                            )
-                            .padding(vertical = 8.dp),
-                    ) {
-                        RadioButton(
-                            selected = selectedMode == mode,
-                            onClick = { selectedMode = mode },
-                        )
-                        Spacer(Modifier.width(8.dp))
-                        Text(exportModeLabel(mode))
-                    }
-                }
-            }
-        },
-        confirmButton = {
-            TextButton(onClick = { onConfirm(selectedMode) }) {
-                Text("Export")
-            }
-        },
-        dismissButton = {
-            TextButton(onClick = onDismiss) {
-                Text("Cancel")
-            }
-        },
-    )
-}
-
-private fun exportModeLabel(mode: ExportMode): String = when (mode) {
-    ExportMode.TELEMETRY_ONLY -> "Telemetry only (for analyst handoff)"
-    ExportMode.FINDINGS_ONLY -> "Findings only"
-    ExportMode.BOTH -> "Both (full report)"
-}
+// ExportModeDialog extracted to com.androdr.ui.common.ExportModeDialog
 
 @Suppress("LongMethod") // DiffSection renders new/resolved findings with conditional
 // sub-sections; all branches are needed in one composable to maintain visual cohesion.

--- a/app/src/main/java/com/androdr/ui/timeline/TimelineScreen.kt
+++ b/app/src/main/java/com/androdr/ui/timeline/TimelineScreen.kt
@@ -114,6 +114,7 @@ fun TimelineScreen(
 
     var filterPanelExpanded by rememberSaveable { mutableStateOf(true) }
     var exportMenuExpanded by remember { mutableStateOf(false) }
+    var showExportModeDialog by remember { mutableStateOf(false) }
     var pendingCopy by remember { mutableStateOf(false) }
 
     // Copy to clipboard once report text is ready
@@ -202,6 +203,13 @@ fun TimelineScreen(
                                 onClick = {
                                     exportMenuExpanded = false
                                     viewModel.exportCsv()
+                                }
+                            )
+                            DropdownMenuItem(
+                                text = { Text("Full Report\u2026") },
+                                onClick = {
+                                    exportMenuExpanded = false
+                                    showExportModeDialog = true
                                 }
                             )
                         }
@@ -594,6 +602,17 @@ fun TimelineScreen(
                     putExtra(Intent.EXTRA_SUBJECT, "AndroDR Forensic Timeline")
                 }
                 context.startActivity(Intent.createChooser(intent, "Share Timeline"))
+            }
+        )
+    }
+
+    // Full Report export mode dialog (telemetry/findings/both)
+    if (showExportModeDialog) {
+        com.androdr.ui.common.ExportModeDialog(
+            onDismiss = { showExportModeDialog = false },
+            onConfirm = { mode ->
+                showExportModeDialog = false
+                viewModel.exportFullReport(mode)
             }
         )
     }

--- a/app/src/main/java/com/androdr/ui/timeline/TimelineViewModel.kt
+++ b/app/src/main/java/com/androdr/ui/timeline/TimelineViewModel.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
@@ -52,7 +53,8 @@ class TimelineViewModel @Inject constructor(
     private val dao: ForensicTimelineEventDao,
     private val knownAppResolver: KnownAppResolver,
     private val sigmaRuleEngine: com.androdr.sigma.SigmaRuleEngine,
-    private val scanRepository: ScanRepository
+    private val scanRepository: ScanRepository,
+    private val reportExporter: com.androdr.reporting.ReportExporter,
 ) : ViewModel() {
 
     private val _groupMode = MutableStateFlow(TimelineGroupMode.DATE)
@@ -331,6 +333,27 @@ class TimelineViewModel @Inject constructor(
     }
 
     fun onShareConsumed() { _shareUri.value = null }
+
+    /**
+     * Exports the latest scan as a full report (with telemetry/findings/both
+     * mode). Uses [reportExporter] for the same format as the History screen
+     * export, not the timeline-specific TXT/CSV.
+     */
+    fun exportFullReport(mode: com.androdr.reporting.ExportMode) {
+        viewModelScope.launch {
+            _exporting.value = true
+            try {
+                val scans = scanRepository.allScans.first()
+                val scan = scans.firstOrNull() ?: return@launch
+                val uri = reportExporter.export(scan, mode)
+                _shareUri.value = uri
+            } catch (e: Exception) {
+                android.util.Log.e("TimelineViewModel", "Full report export failed: ${e.message}", e)
+            } finally {
+                _exporting.value = false
+            }
+        }
+    }
 
     private fun buildDisplayNames(events: List<ForensicTimelineEvent>): Map<String, String> {
         val fromEvents = events


### PR DESCRIPTION
## Summary

The report export now includes all 7 telemetry types, not just app hashes + DNS. An analyst receiving a telemetry-only export gets a complete picture of the device state at scan time.

## New TELEMETRY SECTION blocks

- **Device Posture** — ADB, dev options, unknown sources, screen lock, patch level, bootloader, WiFi ADB, unpatched CVE count
- **Accessibility Services** — enabled services with system/non-system flag
- **Broadcast Receivers** — sensitive intent registrations with package + system flag
- **App Operations** — recent camera/mic/location/install-packages usage with timestamps
- **Running Processes** — foreground/background processes
- **File Artifact Checks** — accessible paths checked + inaccessible paths skipped (with reason)

These join the existing DNS Activity and App Hash Inventory sections.

## How it works

`ScanOrchestrator` already cached `lastAppTelemetry`. Now it also caches `lastDeviceTelemetry`, `lastProcessTelemetry`, `lastFileArtifactTelemetry`, `lastAccessibilityTelemetry`, `lastReceiverTelemetry`, `lastAppOpsTelemetry` — all as `@Volatile` fields populated after each scan.

`ReportExporter` reads the caches and passes them to `ReportFormatter`, which renders them in the TELEMETRY SECTION (gated by `mode != FINDINGS_ONLY`).

Cache is in-memory — lost on app restart. Persistent Room-based storage tracked in #96.

## Test plan

- [x] `testDebugUnitTest` pass
- [x] `lintDebug` pass
- [x] `detekt` pass
- [ ] Manual: run scan, export report, verify all 6 new sections appear with real data

🤖 Generated with [Claude Code](https://claude.com/claude-code)