### PR TITLE
feat(build): add sigma-rules submodule + build-time schema cross-check gate

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Full history for git rev-list --count (version number)
+          submodules: true
 
       - name: Set up JDK 21
         uses: actions/setup-java@v4
@@ -112,6 +113,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: true
 
       - name: Set up JDK 21
         uses: actions/setup-java@v4

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "third-party/android-sigma-rules"]
+	path = third-party/android-sigma-rules
+	url = https://github.com/android-sigma-rules/rules.git

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,3 +100,30 @@ for crashes:
 
 AVD: `Medium_Phone_API_36.1` (API 36). Requires `ANDROID_HOME` set.
 Debug package ID: `com.androdr.debug` (applicationIdSuffix = ".debug").
+
+### Submodule: android-sigma-rules
+
+The sigma-rules repo is the authoritative source for the rule schema
+(`rule-schema.json`). It lives at `third-party/android-sigma-rules/` as a
+git submodule.
+
+    # After cloning AndroDR (one-time setup):
+    git submodule update --init
+
+    # When you need to update the submodule to pick up upstream changes:
+    cd third-party/android-sigma-rules && git pull origin main && cd ../..
+    git add third-party/android-sigma-rules
+    git commit -m "build: bump android-sigma-rules submodule"
+
+**Adding a new field or logsource service to `SigmaRuleParser.kt`:**
+
+1. Open a PR in `android-sigma-rules` updating `validation/rule-schema.json`
+2. Merge that PR
+3. In your AndroDR PR: bump the submodule pointer AND make the Kotlin change
+4. `BundledRulesSchemaCrossCheckTest` will fail if the schema and parser disagree
+
+**Submodule update direction (AI pipeline → AndroDR):** The submodule
+pointer stays pinned until explicitly bumped. New rules added upstream by
+`/update-rules` don't affect the build until they're bundled into
+`app/src/main/res/raw/`. Bump the submodule when you need upstream schema
+changes (e.g., after the AI pipeline reveals a schema gap).

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -206,7 +206,7 @@ dependencies {
     testImplementation(libs.mockk)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.org.json) // provides org.json.JSONObject for JVM unit tests
-    testImplementation("com.networknt:json-schema-validator:2.0.1")
+    testImplementation(libs.json.schema.validator)
 
     // Instrumented tests
     androidTestImplementation(libs.androidx.junit)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -206,6 +206,7 @@ dependencies {
     testImplementation(libs.mockk)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.org.json) // provides org.json.JSONObject for JVM unit tests
+    testImplementation("com.networknt:json-schema-validator:2.0.1")
 
     // Instrumented tests
     androidTestImplementation(libs.androidx.junit)

--- a/app/src/test/java/com/androdr/sigma/BundledRulesSchemaCrossCheckTest.kt
+++ b/app/src/test/java/com/androdr/sigma/BundledRulesSchemaCrossCheckTest.kt
@@ -1,0 +1,157 @@
+package com.androdr.sigma
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.networknt.schema.SchemaRegistry
+import com.networknt.schema.SpecificationVersion
+import org.junit.Assume.assumeTrue
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+import org.snakeyaml.engine.v2.api.Load
+import org.snakeyaml.engine.v2.api.LoadSettings
+import java.io.File
+
+/**
+ * Build-time cross-check gate: validates every bundled detection/atom SIGMA rule
+ * against BOTH:
+ * 1. The Kotlin runtime parser (SigmaRuleParser.parse())
+ * 2. The JSON schema from the android-sigma-rules submodule (rule-schema.json)
+ *
+ * If either rejects a rule, the build fails — closing the drift loop between
+ * the dev pipeline and the AI-powered rule updater.
+ *
+ * Correlation rules (sigma_androdr_corr_*.yml) are excluded (deferred to Bundle 3).
+ */
+class BundledRulesSchemaCrossCheckTest {
+
+    private val objectMapper = ObjectMapper()
+
+    private fun rulesDirectory(): File {
+        val candidates = listOf(
+            File("app/src/main/res/raw"),
+            File("src/main/res/raw"),
+            File("/home/yasir/AndroDR/app/src/main/res/raw"),
+        )
+        return candidates.firstOrNull { it.isDirectory }
+            ?: error(
+                "Could not locate res/raw; tried: ${candidates.map { it.absolutePath }}"
+            )
+    }
+
+    private fun schemaFile(): File? {
+        val candidates = listOf(
+            File("third-party/android-sigma-rules/validation/rule-schema.json"),
+            File("../third-party/android-sigma-rules/validation/rule-schema.json"),
+            File("/home/yasir/AndroDR/third-party/android-sigma-rules/validation/rule-schema.json"),
+        )
+        return candidates.firstOrNull { it.isFile }
+    }
+
+    private fun detectionAndAtomRuleFiles(): List<File> =
+        rulesDirectory().listFiles { f ->
+            f.name.startsWith("sigma_androdr_") &&
+                f.name.endsWith(".yml") &&
+                !f.name.startsWith("sigma_androdr_corr_")
+        }?.sorted() ?: emptyList()
+
+    @Test
+    fun `schema file is reachable from submodule`() {
+        val schema = schemaFile()
+        assertTrue(
+            "rule-schema.json not found. Run: git submodule update --init",
+            schema != null && schema.isFile,
+        )
+    }
+
+    @Test
+    fun `every bundled detection rule is accepted by SigmaRuleParser`() {
+        val ruleFiles = detectionAndAtomRuleFiles()
+
+        assertTrue(
+            "Expected at least 40 detection/atom rule files but found ${ruleFiles.size}. " +
+                "Is the test running from the correct working directory?",
+            ruleFiles.size >= 40,
+        )
+
+        val failures = mutableListOf<String>()
+
+        ruleFiles.forEach { file ->
+            try {
+                val result = SigmaRuleParser.parse(file.readText())
+                if (result == null) {
+                    failures += "${file.name}: SigmaRuleParser.parse() returned null"
+                }
+            } catch (e: Exception) {
+                failures += "${file.name}: SigmaRuleParser.parse() threw ${e::class.simpleName}: ${e.message}"
+            }
+        }
+
+        if (failures.isNotEmpty()) {
+            fail(
+                "Kotlin parser gate FAILED for ${failures.size} rule(s):\n" +
+                    failures.joinToString("\n") { "  - $it" } + "\n\n" +
+                    "Check that the rule contains all required fields (id, category, " +
+                    "logsource, detection) and that category is 'incident' or 'device_posture'."
+            )
+        }
+    }
+
+    @Test
+    fun `every bundled detection rule passes JSON schema validation`() {
+        val schema = schemaFile()
+        assumeTrue(
+            "Skipping: rule-schema.json not found (submodule not initialized). " +
+                "Run: git submodule update --init",
+            schema != null && schema.isFile,
+        )
+
+        val ruleFiles = detectionAndAtomRuleFiles()
+
+        assertTrue(
+            "Expected at least 40 detection/atom rule files but found ${ruleFiles.size}.",
+            ruleFiles.size >= 40,
+        )
+
+        val registry = SchemaRegistry.withDefaultDialect(SpecificationVersion.DRAFT_2020_12)
+        val jsonSchema = schema!!.inputStream().use { registry.getSchema(it) }
+
+        val yamlLoader = Load(
+            LoadSettings.builder()
+                .setMaxAliasesForCollections(10)
+                .setAllowDuplicateKeys(false)
+                .build()
+        )
+        val failures = mutableListOf<String>()
+
+        ruleFiles.forEach { file ->
+            try {
+                @Suppress("UNCHECKED_CAST")
+                val yamlMap = yamlLoader.loadFromString(file.readText()) as? Map<String, Any?>
+                if (yamlMap == null) {
+                    failures += "${file.name}: YAML parsed to null or non-map"
+                    return@forEach
+                }
+
+                val jsonNode: JsonNode = objectMapper.valueToTree(yamlMap)
+                val errors = jsonSchema.validate(jsonNode)
+
+                if (errors.isNotEmpty()) {
+                    val errorSummary = errors.joinToString("; ") { err -> err.message }
+                    failures += "${file.name}: schema violations: $errorSummary"
+                }
+            } catch (e: Exception) {
+                failures += "${file.name}: conversion/validation threw ${e::class.simpleName}: ${e.message}"
+            }
+        }
+
+        if (failures.isNotEmpty()) {
+            fail(
+                "JSON schema gate FAILED for ${failures.size} rule(s):\n" +
+                    failures.joinToString("\n") { "  - $it" } + "\n\n" +
+                    "If you added a new field or service to SigmaRuleParser, update " +
+                    "rule-schema.json in the android-sigma-rules repo and bump the submodule."
+            )
+        }
+    }
+}

--- a/docs/superpowers/plans/2026-04-11-ai-rule-framework-01a-validator-sync.md
+++ b/docs/superpowers/plans/2026-04-11-ai-rule-framework-01a-validator-sync.md
@@ -1,0 +1,642 @@
+# Validator Sync + Build-time Gate — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the drift loop between the dev pipeline and AI-powered rule updater by syncing the validator schema and adding a build-time cross-check gate.
+
+**Architecture:** `android-sigma-rules` is the authoritative schema source, brought into AndroDR via git submodule at `third-party/android-sigma-rules/`. A new Kotlin unit test cross-checks every bundled detection/atom rule against both `SigmaRuleParser.parse()` and the JSON schema using `com.networknt:json-schema-validator:2.0.1`. The build fails if they disagree.
+
+**Tech Stack:** Kotlin (JVM unit tests), snakeyaml-engine (existing), com.networknt:json-schema-validator + Jackson (new test deps), Python (validate-rule.py — unchanged logic), git submodules.
+
+**Spec:** `docs/superpowers/specs/2026-04-11-validator-sync-and-build-time-gate.md`  
+**Tracking issue:** #105  
+
+---
+
+## File Map
+
+### `android-sigma-rules` repo (upstream)
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Modify | `validation/rule-schema.json` | Add `category` required, expand service enum, add optional fields |
+| Modify | `validation/validate-rule.py` | Sync `valid_services` whitelist (line 63) |
+
+### `AndroDR` repo (main app)
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Create | `.gitmodules` | Register submodule |
+| Create | `third-party/android-sigma-rules/` | Submodule checkout (pinned SHA) |
+| Modify | `app/build.gradle.kts` | Add `testImplementation` for json-schema-validator |
+| Create | `app/src/test/java/com/androdr/sigma/BundledRulesSchemaCrossCheckTest.kt` | Build-time cross-check gate |
+| Modify | `.github/workflows/android-build.yml` | Add submodule init step |
+| Modify | `CLAUDE.md` | Document submodule workflow |
+
+---
+
+## Task 1: Update `rule-schema.json` in `android-sigma-rules`
+
+**Files:**
+- Modify: `/home/yasir/android-sigma-rules/validation/rule-schema.json`
+
+- [ ] **Step 1: Replace rule-schema.json with the synced version**
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "AndroDR SIGMA Rule",
+  "type": "object",
+  "required": ["title", "id", "status", "description", "logsource", "detection", "level", "tags", "category"],
+  "properties": {
+    "title": { "type": "string", "minLength": 1 },
+    "id": { "type": "string", "pattern": "^androdr-(\\d{3}|atom-[a-z-]+|corr-\\d{3})$" },
+    "status": { "type": "string", "enum": ["experimental", "test", "production"] },
+    "description": { "type": "string" },
+    "author": { "type": "string" },
+    "date": { "type": "string" },
+    "references": { "type": "array", "items": { "type": "string" } },
+    "category": { "type": "string", "enum": ["incident", "device_posture"] },
+    "enabled": { "type": "boolean" },
+    "report_safe_state": { "type": "boolean" },
+    "logsource": {
+      "type": "object",
+      "required": ["product", "service"],
+      "properties": {
+        "product": { "const": "androdr" },
+        "service": {
+          "type": "string",
+          "enum": [
+            "app_scanner", "device_auditor", "dns_monitor",
+            "process_monitor", "file_scanner",
+            "receiver_audit", "tombstone_parser",
+            "accessibility", "appops", "network_monitor"
+          ]
+        }
+      }
+    },
+    "detection": {
+      "type": "object",
+      "required": ["condition"],
+      "properties": {
+        "condition": { "type": "string", "minLength": 1 }
+      }
+    },
+    "level": { "type": "string", "enum": ["critical", "high", "medium", "low"] },
+    "tags": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "falsepositives": { "type": "array", "items": { "type": "string" } },
+    "remediation": { "type": "array", "items": { "type": "string" } },
+    "display": {
+      "type": "object",
+      "properties": {
+        "category": { "type": "string", "enum": ["app_risk", "device_posture", "network"] },
+        "icon": { "type": "string" },
+        "triggered_title": { "type": "string" },
+        "safe_title": { "type": "string" },
+        "evidence_type": { "type": "string", "enum": ["none", "cve_list", "ioc_match", "permission_cluster"] },
+        "summary_template": { "type": "string" },
+        "guidance": { "type": "string" }
+      }
+    }
+  }
+}
+```
+
+- [ ] **Step 2: Verify the JSON is valid**
+
+Run: `cd /home/yasir/android-sigma-rules && python3 -c "import json; json.load(open('validation/rule-schema.json'))"`
+
+Expected: No output (successful parse).
+
+---
+
+## Task 2: Update `validate-rule.py` in `android-sigma-rules`
+
+**Files:**
+- Modify: `/home/yasir/android-sigma-rules/validation/validate-rule.py` (line 63)
+
+- [ ] **Step 1: Update the `valid_services` set**
+
+Replace line 63:
+```python
+    valid_services = {"app_scanner", "device_auditor", "dns_monitor", "process_monitor", "file_scanner"}
+```
+
+With:
+```python
+    valid_services = {
+        "app_scanner", "device_auditor", "dns_monitor",
+        "process_monitor", "file_scanner",
+        "receiver_audit", "tombstone_parser",
+        "accessibility", "appops", "network_monitor",
+    }
+```
+
+- [ ] **Step 2: Run the validator against all rules in the sigma-rules repo**
+
+Run:
+```bash
+cd /home/yasir/android-sigma-rules
+for dir in app_scanner device_auditor dns_monitor file_scanner process_monitor receiver_audit; do
+  for f in "$dir"/*.yml; do
+    [ -f "$f" ] && python3 validation/validate-rule.py "$f"
+  done
+done
+```
+
+Expected: All files print `PASS: <filename>`.
+
+- [ ] **Step 3: Run the validator against the 5 staging rules (preview for sub-plan 1c)**
+
+Run:
+```bash
+cd /home/yasir/android-sigma-rules
+for f in staging/*/*.yml; do
+  python3 validation/validate-rule.py "$f" 2>&1 || true
+done
+```
+
+Expected: Some will fail on missing `category` field — this is expected and documents what 1c needs to fix. Capture the output for reference.
+
+- [ ] **Step 4: Commit and push**
+
+```bash
+cd /home/yasir/android-sigma-rules
+git add validation/rule-schema.json validation/validate-rule.py
+git commit -m "fix: sync rule-schema.json and validate-rule.py with AndroDR runtime
+
+Add category to required fields (incident | device_posture).
+Expand logsource.service enum to include all 10 telemetry services.
+Add optional fields: enabled, report_safe_state, display.guidance.
+Sync validate-rule.py valid_services whitelist.
+
+Part of yasirhamza/AndroDR#105"
+git push origin main
+```
+
+---
+
+## Task 3: Add git submodule to AndroDR
+
+**Files:**
+- Create: `/home/yasir/AndroDR/.gitmodules`
+- Create: `/home/yasir/AndroDR/third-party/android-sigma-rules/` (submodule)
+
+- [ ] **Step 1: Add the submodule**
+
+Run:
+```bash
+cd /home/yasir/AndroDR
+git submodule add https://github.com/android-sigma-rules/rules.git third-party/android-sigma-rules
+```
+
+Expected: Creates `.gitmodules` and clones the repo into `third-party/android-sigma-rules/`.
+
+- [ ] **Step 2: Verify the submodule contains the updated schema**
+
+Run:
+```bash
+grep '"category"' third-party/android-sigma-rules/validation/rule-schema.json | head -1
+```
+
+Expected: Shows the `"category"` property line from the updated schema. If it shows the OLD schema (without category in required), the submodule needs to be updated to the latest commit:
+```bash
+cd third-party/android-sigma-rules && git pull origin main && cd ../..
+```
+
+- [ ] **Step 3: Commit the submodule addition**
+
+```bash
+cd /home/yasir/AndroDR
+git add .gitmodules third-party/android-sigma-rules
+git commit -m "build: add android-sigma-rules as git submodule at third-party/
+
+Establishes the sigma-rules repo as the authoritative schema source.
+The build-time cross-check test (next commit) reads rule-schema.json
+from this submodule to validate bundled rules.
+
+Part of #105"
+```
+
+---
+
+## Task 4: Add json-schema-validator test dependency
+
+**Files:**
+- Modify: `/home/yasir/AndroDR/app/build.gradle.kts` (dependencies block)
+
+- [ ] **Step 1: Add the dependency**
+
+Add after the existing `testImplementation(libs.org.json)` line (around line 208):
+
+```kotlin
+    testImplementation("com.networknt:json-schema-validator:2.0.1")
+```
+
+- [ ] **Step 2: Verify Gradle resolves the dependency**
+
+Run:
+```bash
+cd /home/yasir/AndroDR
+./gradlew app:dependencies --configuration testDebugRuntimeClasspath 2>&1 | grep networknt
+```
+
+Expected: Shows `com.networknt:json-schema-validator:2.0.1` in the dependency tree.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /home/yasir/AndroDR
+git add app/build.gradle.kts
+git commit -m "build: add json-schema-validator test dependency for cross-check gate
+
+com.networknt:json-schema-validator:2.0.1 (pure JVM, JSON Schema draft
+2020-12). Used by BundledRulesSchemaCrossCheckTest to validate bundled
+rules against rule-schema.json from the submodule. Test-only scope —
+Jackson transitive dep does not affect production classpath.
+
+Part of #105"
+```
+
+---
+
+## Task 5: Write `BundledRulesSchemaCrossCheckTest.kt`
+
+**Files:**
+- Create: `/home/yasir/AndroDR/app/src/test/java/com/androdr/sigma/BundledRulesSchemaCrossCheckTest.kt`
+
+- [ ] **Step 1: Write the complete test class**
+
+```kotlin
+package com.androdr.sigma
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.networknt.schema.JsonSchemaFactory
+import com.networknt.schema.SpecVersion
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Assume.assumeTrue
+import org.junit.Test
+import org.snakeyaml.engine.v2.api.Load
+import org.snakeyaml.engine.v2.api.LoadSettings
+import java.io.File
+
+/**
+ * Build-time cross-check gate: every bundled detection/atom rule must pass
+ * BOTH the Kotlin runtime parser (SigmaRuleParser.parse()) AND the JSON
+ * schema from the android-sigma-rules submodule (rule-schema.json).
+ *
+ * If these two validators disagree on any rule, the build fails — surfacing
+ * drift between the dev pipeline and the AI-powered rule updater before it
+ * reaches production.
+ *
+ * Correlation rules (sigma_androdr_corr_*.yml) are excluded — they have a
+ * different structure and are validated only by SigmaRuleParser.parseCorrelation().
+ */
+class BundledRulesSchemaCrossCheckTest {
+
+    private val objectMapper = ObjectMapper()
+
+    private val yamlSettings = LoadSettings.builder()
+        .setMaxAliasesForCollections(10)
+        .setAllowDuplicateKeys(false)
+        .build()
+
+    /**
+     * Locate rule-schema.json from the submodule. Tries multiple paths to
+     * work regardless of which directory Gradle invokes the test from.
+     */
+    private fun schemaFile(): File {
+        val candidates = listOf(
+            File("third-party/android-sigma-rules/validation/rule-schema.json"),
+            File("../third-party/android-sigma-rules/validation/rule-schema.json"),
+            File("/home/yasir/AndroDR/third-party/android-sigma-rules/validation/rule-schema.json"),
+        )
+        return candidates.firstOrNull { it.exists() }
+            ?: error(
+                "rule-schema.json not found. Run: git submodule update --init\n" +
+                "Tried: ${candidates.map { it.absolutePath }}"
+            )
+    }
+
+    /**
+     * Locate the res/raw directory containing bundled rules.
+     */
+    private fun rulesDirectory(): File {
+        val candidates = listOf(
+            File("app/src/main/res/raw"),
+            File("src/main/res/raw"),
+            File("/home/yasir/AndroDR/app/src/main/res/raw"),
+        )
+        return candidates.firstOrNull { it.isDirectory }
+            ?: error(
+                "Could not locate res/raw; tried: ${candidates.map { it.absolutePath }}"
+            )
+    }
+
+    /**
+     * All detection and atom rule files — everything EXCEPT correlation rules.
+     * This includes sigma_androdr_atom_*.yml (atoms are structurally identical
+     * to detection rules and parsed by SigmaRuleParser.parse()).
+     */
+    private fun detectionAndAtomRuleFiles(): List<File> =
+        rulesDirectory().listFiles { f ->
+            f.name.startsWith("sigma_androdr_") &&
+                f.name.endsWith(".yml") &&
+                !f.name.startsWith("sigma_androdr_corr_")
+        }?.sorted() ?: emptyList()
+
+    /**
+     * Convert a YAML string to a Jackson JsonNode for schema validation.
+     * YAML pipe-keys like "field|endswith" become literal JSON object keys —
+     * snakeyaml-engine parses them as plain strings, no special handling needed.
+     */
+    private fun yamlToJsonNode(yaml: String): JsonNode {
+        val load = Load(yamlSettings)
+        val parsed = load.loadFromString(yaml)
+        return objectMapper.valueToTree(parsed)
+    }
+
+    @Test
+    fun `schema file is reachable from submodule`() {
+        val schema = schemaFile()
+        assertTrue(
+            "rule-schema.json must exist at submodule path. " +
+                "Run: git submodule update --init",
+            schema.exists()
+        )
+    }
+
+    @Test
+    fun `every bundled detection rule is accepted by SigmaRuleParser`() {
+        val ruleFiles = detectionAndAtomRuleFiles()
+
+        assertTrue(
+            "Expected at least 40 detection/atom rule files; found ${ruleFiles.size}. " +
+                "Is the test running from the app module root?",
+            ruleFiles.size >= 40
+        )
+
+        val failures = mutableListOf<String>()
+
+        ruleFiles.forEach { file ->
+            try {
+                val result = SigmaRuleParser.parse(file.readText())
+                if (result == null) {
+                    failures += "${file.name}: SigmaRuleParser.parse() returned null"
+                }
+            } catch (e: SigmaRuleParseException) {
+                failures += "${file.name}: SigmaRuleParseException — ${e.message}"
+            } catch (e: Exception) {
+                failures += "${file.name}: ${e.javaClass.simpleName} — ${e.message}"
+            }
+        }
+
+        if (failures.isNotEmpty()) {
+            fail(
+                "Kotlin parser rejected ${failures.size} rule(s):\n" +
+                    failures.joinToString("\n") { "  - $it" } + "\n\n" +
+                    "Fix the rule YAML or update SigmaRuleParser to accept it."
+            )
+        }
+    }
+
+    @Test
+    fun `every bundled detection rule passes JSON schema validation`() {
+        // Skip if submodule not initialized (avoid cryptic failures in local dev)
+        val schemaPath = try { schemaFile() } catch (e: Exception) {
+            assumeTrue("Skipping: submodule not initialized", false)
+            return
+        }
+
+        val schemaFactory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V202012)
+        val schema = schemaFactory.getSchema(schemaPath.toURI())
+
+        val ruleFiles = detectionAndAtomRuleFiles()
+
+        assertTrue(
+            "Expected at least 40 detection/atom rule files; found ${ruleFiles.size}.",
+            ruleFiles.size >= 40
+        )
+
+        val failures = mutableListOf<String>()
+
+        ruleFiles.forEach { file ->
+            try {
+                val jsonNode = yamlToJsonNode(file.readText())
+                val errors = schema.validate(jsonNode)
+                if (errors.isNotEmpty()) {
+                    val errorMessages = errors.joinToString("; ") { it.message }
+                    failures += "${file.name}: $errorMessages"
+                }
+            } catch (e: Exception) {
+                failures += "${file.name}: ${e.javaClass.simpleName} — ${e.message}"
+            }
+        }
+
+        if (failures.isNotEmpty()) {
+            fail(
+                "JSON schema rejected ${failures.size} rule(s):\n" +
+                    failures.joinToString("\n") { "  - $it" } + "\n\n" +
+                    "If you added a new field or service to SigmaRuleParser, " +
+                    "update rule-schema.json in the android-sigma-rules repo " +
+                    "and bump the submodule."
+            )
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they pass**
+
+Run:
+```bash
+cd /home/yasir/AndroDR
+./gradlew testDebugUnitTest --tests "com.androdr.sigma.BundledRulesSchemaCrossCheckTest" --stacktrace
+```
+
+Expected: All 3 tests PASS. If any fail, check:
+- Submodule schema has `category` in required → submodule at latest commit?
+- All 44 bundled rules have `category:` at top level → they already do per `AllRulesHaveCategoryTest`
+- Jackson/snakeyaml classpath issue → check Gradle dependency tree
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /home/yasir/AndroDR
+git add app/src/test/java/com/androdr/sigma/BundledRulesSchemaCrossCheckTest.kt
+git commit -m "test: add build-time schema cross-check gate for bundled rules
+
+BundledRulesSchemaCrossCheckTest validates every detection/atom rule
+against both SigmaRuleParser.parse() (Kotlin runtime) and rule-schema.json
+(JSON Schema from the android-sigma-rules submodule). Build fails if
+they disagree — closing the drift loop between the dev pipeline and
+the AI-powered rule updater.
+
+Uses com.networknt:json-schema-validator for JSON Schema draft 2020-12
+validation. Correlation rules are excluded (deferred to Bundle 3).
+
+Part of #105"
+```
+
+---
+
+## Task 6: Update CI workflow
+
+**Files:**
+- Modify: `/home/yasir/AndroDR/.github/workflows/android-build.yml`
+
+- [ ] **Step 1: Add submodule initialization to the `build` job**
+
+After the existing `actions/checkout@v4` step (line 17-19), add:
+
+```yaml
+      - name: Initialize submodules
+        run: git submodule update --init --recursive
+```
+
+- [ ] **Step 2: Add submodule initialization to the `instrumented-test` job**
+
+After the existing `actions/checkout@v4` step in the `instrumented-test` job (line 114), add:
+
+```yaml
+      - name: Initialize submodules
+        run: git submodule update --init --recursive
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /home/yasir/AndroDR
+git add .github/workflows/android-build.yml
+git commit -m "ci: initialize submodules before build and instrumented tests
+
+Required for BundledRulesSchemaCrossCheckTest to find rule-schema.json
+from the android-sigma-rules submodule at third-party/.
+
+Part of #105"
+```
+
+---
+
+## Task 7: Update CLAUDE.md with submodule workflow
+
+**Files:**
+- Modify: `/home/yasir/AndroDR/CLAUDE.md`
+
+- [ ] **Step 1: Add submodule section after the "Local development" section**
+
+Add the following after the `### Smoke test (local emulator)` section at the end of CLAUDE.md:
+
+```markdown
+### Submodule: android-sigma-rules
+
+The sigma-rules repo is the authoritative source for the rule schema
+(`rule-schema.json`). It lives at `third-party/android-sigma-rules/` as a
+git submodule.
+
+    # After cloning AndroDR (one-time setup):
+    git submodule update --init
+
+    # When you need to update the submodule to pick up upstream changes:
+    cd third-party/android-sigma-rules && git pull origin main && cd ../..
+    git add third-party/android-sigma-rules
+    git commit -m "build: bump android-sigma-rules submodule"
+
+**Adding a new field or logsource service to `SigmaRuleParser.kt`:**
+
+1. Open a PR in `android-sigma-rules` updating `validation/rule-schema.json`
+2. Merge that PR
+3. In your AndroDR PR: bump the submodule pointer AND make the Kotlin change
+4. `BundledRulesSchemaCrossCheckTest` will fail if the schema and parser disagree
+
+**Submodule update direction (AI pipeline → AndroDR):** The submodule
+pointer stays pinned until explicitly bumped. New rules added upstream by
+`/update-rules` don't affect the build until they're bundled into
+`app/src/main/res/raw/`. Bump the submodule when you need upstream schema
+changes (e.g., after the AI pipeline reveals a schema gap).
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+cd /home/yasir/AndroDR
+git add CLAUDE.md
+git commit -m "docs: add submodule workflow section to CLAUDE.md
+
+Documents the two-PR dance for schema changes, one-time setup,
+and submodule update direction.
+
+Part of #105"
+```
+
+---
+
+## Task 8: Final verification and PR
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Run the full test suite to confirm nothing broke**
+
+Run:
+```bash
+cd /home/yasir/AndroDR
+./gradlew testDebugUnitTest --stacktrace
+```
+
+Expected: All tests pass, including the new `BundledRulesSchemaCrossCheckTest` (3 tests) alongside all existing tests.
+
+- [ ] **Step 2: Run lint to confirm no warnings**
+
+Run:
+```bash
+cd /home/yasir/AndroDR
+./gradlew lintDebug --stacktrace
+```
+
+Expected: Clean (no new warnings).
+
+- [ ] **Step 3: Verify the drift-prevention guarantee (intentional break test)**
+
+Temporarily remove `category:` from one bundled rule to confirm the gate catches it:
+
+```bash
+cd /home/yasir/AndroDR
+# Backup
+cp app/src/main/res/raw/sigma_androdr_005_graphite_paragon.yml /tmp/sigma_005_backup.yml
+# Remove category line
+sed -i '/^category:/d' app/src/main/res/raw/sigma_androdr_005_graphite_paragon.yml
+# Run test — should FAIL
+./gradlew testDebugUnitTest --tests "com.androdr.sigma.BundledRulesSchemaCrossCheckTest" 2>&1 | tail -20
+# Restore
+cp /tmp/sigma_005_backup.yml app/src/main/res/raw/sigma_androdr_005_graphite_paragon.yml
+```
+
+Expected: Test fails with `SigmaRuleParseException — Rule androdr-005 is missing required 'category' field`. This proves the gate works.
+
+- [ ] **Step 4: Push and open PR**
+
+```bash
+cd /home/yasir/AndroDR
+git push origin HEAD
+```
+
+Open PR with title: `feat(build): add sigma-rules submodule + build-time schema cross-check gate`
+
+Body must include: `Closes #105`
+
+---
+
+## Verification Checklist (post-merge)
+
+After both PRs merge (sigma-rules first, then AndroDR):
+
+- [ ] `./gradlew testDebugUnitTest` passes with all 44 detection/atom rules validated
+- [ ] CI passes with submodule initialized automatically
+- [ ] `python validate-rule.py <any-bundled-rule.yml>` passes in the sigma-rules repo
+- [ ] Intentional breakage (remove category) is caught by the gate
+- [ ] CLAUDE.md documents the developer workflow

--- a/docs/superpowers/plans/2026-04-11-ai-rule-framework-audit-meta-plan.md
+++ b/docs/superpowers/plans/2026-04-11-ai-rule-framework-audit-meta-plan.md
@@ -1,0 +1,213 @@
+# AI-Powered Rule Update Framework — Audit Remediation Meta Plan
+
+**Tracking issue (epic):** #104
+**Source audit:** in-session audit 2026-04-11
+**Branch:** TBD (new branch off `claude/android-edr-setup-rl68Y`)
+**Merge model:** Per-sub-plan PR, not atomic. Bundle 1's three sub-plans form a dependency chain but each merges independently so the build-time gate lands early and starts catching drift immediately. Every PR references its sub-plan issue via `Closes #N`; the epic (#104) is closed manually once all five sub-plan issues resolve.
+
+---
+
+## Purpose of this document
+
+An audit of the AI-powered SIGMA rule update framework on 2026-04-11 surfaced 11 concrete findings. The root cause of most of them is a structural gap: **two independent write paths modify rules** — the dev pipeline (human PRs) and the AI pipeline (`/update-rules`) — and only the AI pipeline enforces schema discipline. The dev pipeline has already drifted the validator out of sync with runtime requirements (missing `category` field, stale logsource whitelist, no correlation rule support, staging ID collision).
+
+This meta-plan organizes remediation into **three bundles comprising five sub-plans**, ordered so:
+1. The drift loop closes first (structural fix, not procedural)
+2. The pipeline is proven to work end-to-end with at least one real AI-generated rule promoted
+3. Author quality improves on top of a now-trustworthy pipeline
+4. Operational hardening automates the whole thing
+
+**Execution model:** For each sub-plan — brainstorm (if flagged) → write spec → user approves → write plan → execute via `subagent-driven-development` → two-reviewer cycle → merge. Each sub-plan's plan is written against the actual codebase state after the previous sub-plan merges, not against assumptions.
+
+---
+
+## Context — findings from the audit
+
+Numbered per the original audit report (reproduced here for self-containment):
+
+1. **F1** — Gate 4 (Dry-Run Evaluation) has no programmatic test harness
+2. **F2** — Pipeline has never successfully promoted an AI-generated rule end-to-end; 5 staging rules sit untouched
+3. **F3** — IOC data `source` field is mandatory per spec but unenforced
+4. **F4** — `feed-state.json` cursor schema inconsistent across ingesters; NVD cursor is `null`
+5. **F5** — No scheduled automation; feed state 9 days stale
+6. **F6** — Decision manifest from Rule Author has no JSON schema
+7. **F7** — Threat researcher could hallucinate IOCs with no cross-source verification
+8. **F8** — Bundled correlation rules have no integration tests
+9. **F9** — Rule Author has no logsource field taxonomy reference
+10. **F10** — No build-time check that bundled rules parse and conform to schema
+11. **F11** — IOC source enum not validated in `merge-ioc-data.py`
+
+**Discovered during scoping (not in original audit):**
+- **Validator is stale** — `rule-schema.json` missing required top-level `category`; `valid_services` whitelist missing `receiver_audit`, `tombstone_parser`, `accessibility`, `appops`, `network_monitor`; no support for correlation rule type
+- **Staging rule ID collision** — `androdr-071` is taken in production (`crash_loop_anti_forensics`) but also claimed by staging rule `popular_app_impersonation`
+- **Root cause (per user on 2026-04-11):** dev pipeline has no build-time enforcement that rule changes keep schema + validator in sync, so drift is structural not procedural
+
+---
+
+## Bundle inventory
+
+| Bundle | Sub-plans | Approach | Why |
+|---|---|---|---|
+| 1. Close drift loop + prove pipeline works | 1a, 1b, 1c | **Brainstorm first** for 1a and 1b; 1c direct to plan | Multiple design decisions; highest leverage |
+| 2. Author quality | 2 | **Brainstorm first** | Judgment calls on confidence thresholds and taxonomy shape |
+| 3. Framework hardening | 3 | **Partial brainstorm** (F5 only) | F4/F6/F8 mechanical; F5 needs automation cadence decisions |
+
+## Sub-plan inventory
+
+| # | Issue | Sub-plan file | Status | Approach | Goal |
+|---|---|---|---|---|---|
+| 1a | #105 | `2026-04-11-ai-rule-framework-01a-validator-sync.md` | Pending | Brainstorm → spec → plan | Sync `rule-schema.json` + `validate-rule.py` with runtime; add build-time Gradle gate parsing every bundled rule + validating against schema. **Closes the drift loop permanently.** |
+| 1b | #106 | `2026-04-11-ai-rule-framework-01b-gate4-ioc-source.md` | Pending | Brainstorm → spec → plan | Build programmatic Gate 4 test harness callable by validator skill; enforce IOC `source` field validation in `merge-ioc-data.py` |
+| 1c | #107 | `2026-04-11-ai-rule-framework-01c-staging-rerun-and-proof.md` | Pending | Direct to plan | Re-run 5 staging rules through updated validator; decide promote/renumber/reject per rule; run `/update-rules source stalkerware` end-to-end; promote at least one AI-generated rule to production |
+| 2 | #108 | `2026-04-11-ai-rule-framework-02-author-quality.md` | Pending | Brainstorm → spec → plan | Threat researcher IOC confidence filtering (F7); logsource field taxonomy as Rule Author input (F9) |
+| 3 | #109 | `2026-04-11-ai-rule-framework-03-hardening.md` | Pending | F5 brainstorm → partial spec → plan; F4/F6/F8 direct | Cursor schema standardization (F4); scheduled GitHub Actions automation (F5); decision manifest JSON schema (F6); correlation rule integration tests (F8) |
+
+**Total estimated work:** 5 sub-plans; mix of mechanical and design-heavy work.
+
+---
+
+## Per-sub-plan entry/exit contracts
+
+### Sub-plan 1a — Validator Sync and Build-time Gate
+
+**Entry state:** main branch current. `android-sigma-rules/validation/rule-schema.json` missing `category` in required fields. `validate-rule.py:63` whitelist is `{app_scanner, device_auditor, dns_monitor, process_monitor, file_scanner}` (stale). No build-time rule validation in Gradle. Staging rules untouched.
+
+**Exit state:**
+- `rule-schema.json` updated: top-level `category` added to required fields with enum matching `RuleCategory` values
+- `valid_services` whitelist in `validate-rule.py` synced with actual telemetry model classes — add `receiver_audit`, `tombstone_parser`, `accessibility`, `appops`, `network_monitor`
+- Validator recognizes correlation rule type (`selection_atoms`, `timespan`, `ordered`, `group_by`) and skips fields that don't apply
+- New Gradle task `validateBundledRules` runs on every build; parses all `sigma_androdr_*.yml` via `SigmaRuleParser` AND invokes `validate-rule.py` if Python is on PATH; fails build on any violation
+- Task wired into `check` task so CI catches drift automatically
+- All 48 current bundled rules pass the new gate
+- New `AllBundledRulesPassValidatorTest.kt` enforces the gate in unit tests as well (redundancy for defense in depth)
+
+**What 1b can assume:** Validator is trustworthy; schema matches runtime; build fails on drift; both write paths are structurally synced.
+
+---
+
+### Sub-plan 1b — Gate 4 Harness and IOC Source Validation
+
+**Entry state:** end of 1a. Gate 4 is documented but has no programmatic harness; `update-rules-validate` skill instructs reviewers to hand-trace or write throwaway tests. `merge-ioc-data.py` does not validate `source` field against allowed enum.
+
+**Exit state:**
+- New `GateFourTestHarness.kt` in `app/src/test/` with a simple API: `runGate4(rule: SigmaRule, truePositives: List<TelemetrySample>, trueNegatives: List<TelemetrySample>): Gate4Result`
+- `update-rules-validate` skill updated to describe inputs to the harness instead of hand-tracing
+- At least 3 representative synthetic fixtures checked in: simple selection, `ioc_lookup`, correlation atom
+- `merge-ioc-data.py` validates `source` field against enum (`stalkerware-indicators`, `malwarebazaar`, `threatfox`, `amnesty-investigations`, `citizenlab-indicators`, `mvt-indicators`, `virustotal`, `android-security-bulletin`); rejects entries with missing or unknown source; exits non-zero with a clear error
+- `validate-rule.py` gains a companion function for IOC data files so the skill can invoke validation either on a rule or an IOC file
+
+**What 1c can assume:** Gate 4 can be run programmatically; IOC merges can't accept polluted data; validator gives trustworthy answers across all 5 gates.
+
+---
+
+### Sub-plan 1c — Staging Rerun and End-to-End Proof
+
+**Entry state:** end of 1b. Validator and gates are trustworthy. 5 staging rules still sit in `android-sigma-rules/staging/`. No AI-generated rule has ever been promoted through the full pipeline.
+
+**Exit state:**
+- All 5 staging rules re-validated against updated framework; per-rule decision recorded in a decision log committed to the repo:
+  - **androdr-069** (overlay permission) — decision TBD (likely reject as single-permission-too-broad, preserve intel as correlation atom)
+  - **androdr-070** (DDNS C2) — decision TBD (likely migrate domain list to `ioc-data/domains.yml`, promote rule as `domain|ioc_lookup` form consistent with rule 005)
+  - **androdr-051** (Cellebrite CVEs) — decision TBD (likely promote as-is after adding top-level `category`)
+  - **androdr-066** (boot persistence) — decision TBD (likely reject or demote to low + strengthen with correlation)
+  - **androdr-071** (fake popular app) — MUST renumber (ID collision with production); decision TBD (likely migrate prefix list to IOC data)
+- Any rules promoted get top-level `category` added and pass the new Gradle gate
+- `/update-rules source stalkerware` run end-to-end with real feed state; produces at least one new candidate rule that passes all 5 gates including the new Gate 4 harness
+- At least one candidate promoted to `app/src/main/res/raw/`, committed via the pipeline's decision output
+- `feed-state.json` updated with correct cursor from the run
+- Release notes entry: "First AI-generated SIGMA rule promoted via end-to-end pipeline"
+
+**What Bundle 2 can assume:** Pipeline actually works; drift is closed; at least one AI-generated rule is in production; we have empirical signal on what the Rule Author currently produces.
+
+---
+
+### Sub-plan 2 — Author Quality
+
+**Entry state:** end of 1c. Pipeline works but empirical output from 1c may reveal weak rules — thin evidence, missing telemetry fields, hallucinated IOCs.
+
+**Exit state:**
+- `update-rules-research-threat` skill enforces "2 sources or 1 structured source" rule; single-source IOCs marked `requires_verification` and routed to manual review
+- Logsource field taxonomy documented (shape decided during brainstorming — markdown reference, embedded in skill, or auto-generated from `toFieldMap()` implementations)
+- Rule Author skill consumes taxonomy; decision manifest includes `telemetry_gap` decision type for out-of-taxonomy fields
+- Re-run from 1c repeated against the same threat; output measurably improved (more specific field matchers, fewer weak single-source rules, fewer ambiguous decisions)
+
+**What Bundle 3 can assume:** Rule Author and researcher produce release-quality output; automation can run unsupervised with reasonable confidence.
+
+---
+
+### Sub-plan 3 — Framework Hardening
+
+**Entry state:** end of 2. Pipeline works, produces good rules, but runs only on manual trigger. Feed state drifts between runs. Correlation rules untested.
+
+**Exit state:**
+- `feed-state.json` migrated to unified cursor schema; each feed has `last_seen_timestamp` + feed-specific secondary keys; NVD cursor initialized
+- New GitHub Actions workflow `.github/workflows/update-rules-scheduled.yml` runs `/update-rules full` weekly; commits output to `android-sigma-rules` repo; opens PR against main for human review; does **not** auto-merge
+- `decisions-schema.json` added to `android-sigma-rules/validation/`; Gate 1 validates decision manifest structure against it
+- `SigmaCorrelationRuleIntegrationTest.kt` added to `app/src/test/`; exercises each bundled correlation rule against synthetic timeline events; verifies expected signals fire; fails build on regression
+- All new hardening work passes the build-time gate from sub-plan 1a
+
+**What's next (out of this meta-plan):** Public rules repo release (Tier 1 project per `project_rule_engine_priority`), coverage metrics, SIGMA-HQ upstream contribution.
+
+---
+
+## Ordering and rationale
+
+**Bundle 1 must be done first and in order.** Without 1a (validator sync + build gate), everything else builds on sand: you can't trust validation results, can't prove the pipeline works, and drift will recur on the next sprint. 1b depends on 1a (you need a trustworthy validator before adding Gate 4 programmatic support). 1c depends on both (you need the full validation stack working before claiming end-to-end proof).
+
+**Bundle 2 must wait for Bundle 1.** Improving author quality is speculation until the pipeline actually works and produces empirical output you can measure. Doing it earlier risks optimizing the wrong things.
+
+**Bundle 3 must wait for Bundle 2.** Automating a pipeline that produces mediocre rules just automates mediocrity. Schedule automation only once rules are release-quality.
+
+**Parallelization:** Inside Bundle 1, 1a → 1b → 1c is a strict chain. Inside Bundle 3, F4 (cursor schema) must precede F5 (automation) because the scheduler reads cursors; F6 (manifest schema) and F8 (correlation tests) are independent and can run in parallel subagent streams.
+
+---
+
+## Open decisions (resolve during Bundle 1 brainstorming)
+
+These affect sub-plan 1a's scope and must be settled before 1a's spec is written:
+
+1. **Build-time gate mechanism.** Kotlin parser, Python validator, or both?
+   *Recommendation:* Kotlin parser is mandatory (lives in main repo build, no extra dependency). Python validator is optional (runs only if Python is on PATH, prints a warning otherwise). This catches the 95% case in Gradle and the remaining 5% in CI where Python is guaranteed.
+
+2. **Where does IOC source validation live?**
+   *Recommendation:* Both — `validate-rule.py` (via a new `validate-ioc-data.py` sibling) for the pipeline's validator skill, and `merge-ioc-data.py` as the last line of defense before disk write.
+
+3. **Gate 4 test harness shape.**
+   *Recommendation:* Standalone Kotlin class in `app/src/test/` with a simple runnable API. No code generation, no YAML fixtures, no separate test-rule DSL. The validator skill describes inputs to the harness and reads structured output.
+
+Decisions deferred to sub-plan 1c spec writing (don't affect 1a):
+
+4. **androdr-071 ID collision** — renumber staging or production?
+   *Recommendation:* Renumber the staging rule (production already shipped).
+
+5. **Low-value staging rules (069, 066).** Promote, strengthen, or reject?
+   *Recommendation:* Reject both; preserve intel as correlation atoms or IOC data.
+
+6. **Bundle 1 "done" definition** — one rule promoted or all 5 resolved?
+   *Recommendation:* The narrower one — one promoted end-to-end. The 5 staging rules are evaluated as a side effect but not blockers.
+
+---
+
+## Out of scope
+
+Explicitly **not** in this meta-plan:
+- Removing remaining hardcoded patterns from detection code (already done in PR #81)
+- Wiring `evaluateDns()` into VPN/scan pipeline (separate project per `project_dns_eval_wiring` memory)
+- Authoring new detection rules beyond what the 1c end-to-end run produces
+- Publishing the rules repo as a standalone public project (separate Tier 1 project per `project_rule_engine_priority` memory)
+- Migrating the AI pipeline skills to a shared plugin repo
+- UAT on any of the above (existing UAT framework can be invoked separately via `uat-test` skill)
+
+---
+
+## Next step
+
+**Start Bundle 1 with brainstorming for sub-plan 1a.** Invoke `superpowers:brainstorming` with the goal: *"Design sub-plan 1a: sync the validator with runtime schema and add a build-time gate that prevents future drift between the dev pipeline and the AI-powered rule updater."*
+
+The brainstorm should:
+1. Resolve open decisions 1, 2, 3 above
+2. Produce a spec at `docs/superpowers/specs/2026-04-11-validator-sync-and-build-time-gate.md`
+
+Then `superpowers:writing-plans` produces `docs/superpowers/plans/2026-04-11-ai-rule-framework-01a-validator-sync.md`. Then `superpowers:subagent-driven-development` executes. Then two-reviewer cycle. Then merge.
+
+Sub-plans 1b, 1c, 2, 3 follow the same loop. Sub-plan 3 skips brainstorming for F4/F6/F8 and goes direct to plan writing, then brainstorms only F5.

--- a/docs/superpowers/plans/2026-04-11-ai-rule-framework-audit-meta-plan.md
+++ b/docs/superpowers/plans/2026-04-11-ai-rule-framework-audit-meta-plan.md
@@ -73,15 +73,16 @@ Numbered per the original audit report (reproduced here for self-containment):
 **Entry state:** main branch current. `android-sigma-rules/validation/rule-schema.json` missing `category` in required fields. `validate-rule.py:63` whitelist is `{app_scanner, device_auditor, dns_monitor, process_monitor, file_scanner}` (stale). No build-time rule validation in Gradle. Staging rules untouched.
 
 **Exit state:**
-- `rule-schema.json` updated: top-level `category` added to required fields with enum matching `RuleCategory` values
+- `android-sigma-rules` added to AndroDR as a git submodule at `third-party/android-sigma-rules/`
+- `rule-schema.json` updated: top-level `category` added to required fields with enum matching `RuleCategory` values; `additionalProperties` left permissive (true)
 - `valid_services` whitelist in `validate-rule.py` synced with actual telemetry model classes — add `receiver_audit`, `tombstone_parser`, `accessibility`, `appops`, `network_monitor`
-- Validator recognizes correlation rule type (`selection_atoms`, `timespan`, `ordered`, `group_by`) and skips fields that don't apply
-- New Gradle task `validateBundledRules` runs on every build; parses all `sigma_androdr_*.yml` via `SigmaRuleParser` AND invokes `validate-rule.py` if Python is on PATH; fails build on any violation
-- Task wired into `check` task so CI catches drift automatically
-- All 48 current bundled rules pass the new gate
-- New `AllBundledRulesPassValidatorTest.kt` enforces the gate in unit tests as well (redundancy for defense in depth)
+- Correlation rule schema support deferred to Bundle 3 (#109) — only detection/atom rules are cross-checked
+- New `BundledRulesSchemaCrossCheckTest.kt` unit test validates all 44 detection/atom rules against both `SigmaRuleParser.parse()` (Kotlin runtime) AND the JSON schema from the submodule (via `com.networknt:json-schema-validator:2.0.1`); fails build on any disagreement
+- CI workflow updated with `git submodule update --init`
+- All 44 current detection/atom bundled rules pass the new gate
+- Developer workflow documented in CLAUDE.md (submodule init, two-PR dance for schema changes)
 
-**What 1b can assume:** Validator is trustworthy; schema matches runtime; build fails on drift; both write paths are structurally synced.
+**What 1b can assume:** Validator is trustworthy; schema matches runtime; build fails on drift; both write paths are structurally synced via the submodule.
 
 ---
 

--- a/docs/superpowers/specs/2026-04-11-validator-sync-and-build-time-gate.md
+++ b/docs/superpowers/specs/2026-04-11-validator-sync-and-build-time-gate.md
@@ -1,0 +1,377 @@
+# Sub-plan 1a Spec: Validator Sync + Build-time Gate
+
+**Tracking issue:** #105  
+**Parent epic:** #104  
+**Meta-plan:** `docs/superpowers/plans/2026-04-11-ai-rule-framework-audit-meta-plan.md`  
+**Depends on:** nothing (starting point)  
+**Unblocks:** #106 (Gate 4 harness + IOC source validation), #107 (staging rerun + end-to-end proof)
+
+---
+
+## Problem
+
+AndroDR rules are modified by two independent write paths:
+
+1. **Dev pipeline** — human PRs edit bundled rules and the Kotlin parser in `AndroDR/`
+2. **AI pipeline** — `/update-rules` generates rules validated by `validate-rule.py` + `rule-schema.json` in `android-sigma-rules/`
+
+These two paths enforce different schemas. The Kotlin parser (`SigmaRuleParser.kt:155-169`) requires a top-level `category` field and accepts logsource services like `receiver_audit` and `tombstone_parser`. The Python validator (`validate-rule.py:63`) does not know about `category` and only accepts 5 of the 10+ real services. Neither side checks the other.
+
+When dev PRs add fields or services without updating `rule-schema.json`, the AI pipeline either rejects valid rules (false negative) or accepts invalid ones (false positive). This drift caused all five staging rules to silently carry stale metadata for 9+ days.
+
+The root cause is structural: the two paths share no authoritative schema, and nothing enforces that they agree.
+
+## Solution
+
+Make `android-sigma-rules` the single authoritative source of the rule schema. Bring it into AndroDR's build as a **git submodule** so both repos read the same file. Add a **Kotlin build-time gate** that cross-checks every bundled rule against both the Kotlin parser and the JSON schema. The build fails if they disagree — making it mechanically impossible to drift.
+
+## Design decisions (resolved during brainstorming)
+
+| # | Decision | Resolution | Rationale |
+|---|---|---|---|
+| D1 | Where does the authoritative schema live? | `android-sigma-rules` (Option D1 — git submodule into AndroDR) | The sigma-rules repo is conceptually upstream; it's a publishable detection-content project (Tier 1, own public repo). AndroDR is a consumer. The two-PR dance for schema changes is the price of structural discipline and prevents drift by construction. |
+| D2 | Build-time gate mechanism? | Kotlin parser + JSON schema cross-check using `com.networknt:json-schema-validator:2.0.1` (Option B with library) | Catches drift in both directions: parser rejects what schema accepts → build fails; schema rejects what parser accepts → build fails. No Python dependency in the build. The library is pure JVM, supports JSON Schema draft 2020-12. |
+| D3 | Scope: correlation rules included? | No — detection/atom rules only (Option B1) | Correlation rules have a different structure (`correlation.type`, `timespan`, etc.) that would require a new schema definition. Deferred to Bundle 3 (#109) alongside F8 (correlation rule integration tests). Existing `SigmaRuleParser.parseCorrelation()` continues as the only validator for correlation rules. |
+| D4 | Submodule path? | `third-party/android-sigma-rules/` | Self-documenting convention for external content; sets a precedent for future external repos. |
+
+---
+
+## Architecture
+
+### Repo layout after sub-plan 1a
+
+```
+AndroDR/                                          (main repo)
+├── .gitmodules                                   (NEW — registers the submodule)
+├── third-party/
+│   └── android-sigma-rules/                      (NEW — git submodule, pinned SHA)
+│       └── validation/
+│           ├── rule-schema.json                  (authoritative schema, edited here)
+│           ├── validate-rule.py                  (AI pipeline validator)
+│           └── android-permissions.txt
+├── app/
+│   ├── build.gradle.kts                          (+1 test dependency)
+│   ├── src/main/java/com/androdr/sigma/
+│   │   └── SigmaRuleParser.kt                   (unchanged)
+│   ├── src/main/res/raw/
+│   │   └── sigma_androdr_*.yml                   (48 bundled rules, unchanged)
+│   └── src/test/java/com/androdr/sigma/
+│       ├── AllRulesHaveCategoryTest.kt           (existing, unchanged)
+│       ├── AllCorrelationRulesFireTest.kt        (existing, unchanged)
+│       └── BundledRulesSchemaCrossCheckTest.kt   (NEW — the build-time gate)
+└── .github/workflows/
+    └── android-build.yml                         (+1 line: submodule init)
+
+android-sigma-rules/                              (canonical upstream, separate repo)
+├── validation/
+│   ├── rule-schema.json                          (UPDATED — synced with runtime)
+│   ├── validate-rule.py                          (UPDATED — valid_services whitelist)
+│   └── ...
+└── ...
+```
+
+### Data flow: build-time gate
+
+```
+./gradlew check
+  └── BundledRulesSchemaCrossCheckTest
+        │
+        ├── loads rule-schema.json from third-party/android-sigma-rules/validation/
+        │   (fails with clear error if submodule not initialized)
+        │
+        ├── iterates app/src/main/res/raw/sigma_androdr_*.yml
+        │   (excludes sigma_androdr_corr_*.yml — correlation rules deferred)
+        │
+        └── for each rule file:
+              ├── SigmaRuleParser.parse(yaml) — must succeed
+              │   (catches: missing category, invalid enum, bad modifier, etc.)
+              │
+              └── jsonSchemaValidator.validate(yamlAsJson, schema) — must pass
+                  (catches: missing required field, unknown service, wrong type, etc.)
+                  
+              → if either fails: build fails with structured error + fix hint
+```
+
+### Data flow: AI pipeline (unchanged but now reliable)
+
+```
+/update-rules
+  └── update-rules-validate skill
+        └── Gate 1: validate-rule.py
+              └── loads same rule-schema.json from android-sigma-rules/validation/
+                  (same file, same commit — guaranteed by submodule pin)
+```
+
+### Drift-prevention guarantee
+
+Any change to runtime requirements forces a change to `rule-schema.json`, which lives in the submodule. Updating the submodule pointer is itself a git operation visible in the AndroDR PR diff. Reviewers see the Kotlin change and the submodule bump together. The build fails unless they are consistent.
+
+---
+
+## Changes: `android-sigma-rules` repo
+
+A single PR that syncs `rule-schema.json` and `validate-rule.py` with the current AndroDR runtime.
+
+### rule-schema.json changes
+
+**1. Add `category` to required fields:**
+
+Current:
+```json
+"required": ["title", "id", "status", "description", "logsource", "detection", "level", "tags"]
+```
+
+Updated:
+```json
+"required": ["title", "id", "status", "description", "logsource", "detection", "level", "tags", "category"]
+```
+
+**2. Add `category` property definition:**
+
+```json
+"category": {
+  "type": "string",
+  "enum": ["incident", "device_posture"]
+}
+```
+
+This matches `SigmaRuleParser.kt:162-168` which accepts exactly these two values (case-insensitive, mapped to `RuleCategory.INCIDENT` and `RuleCategory.DEVICE_POSTURE`).
+
+**3. Expand `logsource.service` enum:**
+
+Current (5 services):
+```json
+"enum": ["app_scanner", "device_auditor", "dns_monitor", "process_monitor", "file_scanner"]
+```
+
+Updated (10 services — matching all telemetry model classes with `toFieldMap()`):
+```json
+"enum": [
+  "app_scanner", "device_auditor", "dns_monitor",
+  "process_monitor", "file_scanner",
+  "receiver_audit", "tombstone_parser",
+  "accessibility", "appops", "network_monitor"
+]
+```
+
+Source of truth for this list: the telemetry model classes that implement `toFieldMap()`:
+- `AppTelemetry.kt` → `app_scanner`
+- `DeviceTelemetry.kt` → `device_auditor`
+- `DnsEvent.kt` → `dns_monitor`
+- `ProcessTelemetry.kt` → `process_monitor`
+- `FileArtifactTelemetry.kt` → `file_scanner`
+- `ReceiverTelemetry.kt` → `receiver_audit`
+- (tombstone, accessibility, appops, network) → respective services from bugreport parser modules
+
+**4. Add optional fields that production rules already use:**
+
+```json
+"enabled": { "type": "boolean" },
+"report_safe_state": { "type": "boolean" }
+```
+
+And inside the `display` object:
+```json
+"guidance": { "type": "string" }
+```
+
+These fields are consumed by `SigmaRuleParser.kt:171-172` (`enabled`, `reportSafeState`) and `SigmaRuleParser.kt:269` (`display.guidance`). Making them schema-known prevents the JSON schema validator from rejecting rules that use them (JSON Schema's `additionalProperties` default is permissive, but documenting them is correct practice).
+
+### validate-rule.py changes
+
+**1. Sync `valid_services` whitelist** (line 63):
+
+```python
+valid_services = {
+    "app_scanner", "device_auditor", "dns_monitor",
+    "process_monitor", "file_scanner",
+    "receiver_audit", "tombstone_parser",
+    "accessibility", "appops", "network_monitor",
+}
+```
+
+No other changes to `validate-rule.py`. The script's logic is sound; only its data was stale.
+
+### Verification before merging
+
+Run `python validate-rule.py` against:
+- All rules in the sigma-rules repo's service directories (must all pass)
+- The 5 staging rules (capture which pass and which fail for reference during sub-plan 1c)
+
+---
+
+## Changes: `AndroDR` repo
+
+A single PR that adds the submodule, the test dependency, the cross-check test, and the CI config.
+
+### 1. Git submodule
+
+```bash
+git submodule add https://github.com/android-sigma-rules/rules.git third-party/android-sigma-rules
+```
+
+Pin to the commit SHA from the merged sigma-rules PR above.
+
+### 2. Test dependency in `app/build.gradle.kts`
+
+```kotlin
+testImplementation("com.networknt:json-schema-validator:2.0.1")
+```
+
+This library is pure JVM, has no Android-specific dependencies, and supports JSON Schema draft 2020-12 (which `rule-schema.json` declares via `"$schema": "https://json-schema.org/draft/2020-12/schema"`). [Maven Central](https://mvnrepository.com/artifact/com.networknt/json-schema-validator), [GitHub](https://github.com/networknt/json-schema-validator).
+
+### 3. New test: `BundledRulesSchemaCrossCheckTest.kt`
+
+Location: `app/src/test/java/com/androdr/sigma/BundledRulesSchemaCrossCheckTest.kt`
+
+**Structure:**
+
+```kotlin
+class BundledRulesSchemaCrossCheckTest {
+
+    // --- Setup ---
+    // Locate rule-schema.json from the submodule path
+    // (fallback chain similar to AllRulesHaveCategoryTest.rulesDirectory())
+    // Fail with a clear error if not found:
+    //   "rule-schema.json not found. Run: git submodule update --init"
+    
+    // Load schema via JsonSchemaFactory (networknt library)
+    // Locate res/raw directory (same fallback chain as existing tests)
+    
+    // --- Helpers ---
+    // yamlToJsonNode(yamlString): parse YAML with snakeyaml-engine,
+    //   convert the resulting Map to a Jackson JsonNode (networknt 
+    //   uses Jackson internally). snakeyaml-engine is already a 
+    //   project dependency.
+    
+    // detectionAndAtomRuleFiles(): same filter as AllRulesHaveCategoryTest
+    //   — includes sigma_androdr_*.yml, excludes sigma_androdr_corr_*.yml
+    
+    // --- Test methods ---
+    
+    @Test
+    fun `every bundled detection rule is accepted by SigmaRuleParser`()
+    // Iterate detection/atom files, call SigmaRuleParser.parse(yaml)
+    // Collect all failures, report as a single assertion with per-file detail
+    
+    @Test
+    fun `every bundled detection rule passes JSON schema validation`()
+    // Iterate detection/atom files, convert to JSON, validate against schema
+    // Collect all failures, report with per-file detail + schema error messages
+    
+    @Test
+    fun `schema file is reachable from submodule`()
+    // Precondition check — fail fast with developer-friendly error
+    // "third-party/android-sigma-rules not found. 
+    //  Run: git submodule update --init"
+}
+```
+
+**Error messages include:**
+- Which rule file failed
+- Which gate failed (Kotlin parser vs JSON schema)
+- Exact validation error
+- Fix hint: "If you added a new field or service to SigmaRuleParser, update rule-schema.json in the android-sigma-rules repo and bump the submodule."
+
+### 4. CI workflow update
+
+In `.github/workflows/android-build.yml`, add before the build step:
+
+```yaml
+- name: Initialize submodules
+  run: git submodule update --init --recursive
+```
+
+### 5. Existing tests: no changes
+
+`AllRulesHaveCategoryTest` stays as-is. It overlaps with part of the new cross-check (the category field) but provides a more focused error message for the most common failure mode. The overlap is harmless — two tests catching the same bug is better than zero.
+
+`AllCorrelationRulesFireTest`, `SigmaRuleParserCategoryEnforcementTest`, and all other existing tests are untouched.
+
+---
+
+## Migration sequence
+
+### Step 1: PR against `android-sigma-rules`
+
+**Title:** "Sync rule-schema.json with AndroDR runtime requirements"
+
+Contents:
+- Update `rule-schema.json` (add `category` required, expand service enum, add optional fields)
+- Update `validate-rule.py` (sync `valid_services` whitelist)
+- Run validation against all existing rules + staging rules (capture results)
+- Merge
+
+### Step 2: PR against `AndroDR`
+
+**Title:** "Add sigma-rules submodule + build-time schema cross-check gate"  
+**Body includes:** `Closes #105`
+
+Contents:
+- Add submodule at `third-party/android-sigma-rules/` pinned to Step 1's merge commit
+- Add `com.networknt:json-schema-validator:2.0.1` test dependency
+- Add `BundledRulesSchemaCrossCheckTest.kt`
+- Add `git submodule update --init` to CI workflow
+- Run `./gradlew testDebugUnitTest` — all 48 rules must pass both Kotlin parser and JSON schema
+- Merge
+
+### Step 3: Verification (during PR review, not shipped)
+
+Two intentional-break experiments to prove the drift loop is closed:
+
+**Test A — "Dev adds a Kotlin field but forgets the schema."**
+1. Temporarily add a required field to `SigmaRuleParser.parseDocument()` (e.g., require `foo`)
+2. Run `./gradlew testDebugUnitTest` → Kotlin parser fails on every rule missing `foo`
+3. Add `foo:` to one bundled rule → parser passes, but JSON schema fails (unknown property)
+4. Only fix: update `rule-schema.json`, bump submodule → build green
+5. Revert the experiment
+
+**Test B — "Someone loosens the schema without touching the parser."**
+1. Temporarily remove `category` from the `required` array in the submodule's `rule-schema.json`
+2. Remove `category:` from one bundled rule
+3. Run `./gradlew testDebugUnitTest` → Kotlin parser throws `SigmaRuleParseException`, schema passes (it's no longer required)
+4. Cross-check test fails on the parser side, surfacing the inconsistency
+5. Revert the experiment
+
+### Step 4: Document the developer workflow
+
+Add to CLAUDE.md under a new "Submodule: android-sigma-rules" section:
+
+- After cloning AndroDR, run `git submodule update --init` once
+- When adding a new field or logsource service to `SigmaRuleParser.kt`: first update `rule-schema.json` in the sigma-rules repo (open a PR there), merge it, then bump the submodule in AndroDR in the same PR as the Kotlin change
+- The build-time cross-check test (`BundledRulesSchemaCrossCheckTest`) will fail if the schema and parser disagree
+
+---
+
+## Scope boundaries
+
+### In scope for sub-plan 1a
+
+- Sync `rule-schema.json` with current runtime (category, services, optional fields)
+- Sync `validate-rule.py` whitelist
+- Add git submodule to AndroDR
+- Add `com.networknt:json-schema-validator:2.0.1` test dependency
+- Add `BundledRulesSchemaCrossCheckTest.kt`
+- Update CI workflow for submodule init
+- Update CLAUDE.md with submodule developer workflow
+
+### Explicitly out of scope
+
+- **Correlation rule schema** — deferred to Bundle 3 (#109). No changes to correlation rule parsing, testing, or validation. `sigma_androdr_corr_*.yml` files are excluded from the cross-check.
+- **IOC data validation** — deferred to sub-plan 1b (#106). `merge-ioc-data.py` untouched. IOC `source` field enforcement not in scope.
+- **Gate 4 test harness** — deferred to sub-plan 1b (#106).
+- **Staging rule re-validation** — deferred to sub-plan 1c (#107). The sigma-rules PR will run validation against staging rules for preview purposes, but no decisions or promotions happen in 1a.
+- **Runtime changes** — `SigmaRuleParser.kt` is NOT modified. The parser already enforces everything correctly; only the external schema and the cross-check test are new.
+- **`validate-rule.py` logic changes** — only the `valid_services` data constant is updated. No structural changes to the script.
+
+---
+
+## Success criteria
+
+After both PRs merge:
+
+1. `./gradlew testDebugUnitTest` passes with all 48 detection/atom rules validated against both the Kotlin parser and the JSON schema from the submodule
+2. CI passes with the submodule initialized automatically
+3. `python validate-rule.py <any-bundled-rule.yml>` passes in the sigma-rules repo (using the same schema)
+4. It is mechanically impossible to ship a bundled rule that the Kotlin parser accepts but the JSON schema rejects (or vice versa) without a build failure
+5. Developer workflow for schema changes is documented in CLAUDE.md

--- a/docs/superpowers/specs/2026-04-11-validator-sync-and-build-time-gate.md
+++ b/docs/superpowers/specs/2026-04-11-validator-sync-and-build-time-gate.md
@@ -33,6 +33,8 @@ Make `android-sigma-rules` the single authoritative source of the rule schema. B
 | D2 | Build-time gate mechanism? | Kotlin parser + JSON schema cross-check using `com.networknt:json-schema-validator:2.0.1` (Option B with library) | Catches drift in both directions: parser rejects what schema accepts → build fails; schema rejects what parser accepts → build fails. No Python dependency in the build. The library is pure JVM, supports JSON Schema draft 2020-12. |
 | D3 | Scope: correlation rules included? | No — detection/atom rules only (Option B1) | Correlation rules have a different structure (`correlation.type`, `timespan`, etc.) that would require a new schema definition. Deferred to Bundle 3 (#109) alongside F8 (correlation rule integration tests). Existing `SigmaRuleParser.parseCorrelation()` continues as the only validator for correlation rules. |
 | D4 | Submodule path? | `third-party/android-sigma-rules/` | Self-documenting convention for external content; sets a precedent for future external repos. |
+| D5 | `additionalProperties` posture? | `true` (permissive — the default) | The cross-check catches required-field and enum drift (the actual problems). Unknown-field drift is benign — the Kotlin parser simply ignores fields it doesn't recognize. Setting `false` would force a schema change every time a new optional field is added, creating churn without safety benefit. |
+| D6 | `category` enum case sensitivity? | Schema uses lowercase enum `["incident", "device_posture"]`; bundled rules MUST use lowercase | All 44 current detection/atom rules already use lowercase. The Kotlin parser does `.lowercase()` before matching (permissive), but JSON Schema enum is case-sensitive. Convention: bundled rules always use lowercase `category` values. |
 
 ---
 
@@ -54,7 +56,7 @@ AndroDR/                                          (main repo)
 │   ├── src/main/java/com/androdr/sigma/
 │   │   └── SigmaRuleParser.kt                   (unchanged)
 │   ├── src/main/res/raw/
-│   │   └── sigma_androdr_*.yml                   (48 bundled rules, unchanged)
+│   │   └── sigma_androdr_*.yml                   (44 detection/atom + 4 correlation, unchanged)
 │   └── src/test/java/com/androdr/sigma/
 │       ├── AllRulesHaveCategoryTest.kt           (existing, unchanged)
 │       ├── AllCorrelationRulesFireTest.kt        (existing, unchanged)
@@ -80,7 +82,7 @@ android-sigma-rules/                              (canonical upstream, separate 
         │   (fails with clear error if submodule not initialized)
         │
         ├── iterates app/src/main/res/raw/sigma_androdr_*.yml
-        │   (excludes sigma_androdr_corr_*.yml — correlation rules deferred)
+        │   (includes all detection + atom rules; excludes only sigma_androdr_corr_*.yml)
         │
         └── for each rule file:
               ├── SigmaRuleParser.parse(yaml) — must succeed
@@ -135,7 +137,9 @@ Updated:
 }
 ```
 
-This matches `SigmaRuleParser.kt:162-168` which accepts exactly these two values (case-insensitive, mapped to `RuleCategory.INCIDENT` and `RuleCategory.DEVICE_POSTURE`).
+This matches `SigmaRuleParser.kt:162-168` which accepts exactly these two values (case-insensitive via `.lowercase()`, mapped to `RuleCategory.INCIDENT` and `RuleCategory.DEVICE_POSTURE`).
+
+**Convention:** Bundled rules MUST use lowercase `category` values. The Kotlin parser is permissive (it lowercases before matching), but JSON Schema `enum` is case-sensitive. All 44 current detection/atom rules already use lowercase — this convention just makes it explicit.
 
 **3. Expand `logsource.service` enum:**
 
@@ -175,7 +179,15 @@ And inside the `display` object:
 "guidance": { "type": "string" }
 ```
 
-These fields are consumed by `SigmaRuleParser.kt:171-172` (`enabled`, `reportSafeState`) and `SigmaRuleParser.kt:269` (`display.guidance`). Making them schema-known prevents the JSON schema validator from rejecting rules that use them (JSON Schema's `additionalProperties` default is permissive, but documenting them is correct practice).
+These fields are consumed by `SigmaRuleParser.kt:171-172` (`enabled`, `reportSafeState`) and `SigmaRuleParser.kt:269` (`display.guidance`). Making them schema-known documents the contract.
+
+**5. `additionalProperties` stays unset (defaults to `true` — permissive):**
+
+The schema deliberately does NOT set `additionalProperties: false`. This means:
+- Unknown fields are silently accepted by the schema (rules can carry extra metadata without a schema change)
+- The cross-check catches **required-field and enum drift** (the actual problem) but not "unknown field added to a rule"
+- The Kotlin parser already ignores fields it doesn't recognize, so unknown-field drift is benign
+- Setting `false` would force a schema update every time any optional field is added — creating churn without safety benefit
 
 ### validate-rule.py changes
 
@@ -220,6 +232,8 @@ testImplementation("com.networknt:json-schema-validator:2.0.1")
 
 This library is pure JVM, has no Android-specific dependencies, and supports JSON Schema draft 2020-12 (which `rule-schema.json` declares via `"$schema": "https://json-schema.org/draft/2020-12/schema"`). [Maven Central](https://mvnrepository.com/artifact/com.networknt/json-schema-validator), [GitHub](https://github.com/networknt/json-schema-validator).
 
+**Transitive dependency note:** `json-schema-validator:2.0.1` pulls in Jackson 2.17.x. AndroDR uses `kotlinx.serialization` for production JSON (no Jackson in production code). Jackson will only appear in the `testImplementation` classpath — no conflict with production dependencies. If a future dependency introduces a Jackson version pin, the test-only scope prevents classpath issues at runtime.
+
 ### 3. New test: `BundledRulesSchemaCrossCheckTest.kt`
 
 Location: `app/src/test/java/com/androdr/sigma/BundledRulesSchemaCrossCheckTest.kt`
@@ -243,9 +257,20 @@ class BundledRulesSchemaCrossCheckTest {
     //   convert the resulting Map to a Jackson JsonNode (networknt 
     //   uses Jackson internally). snakeyaml-engine is already a 
     //   project dependency.
+    //
+    //   Implementation notes:
+    //   - YAML pipe-keys like "field|endswith" become literal JSON 
+    //     object keys — no special handling needed, snakeyaml-engine 
+    //     parses them as plain strings
+    //   - Bundled rules do not use YAML anchors, merge keys, or 
+    //     multi-doc; only simple maps and lists
+    //   - Conversion is Map<String,Any?> → ObjectMapper.valueToTree()
     
-    // detectionAndAtomRuleFiles(): same filter as AllRulesHaveCategoryTest
-    //   — includes sigma_androdr_*.yml, excludes sigma_androdr_corr_*.yml
+    // detectionAndAtomRuleFiles(): includes ALL sigma_androdr_*.yml 
+    //   files EXCEPT sigma_androdr_corr_*.yml. This explicitly includes 
+    //   sigma_androdr_atom_*.yml (atom rules are structurally identical 
+    //   to detection rules — they have detection/condition blocks and 
+    //   are parsed by the same SigmaRuleParser.parse() path)
     
     // --- Test methods ---
     
@@ -312,7 +337,7 @@ Contents:
 - Add `com.networknt:json-schema-validator:2.0.1` test dependency
 - Add `BundledRulesSchemaCrossCheckTest.kt`
 - Add `git submodule update --init` to CI workflow
-- Run `./gradlew testDebugUnitTest` — all 48 rules must pass both Kotlin parser and JSON schema
+- Run `./gradlew testDebugUnitTest` — all 44 detection/atom rules must pass both Kotlin parser and JSON schema
 - Merge
 
 ### Step 3: Verification (during PR review, not shipped)
@@ -340,6 +365,7 @@ Add to CLAUDE.md under a new "Submodule: android-sigma-rules" section:
 - After cloning AndroDR, run `git submodule update --init` once
 - When adding a new field or logsource service to `SigmaRuleParser.kt`: first update `rule-schema.json` in the sigma-rules repo (open a PR there), merge it, then bump the submodule in AndroDR in the same PR as the Kotlin change
 - The build-time cross-check test (`BundledRulesSchemaCrossCheckTest`) will fail if the schema and parser disagree
+- **Submodule update direction (AI pipeline → AndroDR):** When the AI pipeline adds new rules to `android-sigma-rules` (via `/update-rules`), the submodule pointer in AndroDR stays pinned until the next release cycle. The cross-check only validates rules bundled in `app/src/main/res/raw/` — new upstream rules don't affect the build until they're bundled. Bumping the submodule to pick up upstream schema changes (e.g., after the AI pipeline reveals a schema gap) follows the same two-PR dance: update sigma-rules first, then bump the submodule in AndroDR.
 
 ---
 
@@ -370,7 +396,7 @@ Add to CLAUDE.md under a new "Submodule: android-sigma-rules" section:
 
 After both PRs merge:
 
-1. `./gradlew testDebugUnitTest` passes with all 48 detection/atom rules validated against both the Kotlin parser and the JSON schema from the submodule
+1. `./gradlew testDebugUnitTest` passes with all 44 detection/atom rules validated against both the Kotlin parser and the JSON schema from the submodule
 2. CI passes with the submodule initialized automatically
 3. `python validate-rule.py <any-bundled-rule.yml>` passes in the sigma-rules repo (using the same schema)
 4. It is mechanically impossible to ship a bundled rule that the Kotlin parser accepts but the JSON schema rejects (or vice versa) without a build failure

--- a/docs/superpowers/specs/2026-04-12-gate4-harness-and-ioc-source-design.md
+++ b/docs/superpowers/specs/2026-04-12-gate4-harness-and-ioc-source-design.md
@@ -26,7 +26,7 @@ or test-origin data cannot reach production IOC files.
 - `app/src/test/java/com/androdr/sigma/GateFourFixtureTest.kt`
 - `app/src/test/resources/gate4-fixtures/sideloaded-app.yml`
 - `app/src/test/resources/gate4-fixtures/package-ioc.yml`
-- `app/src/test/resources/gate4-fixtures/correlation-atom.yml`
+- `app/src/test/resources/gate4-fixtures/accessibility-atom.yml`
 
 ### API
 
@@ -60,6 +60,8 @@ data class Gate4Result(
    produced zero findings. `pass` = tpFired && tnClean.
 5. Collect error strings for any failures (which record failed, what was
    expected vs actual).
+6. Warn (include in errors) if any `iocStubs` key is not referenced by the
+   rule's detection (catches fixture authoring typos).
 
 ### IOC Lookup Handling
 
@@ -106,8 +108,9 @@ fixture file becomes one test case. The test:
 1. Reads the rule YAML from `app/src/main/res/raw/{rule_file}`
 2. Parses it with `SigmaRuleParser.parse()`
 3. Parses fixture YAML for TP/TN records and IOC stubs
-4. Calls `GateFourTestHarness.runGate4()`
-5. Asserts `result.pass == true`
+4. Asserts `rule.service == fixture.service` (catches fixture/rule mismatch)
+5. Calls `GateFourTestHarness.runGate4()`
+6. Asserts `result.pass == true`
 
 ### Representative Fixtures
 
@@ -115,7 +118,7 @@ fixture file becomes one test case. The test:
 |---------|------|-------|
 | `sideloaded-app.yml` | androdr-010 | Simple selection with boolean + field match |
 | `package-ioc.yml` | androdr-001 | `ioc_lookup` modifier with stubbed package DB |
-| `correlation-atom.yml` | androdr-060 | Atom rule (accessibility service detection) |
+| `accessibility-atom.yml` | androdr-060 | Atom rule (accessibility service detection) |
 
 ---
 

--- a/docs/superpowers/specs/2026-04-12-gate4-harness-and-ioc-source-design.md
+++ b/docs/superpowers/specs/2026-04-12-gate4-harness-and-ioc-source-design.md
@@ -1,0 +1,236 @@
+# Gate 4 Programmatic Test Harness + IOC Source Validation
+
+**Issue:** #106
+**Date:** 2026-04-12
+**Status:** Approved
+
+## Summary
+
+Turn Gate 4 (dry-run evaluation) from a manual hand-trace into a programmatic
+Kotlin test harness, and enforce IOC data `source` field validation so polluted
+or test-origin data cannot reach production IOC files.
+
+## Deliverables
+
+1. Gate 4 Kotlin test harness
+2. IOC source validation (Python + JSON enum)
+3. Skill update (`update-rules-validate.md`)
+
+---
+
+## 1. Gate 4 Test Harness
+
+### Files
+
+- `app/src/test/java/com/androdr/sigma/GateFourTestHarness.kt`
+- `app/src/test/java/com/androdr/sigma/GateFourFixtureTest.kt`
+- `app/src/test/resources/gate4-fixtures/sideloaded-app.yml`
+- `app/src/test/resources/gate4-fixtures/package-ioc.yml`
+- `app/src/test/resources/gate4-fixtures/correlation-atom.yml`
+
+### API
+
+```kotlin
+object GateFourTestHarness {
+    fun runGate4(
+        rule: SigmaRule,
+        truePositives: List<Map<String, Any?>>,
+        trueNegatives: List<Map<String, Any?>>,
+        iocStubs: Map<String, Set<String>> = emptyMap()
+    ): Gate4Result
+}
+
+data class Gate4Result(
+    val pass: Boolean,
+    val tpFired: Boolean,
+    val tnClean: Boolean,
+    val errors: List<String>
+)
+```
+
+### Logic
+
+1. Build `iocLookups: Map<String, (Any) -> Boolean>` from `iocStubs` — each
+   key maps to a lambda that returns `true` if the value (as string) is in the
+   stub set.
+2. For each TP record: call `SigmaRuleEvaluator.evaluate(listOf(rule),
+   listOf(record), rule.service, iocLookups)`. Expect >= 1 finding.
+3. For each TN record: same call. Expect 0 findings.
+4. `tpFired` = all TP records produced findings. `tnClean` = all TN records
+   produced zero findings. `pass` = tpFired && tnClean.
+5. Collect error strings for any failures (which record failed, what was
+   expected vs actual).
+
+### IOC Lookup Handling
+
+Rules using `ioc_lookup` (e.g. `package_name|ioc_lookup: package_ioc_db`) are
+tested with **stubbed lookups**. The fixture declares which indicators the stub
+DB should contain. This tests rule condition wiring in isolation — Gate 2
+separately verifies that the real IOC data contains the indicators.
+
+### Fixture Format
+
+Each fixture is a YAML file in `app/src/test/resources/gate4-fixtures/`:
+
+```yaml
+rule_file: sigma_androdr_010_sideloaded_app.yml
+service: app_scanner
+ioc_stubs:
+  package_ioc_db:
+    - "com.malware.test"
+true_positives:
+  - package_name: "com.malware.test"
+    is_sideloaded: true
+    is_system_app: false
+true_negatives:
+  - package_name: "com.google.android.gm"
+    is_sideloaded: false
+    is_system_app: false
+```
+
+Fields:
+- `rule_file`: filename of the bundled rule in `res/raw/` (the test reads it
+  from disk at the project root path)
+- `service`: logsource service to pass to the evaluator
+- `ioc_stubs`: optional map of IOC DB name -> list of indicators that should
+  "exist" in the stub
+- `true_positives`: list of telemetry records that must trigger the rule
+- `true_negatives`: list of telemetry records that must NOT trigger the rule
+
+### Fixture-Driven Test
+
+`GateFourFixtureTest.kt` uses JUnit `@ParameterizedTest` with a
+`@MethodSource` that discovers all `*.yml` files in `gate4-fixtures/`. Each
+fixture file becomes one test case. The test:
+
+1. Reads the rule YAML from `app/src/main/res/raw/{rule_file}`
+2. Parses it with `SigmaRuleParser.parse()`
+3. Parses fixture YAML for TP/TN records and IOC stubs
+4. Calls `GateFourTestHarness.runGate4()`
+5. Asserts `result.pass == true`
+
+### Representative Fixtures
+
+| Fixture | Rule | Tests |
+|---------|------|-------|
+| `sideloaded-app.yml` | androdr-010 | Simple selection with boolean + field match |
+| `package-ioc.yml` | androdr-001 | `ioc_lookup` modifier with stubbed package DB |
+| `correlation-atom.yml` | androdr-060 | Atom rule (accessibility service detection) |
+
+---
+
+## 2. IOC Source Validation
+
+### Allowed Sources Registry
+
+**File:** `third-party/android-sigma-rules/validation/allowed-sources.json`
+
+```json
+[
+  {
+    "id": "stalkerware-indicators",
+    "name": "AssoEchap Stalkerware Indicators",
+    "url": "https://github.com/AssoEchap/stalkerware-indicators"
+  },
+  {
+    "id": "malwarebazaar",
+    "name": "abuse.ch MalwareBazaar",
+    "url": "https://bazaar.abuse.ch"
+  },
+  {
+    "id": "threatfox",
+    "name": "abuse.ch ThreatFox",
+    "url": "https://threatfox.abuse.ch"
+  },
+  {
+    "id": "amnesty-investigations",
+    "name": "Amnesty International Security Lab",
+    "url": "https://github.com/AmnestyTech/investigations"
+  },
+  {
+    "id": "citizenlab-indicators",
+    "name": "Citizen Lab Malware Indicators",
+    "url": "https://github.com/citizenlab/malware-indicators"
+  },
+  {
+    "id": "mvt-indicators",
+    "name": "MVT Project STIX2 Indicators",
+    "url": "https://github.com/mvt-project/mvt-indicators"
+  },
+  {
+    "id": "virustotal",
+    "name": "VirusTotal Intelligence",
+    "url": "https://www.virustotal.com"
+  },
+  {
+    "id": "android-security-bulletin",
+    "name": "Google Android Security Bulletins",
+    "url": "https://source.android.com/docs/security/bulletin"
+  }
+]
+```
+
+### New: validate-ioc-data.py
+
+**File:** `third-party/android-sigma-rules/validation/validate-ioc-data.py`
+
+**Usage:** `python3 validate-ioc-data.py <ioc-data-file.yml>`
+
+**Validation checks:**
+
+1. **Source field present** — every entry must have `source`
+2. **Source in allowed set** — read from `allowed-sources.json` (id field only)
+3. **Blocked categories** — reject `TEST`, `FIXTURE`, `SIMULATION`, `DEBUG`
+4. **Blocked family patterns** — reject entries where family/familyName contains
+   "test", "fixture", "simulation", "sample", "example" (case-insensitive)
+5. **Cert hash format** — if entry has `indicator` that looks like a hash (in
+   `cert-hashes.yml`), must be exactly 64 lowercase hex chars
+6. **No duplicates** — no repeated `indicator` values within the same file
+
+**Exit codes:** 0 = valid, 1 = validation errors, 2 = file not found / parse error
+
+### Modified: merge-ioc-data.py
+
+Add a validation pass before merging:
+
+1. Load `allowed-sources.json` from the submodule path
+   (`third-party/android-sigma-rules/validation/allowed-sources.json`)
+2. For each entry being merged, check `source` is present and in allowed set
+3. If any entry fails, print errors and exit non-zero (no partial merge)
+
+---
+
+## 3. Skill Update
+
+**File:** `.claude/commands/update-rules-validate.md`
+
+Gate 4 section rewritten from:
+> "Write a temporary JUnit test or manually trace the evaluation logic"
+
+To:
+> "Create a fixture YAML and run the harness test"
+
+Updated content describes:
+- The fixture format (rule_file, service, ioc_stubs, true_positives,
+  true_negatives)
+- How to run: `./gradlew testDebugUnitTest --tests
+  "com.androdr.sigma.GateFourFixtureTest"`
+- That IOC lookups are stubbed (not real DB)
+
+IOC Data Validation section updated to reference `validate-ioc-data.py` with
+usage instructions.
+
+---
+
+## Out of Scope
+
+- Fixture-file-based runner for human developers (no dual-use mode)
+- Real IOC data loading in Gate 4 (stubs only; Gate 2 covers IOC presence)
+- Correlation rule evaluation in the harness (only atom/detection rules)
+- Changes to `rule-schema.json` (handled by sub-plan 1a)
+
+## Dependencies
+
+- PR #110 (sub-plan 1a) merged — provides `SigmaRuleParser` stability and
+  `BundledRulesSchemaCrossCheckTest` as the build-time gate
+- Submodule initialized with `allowed-sources.json` pushed to remote

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -47,6 +47,7 @@ junitExt = "1.2.1"
 espressoCore = "3.6.1"
 mockk = "1.13.12"
 orgJson = "20240303"
+jsonSchemaValidator = "2.0.1"
 
 [libraries]
 # AndroidX Core
@@ -94,6 +95,7 @@ androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-co
 mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutines" }
 org-json = { group = "org.json", name = "json", version.ref = "orgJson" }
+json-schema-validator = { group = "com.networknt", name = "json-schema-validator", version.ref = "jsonSchemaValidator" }
 
 # WorkManager
 androidx-work-runtime-ktx = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "workManager" }


### PR DESCRIPTION
## Summary

- Adds `android-sigma-rules` as a git submodule at `third-party/android-sigma-rules/` — establishes the sigma-rules repo as the authoritative schema source
- Adds `BundledRulesSchemaCrossCheckTest` that validates every bundled detection/atom rule against both the Kotlin runtime parser AND the JSON schema from the submodule
- Build fails if they disagree — making it mechanically impossible for the dev pipeline and AI pipeline schemas to drift apart
- Uses `com.networknt:json-schema-validator:2.0.1` for JSON Schema draft 2020-12 validation (test-only dependency)
- CI workflow updated with `submodules: true` on checkout
- CLAUDE.md documents the two-PR dance for schema changes

## Upstream prerequisite

Two commits merged to `android-sigma-rules` main:
- `8e2369b` — sync rule-schema.json with AndroDR runtime (add `category` required, expand service enum, add optional fields)
- `0dd7b54` — add `informational` to level enum

## Test plan

- [x] All 44 detection/atom rules pass both Kotlin parser and JSON schema cross-check
- [x] Full test suite passes (`./gradlew testDebugUnitTest`)
- [x] Intentional breakage (remove `category:` from a rule) is caught by both gates
- [ ] CI passes with submodule initialized via `submodules: true`

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)