### PR TITLE
feat(test): Gate 4 programmatic harness + IOC source validation (#106)

### DIFF
--- a/.claude/commands/update-rules-validate.md
+++ b/.claude/commands/update-rules-validate.md
@@ -61,24 +61,38 @@ Record: `{ pass: bool, duplicates: string[], overlaps: string[] }`
 
 ## Gate 4: Dry-Run Evaluation
 
-Construct synthetic telemetry and test the rule:
+Use the programmatic Gate 4 test harness to verify rule logic.
 
-1. **True positive test**: Build a telemetry record from the SIR's indicators that SHOULD trigger the rule. For example, if the rule matches `package_name|ioc_lookup: package_ioc_db`, create a record with a package name from the SIR.
+1. **Create a fixture YAML** file with this format:
 
-2. **True negative test**: Use the benign fixtures from `{sigma_repo_path}/validation/test-fixtures/`. Pick the fixture matching the rule's service (benign-app.json for app_scanner, benign-device.json for device_auditor).
+```yaml
+rule_file: sigma_androdr_NNN_rule_name.yml
+service: <logsource.service from the rule>
+ioc_stubs:
+  <lookup_db_name>:
+    - "<indicator_from_SIR>"
+true_positives:
+  - <field_name>: <value_from_SIR_that_should_trigger>
+true_negatives:
+  - <field_name>: <benign_value>
+```
 
-3. To run the dry-run, use AndroDR's unit test infrastructure. Write a temporary JUnit test that:
-   - Parses the candidate YAML with `SigmaRuleParser.parse()`
-   - Creates the synthetic telemetry as a `Map<String, Any?>`
-   - Calls `SigmaRuleEvaluator.evaluate()` with the rule and telemetry
-   - Asserts the rule fires on the TP record and does NOT fire on the TN record
+2. **Copy the fixture** to `app/src/test/resources/gate4-fixtures/`
 
-   Run: `./gradlew testDebugUnitTest --tests "com.androdr.sigma.SigmaRuleEvaluatorTest"`
+3. **Run the harness:**
+```bash
+./gradlew testDebugUnitTest --tests "com.androdr.sigma.GateFourFixtureTest"
+```
 
-   If writing a temp test is not practical, manually trace the evaluation logic:
-   - Parse the YAML and check that detection field names match telemetry field names
-   - Verify that modifier logic would match the TP values
-   - Verify that TN values would NOT match
+4. **Record results:**
+   - If the test passes: `tp_fired: true`, `tn_clean: true`
+   - If it fails: record which records failed and why from the test output
+
+**Fixture tips:**
+- For `ioc_lookup` rules: stub the DB name with indicators from the SIR
+- For simple selection rules: set fields to matching values for TP, non-matching for TN
+- The harness uses stubbed IOC lookups (not real data) — this tests rule wiring only
+- Use `benign-app.json` / `benign-device.json` from `validation/test-fixtures/` as TN templates
 
 Record: `{ pass: bool, tp_fired: bool, tn_clean: bool, errors: string[] }`
 
@@ -108,56 +122,30 @@ Return a JSON ValidationResult:
 
 ## IOC Data Validation
 
-When the pipeline produces IOC data entries (for `ioc-data/*.yml` or bundled `known_bad_*.json`), validate each entry before committing:
+When the pipeline produces IOC data entries (for `ioc-data/*.yml`), validate with:
 
-### Required fields
-
-**Package IOC entries:**
-```json
-{
-  "packageName": "com.example.malware",  // required
-  "name": "MalwareName",                 // required
-  "category": "STALKERWARE",             // required, from allowed set
-  "severity": "CRITICAL",                // required
-  "description": "...",                   // required
-  "source": "stalkerware-indicators"     // REQUIRED — provenance
-}
+```bash
+python3 third-party/android-sigma-rules/validation/validate-ioc-data.py <ioc-data-file.yml>
 ```
 
-**Cert hash IOC entries:**
-```json
-{
-  "certHash": "abc123...",               // required, 64-char hex SHA-256
-  "familyName": "MalwareName",           // required
-  "category": "TROJAN",                  // required, from allowed set
-  "severity": "CRITICAL",               // required
-  "description": "...",                  // required
-  "source": "malwarebazaar"             // REQUIRED — provenance
-}
-```
+The script enforces:
+- `source` field present and in `allowed-sources.json`
+- No blocked categories (TEST, FIXTURE, SIMULATION, DEBUG)
+- No blocked family patterns (test/fixture/simulation/sample/example)
+- Cert hashes: 64 lowercase hex (SHA-256) or 40 lowercase hex (SHA-1)
+- No duplicate indicators within the file
 
-### Rejection rules (HARD FAIL)
+Exit 0 = valid, exit 1 = errors printed to stderr, exit 2 = file not found.
 
-1. **Missing `source` field** — every IOC entry must trace to a verified feed
-2. **Blocked category values**: `TEST`, `FIXTURE`, `SIMULATION`, `DEBUG` — test data must never enter production IOC files
-3. **Blocked familyName patterns**: entries containing "test", "fixture", "simulation", "sample", "example" (case-insensitive) are rejected
-4. **Invalid cert hash format**: must be exactly 64 lowercase hex characters (SHA-256)
-5. **Duplicate entry**: same packageName or certHash already exists
+### Allowed sources
 
-### Allowed `source` values
+See `third-party/android-sigma-rules/validation/allowed-sources.json` for the canonical list with URLs.
 
-| Source | Description |
-|--------|-------------|
-| `stalkerware-indicators` | AssoEchap stalkerware-indicators GitHub repo |
-| `malwarebazaar` | abuse.ch MalwareBazaar |
-| `threatfox` | abuse.ch ThreatFox |
-| `amnesty-investigations` | Amnesty International Security Lab |
-| `citizenlab-indicators` | Citizen Lab malware indicators |
-| `mvt-indicators` | MVT project STIX2 indicators |
-| `virustotal` | VirusTotal intelligence |
-| `android-security-bulletin` | Google Android Security Bulletins |
+### Required fields per entry type
 
-Entries with `source` values not in this list are flagged for manual review.
+**Package IOC:** indicator, family, category, severity, source
+**Cert hash IOC:** indicator, familyName, category, severity, source
+**Domain IOC:** indicator, family, category, severity, source
 
 ## Rules
 

--- a/app/src/test/java/com/androdr/sigma/GateFourFixtureTest.kt
+++ b/app/src/test/java/com/androdr/sigma/GateFourFixtureTest.kt
@@ -35,7 +35,6 @@ class GateFourFixtureTest(
             val candidates = listOf(
                 File("app/src/test/resources/gate4-fixtures"),
                 File("src/test/resources/gate4-fixtures"),
-                File("/home/yasir/AndroDR/app/src/test/resources/gate4-fixtures")
             )
             return candidates.firstOrNull { it.isDirectory }
                 ?: error(
@@ -48,7 +47,6 @@ class GateFourFixtureTest(
             val candidates = listOf(
                 File("app/src/main/res/raw"),
                 File("src/main/res/raw"),
-                File("/home/yasir/AndroDR/app/src/main/res/raw")
             )
             return candidates.firstOrNull { it.isDirectory }
                 ?: error(

--- a/app/src/test/java/com/androdr/sigma/GateFourFixtureTest.kt
+++ b/app/src/test/java/com/androdr/sigma/GateFourFixtureTest.kt
@@ -1,0 +1,135 @@
+package com.androdr.sigma
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import org.snakeyaml.engine.v2.api.Load
+import org.snakeyaml.engine.v2.api.LoadSettings
+import java.io.File
+
+/**
+ * Gate 4 parameterized fixture test.
+ *
+ * Discovers all *.yml files under gate4-fixtures/, loads the referenced SIGMA rule
+ * from res/raw/, parses it with [SigmaRuleParser], verifies the service matches the
+ * fixture declaration, and then runs [GateFourTestHarness.runGate4] asserting all
+ * true-positive and true-negative cases pass.
+ */
+@RunWith(Parameterized::class)
+class GateFourFixtureTest(
+    private val fixtureName: String,
+    private val fixtureFile: File
+) {
+
+    companion object {
+
+        private val yamlLoader: Load = Load(
+            LoadSettings.builder()
+                .setMaxAliasesForCollections(10)
+                .setAllowDuplicateKeys(false)
+                .build()
+        )
+
+        private fun fixturesDirectory(): File {
+            val candidates = listOf(
+                File("app/src/test/resources/gate4-fixtures"),
+                File("src/test/resources/gate4-fixtures"),
+                File("/home/yasir/AndroDR/app/src/test/resources/gate4-fixtures")
+            )
+            return candidates.firstOrNull { it.isDirectory }
+                ?: error(
+                    "Could not locate gate4-fixtures directory; tried: " +
+                        candidates.map { it.absolutePath }
+                )
+        }
+
+        private fun rulesDirectory(): File {
+            val candidates = listOf(
+                File("app/src/main/res/raw"),
+                File("src/main/res/raw"),
+                File("/home/yasir/AndroDR/app/src/main/res/raw")
+            )
+            return candidates.firstOrNull { it.isDirectory }
+                ?: error(
+                    "Could not locate res/raw directory; tried: " +
+                        candidates.map { it.absolutePath }
+                )
+        }
+
+        @JvmStatic
+        @Parameterized.Parameters(name = "{0}")
+        @Suppress("UNCHECKED_CAST")
+        fun fixtures(): List<Array<Any>> {
+            val dir = fixturesDirectory()
+            return dir.listFiles { f -> f.name.endsWith(".yml") }
+                ?.sorted()
+                ?.map { file -> arrayOf(file.nameWithoutExtension, file) as Array<Any> }
+                ?: emptyList()
+        }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    @Test
+    fun `fixture passes gate 4`() {
+        val raw = fixtureFile.readText()
+        val fixtureMap = yamlLoader.loadFromString(raw) as? Map<String, Any?>
+            ?: error("Fixture $fixtureName: YAML did not parse to a map")
+
+        val ruleFile = fixtureMap["rule_file"] as? String
+            ?: error("Fixture $fixtureName: missing 'rule_file' key")
+
+        val fixtureService = fixtureMap["service"] as? String
+            ?: error("Fixture $fixtureName: missing 'service' key")
+
+        // Load and parse the rule
+        val ruleText = File(rulesDirectory(), ruleFile).readText()
+        val rule = SigmaRuleParser.parse(ruleText)
+            ?: error("Fixture $fixtureName: SigmaRuleParser.parse() returned null for $ruleFile")
+
+        // Assert service declared in fixture matches parsed rule
+        assertTrue(
+            "Fixture $fixtureName: service mismatch — fixture declares '$fixtureService' " +
+                "but rule $ruleFile has service '${rule.service}'",
+            rule.service == fixtureService
+        )
+
+        // Parse ioc_stubs: Map<String, List<String>>
+        val iocStubsRaw = fixtureMap["ioc_stubs"] as? Map<String, Any?> ?: emptyMap()
+        val iocStubs: Map<String, Set<String>> = iocStubsRaw.mapValues { (_, v) ->
+            (v as? List<*>)?.mapNotNull { it?.toString() }?.toSet() ?: emptySet()
+        }
+
+        // Parse true_positives and true_negatives: each is a List<Map<String, Any?>>
+        val truePositives = parseRecordList(fixtureMap, "true_positives", fixtureName)
+        val trueNegatives = parseRecordList(fixtureMap, "true_negatives", fixtureName)
+
+        // Run gate 4
+        val result = GateFourTestHarness.runGate4(
+            rule = rule,
+            truePositives = truePositives,
+            trueNegatives = trueNegatives,
+            iocStubs = iocStubs
+        )
+
+        assertTrue(
+            "Fixture '$fixtureName' FAILED gate 4:\n" +
+                result.errors.joinToString("\n") { "  $it" },
+            result.pass
+        )
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun parseRecordList(
+        fixtureMap: Map<String, Any?>,
+        key: String,
+        fixtureName: String
+    ): List<Map<String, Any?>> {
+        val raw = fixtureMap[key] as? List<*> ?: return emptyList()
+        return raw.mapIndexed { idx, entry ->
+            (entry as? Map<*, *>)?.entries
+                ?.associate { (k, v) -> k.toString() to v }
+                ?: error("Fixture $fixtureName: $key[$idx] is not a map")
+        }
+    }
+}

--- a/app/src/test/java/com/androdr/sigma/GateFourTestHarness.kt
+++ b/app/src/test/java/com/androdr/sigma/GateFourTestHarness.kt
@@ -1,0 +1,101 @@
+package com.androdr.sigma
+
+/**
+ * Gate 4 test harness: verifies that a [SigmaRule] fires on all supplied
+ * true-positive records and stays silent on all true-negative records.
+ *
+ * Intended for use in unit tests that validate rule authoring quality.
+ */
+data class Gate4Result(
+    val pass: Boolean,
+    val tpFired: Boolean,
+    val tnClean: Boolean,
+    val errors: List<String>
+)
+
+object GateFourTestHarness {
+
+    /**
+     * Run gate-4 validation for a single rule.
+     *
+     * @param rule           The [SigmaRule] under test.
+     * @param truePositives  Records that MUST produce at least one finding.
+     * @param trueNegatives  Records that MUST produce zero findings.
+     * @param iocStubs       Optional IOC lookup stubs: lookup-name → set of
+     *                       string values that should be considered "known bad".
+     *                       Any key not referenced by the rule's detection
+     *                       selections is reported as a warning in [Gate4Result.errors].
+     */
+    fun runGate4(
+        rule: SigmaRule,
+        truePositives: List<Map<String, Any?>>,
+        trueNegatives: List<Map<String, Any?>>,
+        iocStubs: Map<String, Set<String>> = emptyMap()
+    ): Gate4Result {
+        val errors = mutableListOf<String>()
+
+        // Build iocLookups: each stub key maps to a lambda that checks set membership.
+        val iocLookups: Map<String, (Any) -> Boolean> = iocStubs.mapValues { (_, stubSet) ->
+            { value: Any -> value.toString() in stubSet }
+        }
+
+        // Warn if any iocStubs key is not referenced by any IOC_LOOKUP matcher in the rule.
+        val referencedLookupNames: Set<String> = rule.detection.selections.values
+            .flatMap { selection -> selection.fieldMatchers }
+            .filter { matcher -> matcher.modifier == SigmaModifier.IOC_LOOKUP }
+            .flatMap { matcher -> matcher.values.mapNotNull { it?.toString() } }
+            .toSet()
+
+        for (stubKey in iocStubs.keys) {
+            if (stubKey !in referencedLookupNames) {
+                errors.add(
+                    "WARNING: iocStub key \"$stubKey\" is not referenced by any " +
+                        "IOC_LOOKUP matcher in rule \"${rule.id}\". This may be a fixture typo."
+                )
+            }
+        }
+
+        // Evaluate true positives — each must produce >= 1 finding.
+        var allTpFired = true
+        truePositives.forEachIndexed { index, record ->
+            val findings = SigmaRuleEvaluator.evaluate(
+                rules = listOf(rule),
+                records = listOf(record),
+                service = rule.service,
+                iocLookups = iocLookups
+            )
+            if (findings.isEmpty()) {
+                allTpFired = false
+                errors.add(
+                    "TP[$index] FAILED: expected >= 1 finding but got 0 for rule \"${rule.id}\". " +
+                        "Record: $record"
+                )
+            }
+        }
+
+        // Evaluate true negatives — each must produce 0 findings.
+        var allTnClean = true
+        trueNegatives.forEachIndexed { index, record ->
+            val findings = SigmaRuleEvaluator.evaluate(
+                rules = listOf(rule),
+                records = listOf(record),
+                service = rule.service,
+                iocLookups = iocLookups
+            )
+            if (findings.isNotEmpty()) {
+                allTnClean = false
+                errors.add(
+                    "TN[$index] FAILED: expected 0 findings but got ${findings.size} " +
+                        "for rule \"${rule.id}\". Record: $record"
+                )
+            }
+        }
+
+        return Gate4Result(
+            pass = allTpFired && allTnClean,
+            tpFired = allTpFired,
+            tnClean = allTnClean,
+            errors = errors
+        )
+    }
+}

--- a/app/src/test/java/com/androdr/sigma/GateFourTestHarness.kt
+++ b/app/src/test/java/com/androdr/sigma/GateFourTestHarness.kt
@@ -55,6 +55,12 @@ object GateFourTestHarness {
             }
         }
 
+        // Guard: at least one TP record is required to prevent vacuous pass
+        if (truePositives.isEmpty()) {
+            errors.add("No true-positive records provided — fixture must include at least one TP")
+            return Gate4Result(pass = false, tpFired = false, tnClean = true, errors = errors)
+        }
+
         // Evaluate true positives — each must produce >= 1 finding.
         var allTpFired = true
         truePositives.forEachIndexed { index, record ->

--- a/app/src/test/resources/gate4-fixtures/accessibility-atom.yml
+++ b/app/src/test/resources/gate4-fixtures/accessibility-atom.yml
@@ -1,0 +1,20 @@
+# Fixture for androdr-060: active accessibility service detection
+rule_file: sigma_androdr_060_active_accessibility.yml
+service: accessibility_audit
+ioc_stubs:
+  known_good_app_db:
+    - "com.lastpass.lpandroid"
+true_positives:
+  - package_name: "com.shady.keylogger"
+    is_system_app: false
+    is_enabled: true
+true_negatives:
+  - package_name: "com.lastpass.lpandroid"
+    is_system_app: false
+    is_enabled: true
+  - package_name: "com.android.talkback"
+    is_system_app: true
+    is_enabled: true
+  - package_name: "com.shady.keylogger"
+    is_system_app: false
+    is_enabled: false

--- a/app/src/test/resources/gate4-fixtures/package-ioc.yml
+++ b/app/src/test/resources/gate4-fixtures/package-ioc.yml
@@ -1,0 +1,15 @@
+# Fixture for androdr-001: package name IOC lookup
+rule_file: sigma_androdr_001_package_ioc.yml
+service: app_scanner
+ioc_stubs:
+  package_ioc_db:
+    - "com.thetruthspy"
+    - "com.flexispy.app"
+true_positives:
+  - package_name: "com.thetruthspy"
+    is_system_app: false
+true_negatives:
+  - package_name: "com.thetruthspy"
+    is_system_app: true
+  - package_name: "com.google.android.gm"
+    is_system_app: false

--- a/app/src/test/resources/gate4-fixtures/sideloaded-app.yml
+++ b/app/src/test/resources/gate4-fixtures/sideloaded-app.yml
@@ -1,0 +1,20 @@
+# Fixture for androdr-010: sideloaded app detection
+rule_file: sigma_androdr_010_sideloaded_app.yml
+service: app_scanner
+ioc_stubs:
+  known_good_app_db:
+    - "com.google.android.gm"
+true_positives:
+  - package_name: "com.shady.sideload"
+    is_system_app: false
+    from_trusted_store: false
+    is_known_oem_app: false
+true_negatives:
+  - package_name: "com.google.android.gm"
+    is_system_app: false
+    from_trusted_store: false
+    is_known_oem_app: false
+  - package_name: "com.example.legitimate"
+    is_system_app: false
+    from_trusted_store: true
+    is_known_oem_app: false

--- a/docs/superpowers/specs/2026-04-12-gate4-harness-and-ioc-source-design.md
+++ b/docs/superpowers/specs/2026-04-12-gate4-harness-and-ioc-source-design.md
@@ -146,7 +146,7 @@ fixture file becomes one test case. The test:
     "url": "https://threatfox.abuse.ch"
   },
   {
-    "id": "amnesty-investigations",
+    "id": "amnesty-tech",
     "name": "Amnesty International Security Lab",
     "url": "https://github.com/AmnestyTech/investigations"
   },
@@ -187,7 +187,8 @@ fixture file becomes one test case. The test:
 4. **Blocked family patterns** — reject entries where family/familyName contains
    "test", "fixture", "simulation", "sample", "example" (case-insensitive)
 5. **Cert hash format** — if entry has `indicator` that looks like a hash (in
-   `cert-hashes.yml`), must be exactly 64 lowercase hex chars
+   `cert-hashes.yml`), must be 64 lowercase hex chars (SHA-256) or 40
+   lowercase hex chars (SHA-1)
 6. **No duplicates** — no repeated `indicator` values within the same file
 
 **Exit codes:** 0 = valid, 1 = validation errors, 2 = file not found / parse error

--- a/scripts/merge-ioc-data.py
+++ b/scripts/merge-ioc-data.py
@@ -18,6 +18,11 @@ import yaml
 
 
 REPO_URL = "https://github.com/android-sigma-rules/rules.git"
+
+ALLOWED_SOURCES_PATH = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "..",
+    "third-party", "android-sigma-rules", "validation", "allowed-sources.json"
+)
 DEFAULT_CLONE_DIR = "/tmp/androdr-rules-merge"
 
 BUNDLED_PACKAGES = "app/src/main/res/raw/known_bad_packages.json"
@@ -29,6 +34,31 @@ def load_yaml(path):
     with open(path) as f:
         data = yaml.safe_load(f)
     return data.get("entries", []) if data else []
+
+
+def load_allowed_sources():
+    """Load allowed source IDs from the submodule registry."""
+    if not os.path.exists(ALLOWED_SOURCES_PATH):
+        print(f"WARNING: allowed-sources.json not found at {ALLOWED_SOURCES_PATH}", file=sys.stderr)
+        print("  Skipping source validation (submodule may not be initialized)", file=sys.stderr)
+        return None
+    with open(ALLOWED_SOURCES_PATH) as f:
+        entries = json.load(f)
+    return {entry["id"] for entry in entries}
+
+
+def validate_sources(entries, allowed_sources):
+    """Validate source field on all entries. Return list of errors."""
+    if allowed_sources is None:
+        return []
+    errors = []
+    for i, entry in enumerate(entries):
+        source = entry.get("source")
+        if not source:
+            errors.append(f"Entry {i}: missing 'source' field (indicator: {entry.get('indicator', '?')})")
+        elif source not in allowed_sources:
+            errors.append(f"Entry {i}: unknown source '{source}' (indicator: {entry.get('indicator', '?')})")
+    return errors
 
 
 def merge_packages(entries, bundled_path):
@@ -129,14 +159,32 @@ def main():
     print("Merging IOC data from public repo into bundled files...")
 
     pkg_path = os.path.join(repo_dir, "ioc-data", "package-names.yml")
+    cert_path = os.path.join(repo_dir, "ioc-data", "cert-hashes.yml")
+    domain_path = os.path.join(repo_dir, "ioc-data", "c2-domains.yml")
+
+    allowed_sources = load_allowed_sources()
+
+    # Validate all source entries before merging
+    all_errors = []
+    for label, ioc_file in [("packages", pkg_path), ("certs", cert_path), ("domains", domain_path)]:
+        if os.path.exists(ioc_file):
+            entries = load_yaml(ioc_file)
+            errs = validate_sources(entries, allowed_sources)
+            if errs:
+                all_errors.extend([f"[{label}] {e}" for e in errs])
+
+    if all_errors:
+        print(f"ERROR: Source validation failed ({len(all_errors)} error(s)):", file=sys.stderr)
+        for err in all_errors:
+            print(f"  - {err}", file=sys.stderr)
+        sys.exit(1)
+
     if os.path.exists(pkg_path):
         merge_packages(load_yaml(pkg_path), BUNDLED_PACKAGES)
 
-    cert_path = os.path.join(repo_dir, "ioc-data", "cert-hashes.yml")
     if os.path.exists(cert_path):
         merge_certs(load_yaml(cert_path), BUNDLED_CERTS)
 
-    domain_path = os.path.join(repo_dir, "ioc-data", "c2-domains.yml")
     if os.path.exists(domain_path):
         merge_domains(load_yaml(domain_path), BUNDLED_DOMAINS)
 


### PR DESCRIPTION
## Summary

- Add `GateFourTestHarness` — programmatic dry-run evaluator for SIGMA rules with stub IOC lookups
- Add 3 fixture YAML files (sideloaded-app, package-ioc, accessibility-atom) with parameterized JUnit runner
- Add `allowed-sources.json` — canonical source registry with id/name/url for IOC provenance
- Add `validate-ioc-data.py` — IOC data validator enforcing source, categories, cert format, duplicates
- Add source validation gate to `merge-ioc-data.py` (rejects entries with missing/unknown source)
- Rewrite Gate 4 + IOC sections in `update-rules-validate` skill

Closes #106

## Test plan

- [ ] `GateFourFixtureTest` passes all 3 fixtures (sideloaded-app, package-ioc, accessibility-atom)
- [ ] `validate-ioc-data.py` passes on all 4 IOC data files (package-names, cert-hashes, c2-domains, malware-hashes)
- [ ] `merge-ioc-data.py` rejects entries with invalid source field
- [ ] Full unit test suite passes (`./gradlew testDebugUnitTest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)