### PR TITLE
docs: clarify PR workflow targets main

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,8 +67,10 @@ app/src/main/java/com/androdr/
 - **ReportExporter** is a `@Singleton`; it fetches DNS events and captures
   the app's own logcat (`logcat --pid`) before writing a plaintext report
 
-## Development branch
-Active feature work lives on **`claude/android-edr-setup-rl68Y`**.
+## Development workflow
+All pull requests target **`main`**. Feature work lives on topic branches
+(e.g. `feat/<issue-number>-<short-name>`, `fix/<topic>`, `docs/<topic>`)
+branched from `main`, then merged back via PR.
 
 ## Lint / code style
 The project uses the default Android Lint configuration.  Run

--- a/app/src/main/java/com/androdr/ui/timeline/TimelineScreen.kt
+++ b/app/src/main/java/com/androdr/ui/timeline/TimelineScreen.kt
@@ -449,7 +449,10 @@ fun TimelineScreen(
                     }
                     items(
                         items = group.findingRows,
-                        key = { "finding_${it.finding.ruleId}_${it.finding.matchContext["package_name"].orEmpty()}_${it.timestamp}" }
+                        key = {
+                            val pkg = it.finding.matchContext["package_name"].orEmpty()
+                            "finding_${it.finding.ruleId}_${pkg}_${it.timestamp}"
+                        }
                     ) { row ->
                         FindingCard(
                             row = row,

--- a/app/src/test/java/com/androdr/sigma/GateFourTestHarness.kt
+++ b/app/src/test/java/com/androdr/sigma/GateFourTestHarness.kt
@@ -61,41 +61,22 @@ object GateFourTestHarness {
             return Gate4Result(pass = false, tpFired = false, tnClean = true, errors = errors)
         }
 
-        // Evaluate true positives — each must produce >= 1 finding.
-        var allTpFired = true
-        truePositives.forEachIndexed { index, record ->
-            val findings = SigmaRuleEvaluator.evaluate(
-                rules = listOf(rule),
-                records = listOf(record),
-                service = rule.service,
-                iocLookups = iocLookups
-            )
-            if (findings.isEmpty()) {
-                allTpFired = false
-                errors.add(
-                    "TP[$index] FAILED: expected >= 1 finding but got 0 for rule \"${rule.id}\". " +
-                        "Record: $record"
-                )
-            }
-        }
-
-        // Evaluate true negatives — each must produce 0 findings.
-        var allTnClean = true
-        trueNegatives.forEachIndexed { index, record ->
-            val findings = SigmaRuleEvaluator.evaluate(
-                rules = listOf(rule),
-                records = listOf(record),
-                service = rule.service,
-                iocLookups = iocLookups
-            )
-            if (findings.isNotEmpty()) {
-                allTnClean = false
-                errors.add(
-                    "TN[$index] FAILED: expected 0 findings but got ${findings.size} " +
-                        "for rule \"${rule.id}\". Record: $record"
-                )
-            }
-        }
+        val allTpFired = evaluateFixtures(
+            rule = rule,
+            records = truePositives,
+            iocLookups = iocLookups,
+            errors = errors,
+            label = "TP",
+            shouldFire = true,
+        )
+        val allTnClean = evaluateFixtures(
+            rule = rule,
+            records = trueNegatives,
+            iocLookups = iocLookups,
+            errors = errors,
+            label = "TN",
+            shouldFire = false,
+        )
 
         return Gate4Result(
             pass = allTpFired && allTnClean,
@@ -103,5 +84,46 @@ object GateFourTestHarness {
             tnClean = allTnClean,
             errors = errors
         )
+    }
+
+    /**
+     * Evaluates [records] against [rule]. When [shouldFire] is true, each record
+     * must produce >= 1 finding (true-positive semantics); when false, each must
+     * produce 0 findings (true-negative semantics). Records that violate the
+     * expectation are reported in [errors] with the given [label]. Returns true
+     * if every record behaved as expected.
+     */
+    @Suppress("LongParameterList")
+    private fun evaluateFixtures(
+        rule: SigmaRule,
+        records: List<Map<String, Any?>>,
+        iocLookups: Map<String, (Any) -> Boolean>,
+        errors: MutableList<String>,
+        label: String,
+        shouldFire: Boolean,
+    ): Boolean {
+        var allPassed = true
+        records.forEachIndexed { index, record ->
+            val findings = SigmaRuleEvaluator.evaluate(
+                rules = listOf(rule),
+                records = listOf(record),
+                service = rule.service,
+                iocLookups = iocLookups
+            )
+            val fired = findings.isNotEmpty()
+            if (fired != shouldFire) {
+                allPassed = false
+                errors.add(
+                    if (shouldFire) {
+                        "$label[$index] FAILED: expected >= 1 finding but got 0 for " +
+                            "rule \"${rule.id}\". Record: $record"
+                    } else {
+                        "$label[$index] FAILED: expected 0 findings but got ${findings.size} " +
+                            "for rule \"${rule.id}\". Record: $record"
+                    }
+                )
+            }
+        }
+        return allPassed
     }
 }


### PR DESCRIPTION
## Summary

- Replace the outdated \`Development branch\` section in CLAUDE.md (which pointed at a stale mirror branch) with a \`Development workflow\` section describing the actual practice: PRs target \`main\`, feature work lives on topic branches.
- Companion cleanup: delete the obsolete \`claude/android-edr-setup-rl68Y\` mirror branch after this merges (tracked in follow-up — the branch no longer serves any purpose and has caused repeated confusion when creating PRs).

## Test plan

- [x] \`grep claude/android-edr-setup-rl68Y CLAUDE.md\` returns no matches after this change
- [x] Recent PRs (#110, #112, #113, #114) all confirmed to have \`baseRefName: main\`
- [ ] After merge: \`git push origin --delete claude/android-edr-setup-rl68Y\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)