### PR TITLE
docs: recover Bundle 1b and 1c implementation plans

### DIFF
--- a/docs/superpowers/plans/2026-04-12-gate4-harness-and-ioc-source.md
+++ b/docs/superpowers/plans/2026-04-12-gate4-harness-and-ioc-source.md
@@ -1,0 +1,808 @@
+# Gate 4 Harness + IOC Source Validation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Gate 4 (dry-run evaluation) programmatic and enforce IOC data source provenance.
+
+**Architecture:** Kotlin test harness wraps `SigmaRuleEvaluator.evaluate()` with stub IOC lookups, driven by YAML fixture files. Python script validates IOC data entries against a shared `allowed-sources.json` registry. `merge-ioc-data.py` gains a pre-merge validation pass.
+
+**Tech Stack:** Kotlin + JUnit 5 parameterized tests, snakeyaml-engine (already a dependency), Python 3.
+
+---
+
+## File Map
+
+| Action | Path | Responsibility |
+|--------|------|----------------|
+| Create | `app/src/test/java/com/androdr/sigma/GateFourTestHarness.kt` | Harness API: (rule, TP, TN, stubs) → Gate4Result |
+| Create | `app/src/test/java/com/androdr/sigma/GateFourFixtureTest.kt` | Parameterized test loading fixtures |
+| Create | `app/src/test/resources/gate4-fixtures/sideloaded-app.yml` | Fixture: androdr-010 simple selection |
+| Create | `app/src/test/resources/gate4-fixtures/package-ioc.yml` | Fixture: androdr-001 ioc_lookup |
+| Create | `app/src/test/resources/gate4-fixtures/accessibility-atom.yml` | Fixture: androdr-060 atom rule |
+| Create | `third-party/android-sigma-rules/validation/allowed-sources.json` | Source registry (id, name, url) |
+| Create | `third-party/android-sigma-rules/validation/validate-ioc-data.py` | IOC data validator script |
+| Modify | `scripts/merge-ioc-data.py` | Add source validation before merge |
+| Modify | `.claude/commands/update-rules-validate.md` | Rewrite Gate 4 section |
+
+---
+
+## Task 1: Gate4Result Data Class + GateFourTestHarness
+
+**Files:**
+- Create: `app/src/test/java/com/androdr/sigma/GateFourTestHarness.kt`
+
+- [ ] **Step 1: Create the harness file with data class and object**
+
+```kotlin
+// app/src/test/java/com/androdr/sigma/GateFourTestHarness.kt
+package com.androdr.sigma
+
+/**
+ * Programmatic Gate 4 dry-run evaluator.
+ * Tests that a SIGMA rule fires on true-positive telemetry
+ * and does NOT fire on true-negative telemetry.
+ */
+data class Gate4Result(
+    val pass: Boolean,
+    val tpFired: Boolean,
+    val tnClean: Boolean,
+    val errors: List<String>
+)
+
+object GateFourTestHarness {
+
+    fun runGate4(
+        rule: SigmaRule,
+        truePositives: List<Map<String, Any?>>,
+        trueNegatives: List<Map<String, Any?>>,
+        iocStubs: Map<String, Set<String>> = emptyMap()
+    ): Gate4Result {
+        val errors = mutableListOf<String>()
+
+        // Build iocLookups from stubs
+        val iocLookups: Map<String, (Any) -> Boolean> = iocStubs.mapValues { (_, allowed) ->
+            { value: Any -> value.toString() in allowed }
+        }
+
+        // Warn on unused stubs
+        val referencedLookups = rule.detection.selections.values
+            .flatMap { it.fieldMatchers }
+            .filter { it.modifier == SigmaModifier.IOC_LOOKUP }
+            .mapNotNull { it.values.firstOrNull()?.toString() }
+            .toSet()
+        for (stubKey in iocStubs.keys) {
+            if (stubKey !in referencedLookups) {
+                errors.add("WARNING: iocStub '$stubKey' is not referenced by rule '${rule.id}'")
+            }
+        }
+
+        // Evaluate true positives
+        var tpFired = true
+        truePositives.forEachIndexed { idx, record ->
+            val findings = SigmaRuleEvaluator.evaluate(
+                listOf(rule), listOf(record), rule.service, iocLookups
+            )
+            if (findings.isEmpty()) {
+                tpFired = false
+                errors.add("TP[$idx] did not fire: $record")
+            }
+        }
+
+        // Evaluate true negatives
+        var tnClean = true
+        trueNegatives.forEachIndexed { idx, record ->
+            val findings = SigmaRuleEvaluator.evaluate(
+                listOf(rule), listOf(record), rule.service, iocLookups
+            )
+            if (findings.isNotEmpty()) {
+                tnClean = false
+                errors.add("TN[$idx] fired unexpectedly (${findings.size} finding(s)): $record")
+            }
+        }
+
+        return Gate4Result(
+            pass = tpFired && tnClean && errors.none { !it.startsWith("WARNING") },
+            tpFired = tpFired,
+            tnClean = tnClean,
+            errors = errors
+        )
+    }
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `./gradlew compileTestDebugKotlin 2>&1 | tail -5`
+Expected: BUILD SUCCESSFUL
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/src/test/java/com/androdr/sigma/GateFourTestHarness.kt
+git commit -m "feat: add Gate 4 programmatic test harness (#106)"
+```
+
+---
+
+## Task 2: Fixture Files
+
+**Files:**
+- Create: `app/src/test/resources/gate4-fixtures/sideloaded-app.yml`
+- Create: `app/src/test/resources/gate4-fixtures/package-ioc.yml`
+- Create: `app/src/test/resources/gate4-fixtures/accessibility-atom.yml`
+
+- [ ] **Step 1: Create fixture directory**
+
+```bash
+mkdir -p app/src/test/resources/gate4-fixtures
+```
+
+- [ ] **Step 2: Create sideloaded-app.yml**
+
+This tests androdr-010 (simple selection with `not filter_known_good`). The rule fires when `is_system_app: false`, `from_trusted_store: false`, `is_known_oem_app: false`, AND the package is NOT in `known_good_app_db`.
+
+```yaml
+# Fixture for androdr-010: sideloaded app detection
+rule_file: sigma_androdr_010_sideloaded_app.yml
+service: app_scanner
+ioc_stubs:
+  known_good_app_db:
+    - "com.google.android.gm"
+true_positives:
+  - package_name: "com.shady.sideload"
+    is_system_app: false
+    from_trusted_store: false
+    is_known_oem_app: false
+true_negatives:
+  # Known-good app (in stub DB) — filtered out by condition
+  - package_name: "com.google.android.gm"
+    is_system_app: false
+    from_trusted_store: false
+    is_known_oem_app: false
+  # Trusted store app — selection doesn't match
+  - package_name: "com.example.legitimate"
+    is_system_app: false
+    from_trusted_store: true
+    is_known_oem_app: false
+```
+
+- [ ] **Step 3: Create package-ioc.yml**
+
+This tests androdr-001 (ioc_lookup on `package_ioc_db` with system app filter).
+
+```yaml
+# Fixture for androdr-001: package name IOC lookup
+rule_file: sigma_androdr_001_package_ioc.yml
+service: app_scanner
+ioc_stubs:
+  package_ioc_db:
+    - "com.thetruthspy"
+    - "com.flexispy.app"
+true_positives:
+  - package_name: "com.thetruthspy"
+    is_system_app: false
+true_negatives:
+  # System app with matching package — filtered by condition
+  - package_name: "com.thetruthspy"
+    is_system_app: true
+  # Non-matching package
+  - package_name: "com.google.android.gm"
+    is_system_app: false
+```
+
+- [ ] **Step 4: Create accessibility-atom.yml**
+
+This tests androdr-060 (accessibility_audit service, atom rule).
+
+```yaml
+# Fixture for androdr-060: active accessibility service detection
+rule_file: sigma_androdr_060_active_accessibility.yml
+service: accessibility_audit
+ioc_stubs:
+  known_good_app_db:
+    - "com.lastpass.lpandroid"
+true_positives:
+  - package_name: "com.shady.keylogger"
+    is_system_app: false
+    is_enabled: true
+true_negatives:
+  # Known-good app — filtered out
+  - package_name: "com.lastpass.lpandroid"
+    is_system_app: false
+    is_enabled: true
+  # System app — selection doesn't match
+  - package_name: "com.android.talkback"
+    is_system_app: true
+    is_enabled: true
+  # Disabled service — selection doesn't match
+  - package_name: "com.shady.keylogger"
+    is_system_app: false
+    is_enabled: false
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/test/resources/gate4-fixtures/
+git commit -m "test: add Gate 4 fixture files for 3 representative rule types (#106)"
+```
+
+---
+
+## Task 3: GateFourFixtureTest (Parameterized Runner)
+
+**Files:**
+- Create: `app/src/test/java/com/androdr/sigma/GateFourFixtureTest.kt`
+
+- [ ] **Step 1: Create the parameterized test**
+
+```kotlin
+// app/src/test/java/com/androdr/sigma/GateFourFixtureTest.kt
+package com.androdr.sigma
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import org.snakeyaml.engine.v2.api.Load
+import org.snakeyaml.engine.v2.api.LoadSettings
+import java.io.File
+
+/**
+ * Parameterized test that runs Gate 4 dry-run evaluation for every
+ * fixture file in test resources gate4-fixtures/.
+ */
+@RunWith(Parameterized::class)
+class GateFourFixtureTest(
+    private val fixtureName: String,
+    private val fixtureFile: File
+) {
+    companion object {
+        private fun fixturesDir(): File {
+            val candidates = listOf(
+                File("app/src/test/resources/gate4-fixtures"),
+                File("src/test/resources/gate4-fixtures"),
+                File("/home/yasir/AndroDR/app/src/test/resources/gate4-fixtures"),
+            )
+            return candidates.firstOrNull { it.isDirectory }
+                ?: error("gate4-fixtures directory not found; tried: ${candidates.map { it.absolutePath }}")
+        }
+
+        private fun rulesDir(): File {
+            val candidates = listOf(
+                File("app/src/main/res/raw"),
+                File("src/main/res/raw"),
+                File("/home/yasir/AndroDR/app/src/main/res/raw"),
+            )
+            return candidates.firstOrNull { it.isDirectory }
+                ?: error("res/raw directory not found")
+        }
+
+        @JvmStatic
+        @Parameterized.Parameters(name = "{0}")
+        fun fixtures(): List<Array<Any>> {
+            return fixturesDir().listFiles { f -> f.extension == "yml" }
+                ?.sorted()
+                ?.map { arrayOf(it.nameWithoutExtension, it) as Array<Any> }
+                ?: emptyList()
+        }
+    }
+
+    private val yamlLoader = Load(
+        LoadSettings.builder()
+            .setMaxAliasesForCollections(10)
+            .setAllowDuplicateKeys(false)
+            .build()
+    )
+
+    @Test
+    fun `fixture passes Gate 4`() {
+        val fixture = parseFixture(fixtureFile)
+
+        // Load and parse the referenced rule
+        val ruleFile = File(rulesDir(), fixture.ruleFile)
+        assertTrue(
+            "Rule file not found: ${ruleFile.absolutePath}",
+            ruleFile.isFile
+        )
+        val rule = SigmaRuleParser.parse(ruleFile.readText())
+        assertNotNull("SigmaRuleParser.parse() returned null for ${fixture.ruleFile}", rule)
+
+        // Assert service matches
+        assertEquals(
+            "Fixture service '${fixture.service}' does not match rule service '${rule!!.service}'",
+            fixture.service, rule.service
+        )
+
+        // Run Gate 4
+        val result = GateFourTestHarness.runGate4(
+            rule = rule,
+            truePositives = fixture.truePositives,
+            trueNegatives = fixture.trueNegatives,
+            iocStubs = fixture.iocStubs
+        )
+
+        assertTrue(
+            "Gate 4 FAILED for $fixtureName:\n${result.errors.joinToString("\n") { "  - $it" }}",
+            result.pass
+        )
+    }
+
+    private fun parseFixture(file: File): FixtureData {
+        @Suppress("UNCHECKED_CAST")
+        val raw = yamlLoader.loadFromString(file.readText()) as Map<String, Any?>
+
+        val ruleFile = raw["rule_file"] as String
+        val service = raw["service"] as String
+
+        @Suppress("UNCHECKED_CAST")
+        val iocStubsRaw = (raw["ioc_stubs"] as? Map<String, List<String>>) ?: emptyMap()
+        val iocStubs = iocStubsRaw.mapValues { (_, v) -> v.toSet() }
+
+        @Suppress("UNCHECKED_CAST")
+        val tp = (raw["true_positives"] as? List<Map<String, Any?>>) ?: emptyList()
+        @Suppress("UNCHECKED_CAST")
+        val tn = (raw["true_negatives"] as? List<Map<String, Any?>>) ?: emptyList()
+
+        return FixtureData(ruleFile, service, iocStubs, tp, tn)
+    }
+
+    private data class FixtureData(
+        val ruleFile: String,
+        val service: String,
+        val iocStubs: Map<String, Set<String>>,
+        val truePositives: List<Map<String, Any?>>,
+        val trueNegatives: List<Map<String, Any?>>
+    )
+}
+```
+
+- [ ] **Step 2: Run the tests**
+
+Run: `./gradlew testDebugUnitTest --tests "com.androdr.sigma.GateFourFixtureTest" 2>&1 | tail -20`
+Expected: 3 tests pass (one per fixture file)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/src/test/java/com/androdr/sigma/GateFourFixtureTest.kt
+git commit -m "test: add parameterized Gate 4 fixture runner (#106)"
+```
+
+---
+
+## Task 4: allowed-sources.json
+
+**Files:**
+- Create: `third-party/android-sigma-rules/validation/allowed-sources.json`
+
+- [ ] **Step 1: Create the file**
+
+```json
+[
+  {
+    "id": "stalkerware-indicators",
+    "name": "AssoEchap Stalkerware Indicators",
+    "url": "https://github.com/AssoEchap/stalkerware-indicators"
+  },
+  {
+    "id": "malwarebazaar",
+    "name": "abuse.ch MalwareBazaar",
+    "url": "https://bazaar.abuse.ch"
+  },
+  {
+    "id": "threatfox",
+    "name": "abuse.ch ThreatFox",
+    "url": "https://threatfox.abuse.ch"
+  },
+  {
+    "id": "amnesty-investigations",
+    "name": "Amnesty International Security Lab",
+    "url": "https://github.com/AmnestyTech/investigations"
+  },
+  {
+    "id": "citizenlab-indicators",
+    "name": "Citizen Lab Malware Indicators",
+    "url": "https://github.com/citizenlab/malware-indicators"
+  },
+  {
+    "id": "mvt-indicators",
+    "name": "MVT Project STIX2 Indicators",
+    "url": "https://github.com/mvt-project/mvt-indicators"
+  },
+  {
+    "id": "virustotal",
+    "name": "VirusTotal Intelligence",
+    "url": "https://www.virustotal.com"
+  },
+  {
+    "id": "android-security-bulletin",
+    "name": "Google Android Security Bulletins",
+    "url": "https://source.android.com/docs/security/bulletin"
+  }
+]
+```
+
+- [ ] **Step 2: Commit to submodule**
+
+```bash
+cd third-party/android-sigma-rules
+git add validation/allowed-sources.json
+git commit -m "feat: add allowed-sources.json registry for IOC provenance validation"
+git push origin main
+cd ../..
+git add third-party/android-sigma-rules
+git commit -m "build: bump android-sigma-rules submodule (allowed-sources.json)"
+```
+
+---
+
+## Task 5: validate-ioc-data.py
+
+**Files:**
+- Create: `third-party/android-sigma-rules/validation/validate-ioc-data.py`
+
+- [ ] **Step 1: Create the validator script**
+
+```python
+#!/usr/bin/env python3
+"""Validate an AndroDR IOC data YAML file.
+
+Usage: python3 validate-ioc-data.py <ioc-data-file.yml>
+
+Exit codes:
+  0 = valid
+  1 = validation errors (printed to stderr)
+  2 = file not found / parse error
+"""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:
+    sys.exit("pyyaml required: pip install pyyaml")
+
+SCRIPT_DIR = Path(__file__).parent
+BLOCKED_CATEGORIES = {"TEST", "FIXTURE", "SIMULATION", "DEBUG"}
+BLOCKED_FAMILY_PATTERNS = re.compile(
+    r"(test|fixture|simulation|sample|example)", re.IGNORECASE
+)
+HEX_SHA256 = re.compile(r"^[0-9a-f]{64}$")
+
+
+def load_allowed_sources(path: Path) -> set[str]:
+    with open(path) as f:
+        entries = json.load(f)
+    return {entry["id"] for entry in entries}
+
+
+def validate_ioc_file(data: dict, allowed_sources: set[str], filename: str) -> list[str]:
+    """Return list of error strings. Empty = valid."""
+    errors = []
+    entries = data.get("entries", [])
+    if not entries:
+        errors.append("No 'entries' list found in file")
+        return errors
+
+    seen_indicators = set()
+    is_cert_file = "cert" in filename.lower()
+
+    for idx, entry in enumerate(entries):
+        prefix = f"entries[{idx}]"
+
+        # Source field
+        source = entry.get("source")
+        if not source:
+            errors.append(f"{prefix}: missing 'source' field")
+        elif source not in allowed_sources:
+            errors.append(f"{prefix}: unknown source '{source}' (not in allowed-sources.json)")
+
+        # Blocked categories
+        category = entry.get("category", "")
+        if category.upper() in BLOCKED_CATEGORIES:
+            errors.append(f"{prefix}: blocked category '{category}'")
+
+        # Blocked family patterns
+        family = entry.get("family", "") or entry.get("familyName", "")
+        if family and BLOCKED_FAMILY_PATTERNS.search(family):
+            errors.append(f"{prefix}: blocked family name '{family}' (matches test/fixture pattern)")
+
+        # Cert hash format
+        indicator = entry.get("indicator", "")
+        if is_cert_file and indicator:
+            if not HEX_SHA256.match(indicator):
+                errors.append(f"{prefix}: invalid cert hash format (expected 64 lowercase hex chars): '{indicator[:20]}...'")
+
+        # Duplicate check
+        if indicator:
+            if indicator in seen_indicators:
+                errors.append(f"{prefix}: duplicate indicator '{indicator}'")
+            seen_indicators.add(indicator)
+
+    return errors
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python3 validate-ioc-data.py <ioc-data-file.yml>", file=sys.stderr)
+        sys.exit(2)
+
+    ioc_path = Path(sys.argv[1])
+    if not ioc_path.exists():
+        print(f"File not found: {ioc_path}", file=sys.stderr)
+        sys.exit(2)
+
+    sources_path = SCRIPT_DIR / "allowed-sources.json"
+    if not sources_path.exists():
+        print(f"allowed-sources.json not found at: {sources_path}", file=sys.stderr)
+        sys.exit(2)
+
+    allowed_sources = load_allowed_sources(sources_path)
+
+    with open(ioc_path) as f:
+        try:
+            data = yaml.safe_load(f)
+        except yaml.YAMLError as e:
+            print(f"YAML parse error: {e}", file=sys.stderr)
+            sys.exit(2)
+
+    if not data:
+        print(f"PASS: {ioc_path.name} (empty file)")
+        sys.exit(0)
+
+    errors = validate_ioc_file(data, allowed_sources, ioc_path.name)
+
+    if errors:
+        print(f"FAIL: {ioc_path.name} — {len(errors)} error(s):", file=sys.stderr)
+        for err in errors:
+            print(f"  - {err}", file=sys.stderr)
+        sys.exit(1)
+    else:
+        print(f"PASS: {ioc_path.name}")
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 2: Test it against existing IOC data files**
+
+Run:
+```bash
+python3 third-party/android-sigma-rules/validation/validate-ioc-data.py \
+    third-party/android-sigma-rules/ioc-data/package-names.yml
+```
+Expected: `PASS: package-names.yml`
+
+Run against all IOC files:
+```bash
+for f in third-party/android-sigma-rules/ioc-data/*.yml; do
+    python3 third-party/android-sigma-rules/validation/validate-ioc-data.py "$f"
+done
+```
+Expected: All PASS. If any fail (e.g. missing `source` on some entries), fix the IOC data entries.
+
+- [ ] **Step 3: Commit to submodule**
+
+```bash
+cd third-party/android-sigma-rules
+git add validation/validate-ioc-data.py
+git commit -m "feat: add validate-ioc-data.py for source provenance enforcement"
+git push origin main
+cd ../..
+git add third-party/android-sigma-rules
+git commit -m "build: bump android-sigma-rules submodule (validate-ioc-data.py)"
+```
+
+---
+
+## Task 6: Update merge-ioc-data.py with Source Validation
+
+**Files:**
+- Modify: `scripts/merge-ioc-data.py`
+
+- [ ] **Step 1: Add source validation logic**
+
+Add after the existing imports (line 7), add:
+
+```python
+ALLOWED_SOURCES_PATH = os.path.join(
+    os.path.dirname(__file__), "..",
+    "third-party", "android-sigma-rules", "validation", "allowed-sources.json"
+)
+```
+
+Add a new function after `load_yaml`:
+
+```python
+def load_allowed_sources():
+    """Load allowed source IDs from the submodule registry."""
+    if not os.path.exists(ALLOWED_SOURCES_PATH):
+        print(f"WARNING: allowed-sources.json not found at {ALLOWED_SOURCES_PATH}", file=sys.stderr)
+        print("  Skipping source validation (submodule may not be initialized)", file=sys.stderr)
+        return None
+    with open(ALLOWED_SOURCES_PATH) as f:
+        entries = json.load(f)
+    return {entry["id"] for entry in entries}
+
+
+def validate_sources(entries, allowed_sources):
+    """Validate source field on all entries. Return list of errors."""
+    if allowed_sources is None:
+        return []
+    errors = []
+    for i, entry in enumerate(entries):
+        source = entry.get("source")
+        if not source:
+            errors.append(f"Entry {i}: missing 'source' field (indicator: {entry.get('indicator', '?')})")
+        elif source not in allowed_sources:
+            errors.append(f"Entry {i}: unknown source '{source}' (indicator: {entry.get('indicator', '?')})")
+    return errors
+```
+
+Modify `main()` — add validation before the merge calls. After `print("Merging IOC data...")` (line 129), add:
+
+```python
+    allowed_sources = load_allowed_sources()
+
+    # Validate all source entries before merging
+    all_errors = []
+    for label, path in [("packages", pkg_path), ("certs", cert_path), ("domains", domain_path)]:
+        if os.path.exists(path):
+            entries = load_yaml(path)
+            errs = validate_sources(entries, allowed_sources)
+            if errs:
+                all_errors.extend([f"[{label}] {e}" for e in errs])
+
+    if all_errors:
+        print(f"ERROR: Source validation failed ({len(all_errors)} error(s)):", file=sys.stderr)
+        for err in all_errors:
+            print(f"  - {err}", file=sys.stderr)
+        sys.exit(1)
+```
+
+- [ ] **Step 2: Test the validation gate**
+
+Create a temp file with a bad source and verify rejection:
+```bash
+cat > /tmp/test-bad-source.yml << 'EOF'
+entries:
+  - indicator: "com.evil.app"
+    family: "EvilApp"
+    category: "MALWARE"
+    severity: "CRITICAL"
+    source: "my-random-blog"
+EOF
+python3 scripts/merge-ioc-data.py --repo-dir /tmp/test-ioc-reject
+```
+Expected: exit code 1, error about unknown source
+
+Run with real data (existing submodule):
+```bash
+python3 scripts/merge-ioc-data.py --repo-dir third-party/android-sigma-rules
+```
+Expected: merges successfully (all existing entries have valid sources)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/merge-ioc-data.py
+git commit -m "feat: enforce IOC source validation in merge-ioc-data.py (#106)"
+```
+
+---
+
+## Task 7: Update update-rules-validate.md Skill
+
+**Files:**
+- Modify: `.claude/commands/update-rules-validate.md`
+
+- [ ] **Step 1: Rewrite Gate 4 section**
+
+Replace the existing Gate 4 section (lines 64-83) with:
+
+```markdown
+## Gate 4: Dry-Run Evaluation
+
+Use the programmatic Gate 4 test harness to verify rule logic.
+
+1. **Create a fixture YAML** in `/tmp/gate4-fixture.yml`:
+
+```yaml
+rule_file: sigma_androdr_NNN_rule_name.yml
+service: <logsource.service from the rule>
+ioc_stubs:
+  <lookup_db_name>:
+    - "<indicator_from_SIR>"
+true_positives:
+  - <field_name>: <value_from_SIR_that_should_trigger>
+    <field2>: <value2>
+true_negatives:
+  - <field_name>: <benign_value>
+    <field2>: <value2>
+```
+
+2. **Copy the fixture** to `app/src/test/resources/gate4-fixtures/` (temporary — remove after validation)
+
+3. **Run the harness:**
+```bash
+./gradlew testDebugUnitTest --tests "com.androdr.sigma.GateFourFixtureTest"
+```
+
+4. **Record results:**
+   - If the test passes: `tp_fired: true`, `tn_clean: true`
+   - If it fails: record which records failed and why
+
+**Fixture tips:**
+- For `ioc_lookup` rules: stub the DB name with indicators from the SIR
+- For simple selection rules: set fields to matching values for TP, non-matching for TN
+- The harness uses stubbed IOC lookups (not real data) — this tests rule wiring only
+- Use `benign-app.json` / `benign-device.json` from `validation/test-fixtures/` as TN templates
+
+Record: `{ pass: bool, tp_fired: bool, tn_clean: bool, errors: string[] }`
+```
+
+- [ ] **Step 2: Update IOC Data Validation section**
+
+Replace the paragraph starting "When the pipeline produces IOC data entries" to reference the script:
+
+```markdown
+## IOC Data Validation
+
+When the pipeline produces IOC data entries (for `ioc-data/*.yml`), validate with:
+
+```bash
+python3 third-party/android-sigma-rules/validation/validate-ioc-data.py <ioc-data-file.yml>
+```
+
+The script enforces:
+- `source` field present and in `allowed-sources.json`
+- No blocked categories (TEST, FIXTURE, SIMULATION, DEBUG)
+- No blocked family patterns (test/fixture/simulation/sample/example)
+- Cert hashes: 64 lowercase hex
+- No duplicate indicators
+
+Exit 0 = valid, exit 1 = errors printed to stderr.
+
+### Allowed sources
+
+See `third-party/android-sigma-rules/validation/allowed-sources.json` for the canonical list with URLs.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .claude/commands/update-rules-validate.md
+git commit -m "docs: update validate skill with Gate 4 harness + IOC validator instructions (#106)"
+```
+
+---
+
+## Task 8: Integration Verification
+
+- [ ] **Step 1: Run the full test suite to confirm nothing broke**
+
+Run: `./gradlew testDebugUnitTest 2>&1 | tail -20`
+Expected: BUILD SUCCESSFUL, all tests pass
+
+- [ ] **Step 2: Run IOC validation on all bundled IOC data**
+
+```bash
+for f in third-party/android-sigma-rules/ioc-data/*.yml; do
+    python3 third-party/android-sigma-rules/validation/validate-ioc-data.py "$f"
+done
+```
+Expected: All PASS
+
+- [ ] **Step 3: Final commit if any fixups needed, then push branch**
+
+```bash
+git push origin HEAD
+```

--- a/docs/superpowers/plans/2026-04-13-ai-rule-framework-01c-staging-rerun-and-proof.md
+++ b/docs/superpowers/plans/2026-04-13-ai-rule-framework-01c-staging-rerun-and-proof.md
@@ -1,0 +1,637 @@
+# Sub-plan 1c: Staging Rerun + End-to-End Proof
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Re-validate 5 staging rules, decide promote/reject for each, run `/update-rules source stalkerware` end-to-end, and promote at least one AI-generated rule to production — proving the full pipeline works.
+
+**Architecture:** Fix staging rules to pass the updated validator (add top-level `category`, renumber ID collision), write Gate 4 fixtures for promoted rules, copy to `app/src/main/res/raw/`, run Gradle gate. Then run the `/update-rules` skill for a live stalkerware feed ingest + rule generation cycle.
+
+**Tech Stack:** YAML rule files, Python validator (`validate-rule.py`), Kotlin Gate 4 harness + Gradle build gate (`BundledRulesSchemaCrossCheckTest`), `/update-rules` AI skill pipeline.
+
+**Tracking:** Epic #104, issue #107. PR closes #107.
+
+---
+
+## File Map
+
+| Action | Path | Responsibility |
+|--------|------|----------------|
+| Modify | `third-party/android-sigma-rules/staging/app_scanner/androdr_071_popular_app_impersonation.yml` | Renumber ID 071→077, add top-level `category` |
+| Modify | `third-party/android-sigma-rules/staging/app_scanner/androdr_069_overlay_permission.yml` | Add top-level `category`, demote level to medium |
+| Modify | `third-party/android-sigma-rules/staging/device_auditor/androdr_051_cellebrite_cves.yml` | Add top-level `category` |
+| Modify | `third-party/android-sigma-rules/staging/dns_monitor/androdr_070_ddns_c2.yml` | Add top-level `category` |
+| Modify | `third-party/android-sigma-rules/staging/receiver_audit/androdr_066_boot_persistence.yml` | Add top-level `category`, demote level to low |
+| Copy→Create | `app/src/main/res/raw/sigma_androdr_051_cellebrite_cves.yml` | Promoted staging rule |
+| Copy→Create | `app/src/main/res/raw/sigma_androdr_070_ddns_c2.yml` | Promoted staging rule |
+| Copy→Create | `app/src/main/res/raw/sigma_androdr_069_overlay_permission.yml` | Promoted staging rule |
+| Copy→Create | `app/src/main/res/raw/sigma_androdr_066_boot_persistence.yml` | Promoted staging rule |
+| Copy→Create | `app/src/main/res/raw/sigma_androdr_077_popular_app_impersonation.yml` | Promoted staging rule (renumbered from 071) |
+| Create | `app/src/test/resources/gate4-fixtures/cellebrite-cves.yml` | Gate 4 fixture for androdr-051 |
+| Create | `app/src/test/resources/gate4-fixtures/ddns-c2.yml` | Gate 4 fixture for androdr-070 |
+| Create | `app/src/test/resources/gate4-fixtures/overlay-permission.yml` | Gate 4 fixture for androdr-069 |
+| Create | `app/src/test/resources/gate4-fixtures/boot-persistence.yml` | Gate 4 fixture for androdr-066 |
+| Create | `app/src/test/resources/gate4-fixtures/popular-app-impersonation.yml` | Gate 4 fixture for androdr-077 |
+| Create | `docs/decisions/2026-04-13-staging-rule-triage.md` | Decision log for all 5 staging rules |
+| Create | Gate 4 fixture(s) for any rules produced by `/update-rules` run | TBD path — depends on rule output |
+| Copy→Create | `app/src/main/res/raw/sigma_androdr_NNN_*.yml` | At least one rule from `/update-rules` run |
+| Modify | `third-party/android-sigma-rules/feed-state.json` | Updated cursor after stalkerware feed ingest |
+
+---
+
+## Staging Rule Triage Decisions
+
+Based on rule analysis against the updated validator and schema:
+
+| Rule | ID | Decision | Rationale |
+|------|-----|----------|-----------|
+| Cellebrite CVEs | 051 | **Promote** | Specific CVE-based detection, strong references (Amnesty International), critical severity justified. Just needs top-level `category: device_posture`. |
+| DDNS C2 | 070 | **Promote** | `domain\|endswith` is correct for DDNS suffixes (not individual IOCs — `ioc_lookup` would be wrong here). Comprehensive provider list. Needs top-level `category: incident`. |
+| Overlay Permission | 069 | **Promote at medium** | Combined with sideload + known-good filter, this is a useful signal. Demote from `high` to `medium` — overlay permission alone is common. Needs `category: incident`. |
+| Boot Persistence | 066 | **Promote at low** | Boot receivers are extremely common among legitimate apps, but with known-good filter it adds triage value. Demote from `medium` to `low`. Needs `category: incident`. |
+| Popular App Impersonation | 071→077 | **Renumber + Promote** | ID collides with production `crash_loop_anti_forensics`. Renumber to 077 (next available). Solid detection — sideloaded + prefix match + known-good filter. Needs `category: incident`. |
+
+**All 5 rules are missing the top-level `category` field** (required since sub-plan 1a synced the schema). This is the expected failure — staging rules predate the schema update.
+
+---
+
+## Task 1: Branch Setup + Initial Validation Baseline
+
+**Files:**
+- Read: all 5 staging rules, `validate-rule.py`, `rule-schema.json`
+
+- [ ] **Step 1: Create feature branch**
+
+```bash
+git checkout claude/android-edr-setup-rl68Y
+git pull origin claude/android-edr-setup-rl68Y
+git checkout -b feat/107-staging-rerun-e2e-proof
+```
+
+- [ ] **Step 2: Run Python validator against all 5 staging rules to document baseline failures**
+
+```bash
+cd third-party/android-sigma-rules
+python3 validation/validate-rule.py staging/device_auditor/androdr_051_cellebrite_cves.yml
+python3 validation/validate-rule.py staging/dns_monitor/androdr_070_ddns_c2.yml
+python3 validation/validate-rule.py staging/app_scanner/androdr_069_overlay_permission.yml
+python3 validation/validate-rule.py staging/receiver_audit/androdr_066_boot_persistence.yml
+python3 validation/validate-rule.py staging/app_scanner/androdr_071_popular_app_impersonation.yml
+cd ../..
+```
+
+Expected: All 5 FAIL with "Missing required field: category". Rule 071 may also fail on ID collision if the validator checks uniqueness (it doesn't currently, but document the observation).
+
+- [ ] **Step 3: Record the baseline failures** (note exact error messages for the decision log)
+
+---
+
+## Task 2: Fix Staging Rules — Add Top-Level `category` and Renumber 071
+
+**Files:**
+- Modify: `third-party/android-sigma-rules/staging/device_auditor/androdr_051_cellebrite_cves.yml`
+- Modify: `third-party/android-sigma-rules/staging/dns_monitor/androdr_070_ddns_c2.yml`
+- Modify: `third-party/android-sigma-rules/staging/app_scanner/androdr_069_overlay_permission.yml`
+- Modify: `third-party/android-sigma-rules/staging/receiver_audit/androdr_066_boot_persistence.yml`
+- Modify: `third-party/android-sigma-rules/staging/app_scanner/androdr_071_popular_app_impersonation.yml`
+
+- [ ] **Step 1: Add `category: device_posture` to androdr-051 (Cellebrite CVEs)**
+
+Insert after `status: experimental`:
+
+```yaml
+category: device_posture
+```
+
+- [ ] **Step 2: Add `category: incident` to androdr-070 (DDNS C2)**
+
+Insert after `status: experimental`:
+
+```yaml
+category: incident
+```
+
+- [ ] **Step 3: Add `category: incident` to androdr-069 (overlay permission) and demote level**
+
+Insert after `status: experimental`:
+
+```yaml
+category: incident
+```
+
+Change `level: high` to `level: medium`.
+
+- [ ] **Step 4: Add `category: incident` to androdr-066 (boot persistence) and demote level**
+
+Insert after `status: experimental`:
+
+```yaml
+category: incident
+```
+
+Change `level: medium` to `level: low`.
+
+- [ ] **Step 5: Renumber androdr-071 → androdr-077 (popular app impersonation)**
+
+In `third-party/android-sigma-rules/staging/app_scanner/androdr_071_popular_app_impersonation.yml`:
+
+Change `id: androdr-071` to `id: androdr-077`.
+
+Add after `status: experimental`:
+
+```yaml
+category: incident
+```
+
+Rename the file:
+
+```bash
+cd third-party/android-sigma-rules/staging/app_scanner
+git mv androdr_071_popular_app_impersonation.yml androdr_077_popular_app_impersonation.yml
+cd ../../../..
+```
+
+- [ ] **Step 6: Re-run validator on all 5 fixed rules**
+
+```bash
+cd third-party/android-sigma-rules
+python3 validation/validate-rule.py staging/device_auditor/androdr_051_cellebrite_cves.yml
+python3 validation/validate-rule.py staging/dns_monitor/androdr_070_ddns_c2.yml
+python3 validation/validate-rule.py staging/app_scanner/androdr_069_overlay_permission.yml
+python3 validation/validate-rule.py staging/receiver_audit/androdr_066_boot_persistence.yml
+python3 validation/validate-rule.py staging/app_scanner/androdr_077_popular_app_impersonation.yml
+cd ../..
+```
+
+Expected: All 5 PASS.
+
+- [ ] **Step 7: Commit submodule changes**
+
+```bash
+cd third-party/android-sigma-rules
+git add -A staging/
+git commit -m "fix: add top-level category to staging rules, renumber 071→077"
+cd ../..
+git add third-party/android-sigma-rules
+git commit -m "build: bump android-sigma-rules submodule (staging rule fixes)"
+```
+
+---
+
+## Task 3: Write Gate 4 Fixtures for All 5 Staging Rules
+
+**Files:**
+- Create: `app/src/test/resources/gate4-fixtures/cellebrite-cves.yml`
+- Create: `app/src/test/resources/gate4-fixtures/ddns-c2.yml`
+- Create: `app/src/test/resources/gate4-fixtures/overlay-permission.yml`
+- Create: `app/src/test/resources/gate4-fixtures/boot-persistence.yml`
+- Create: `app/src/test/resources/gate4-fixtures/popular-app-impersonation.yml`
+
+- [ ] **Step 1: Create fixture for androdr-051 (Cellebrite CVEs)**
+
+File: `app/src/test/resources/gate4-fixtures/cellebrite-cves.yml`
+
+```yaml
+rule_file: sigma_androdr_051_cellebrite_cves.yml
+service: device_auditor
+
+true_positives:
+  - unpatched_cve_id:
+      - "CVE-2024-53104"
+      - "CVE-2024-53197"
+
+  - unpatched_cve_id:
+      - "CVE-2024-50302"
+
+true_negatives:
+  - unpatched_cve_id:
+      - "CVE-2023-12345"
+
+  - unpatched_cve_id: []
+```
+
+- [ ] **Step 2: Create fixture for androdr-070 (DDNS C2)**
+
+File: `app/src/test/resources/gate4-fixtures/ddns-c2.yml`
+
+```yaml
+rule_file: sigma_androdr_070_ddns_c2.yml
+service: dns_monitor
+
+true_positives:
+  - domain: "evil.duckdns.org"
+
+  - domain: "malware.no-ip.com"
+
+  - domain: "c2.ddns.net"
+
+true_negatives:
+  - domain: "www.google.com"
+
+  - domain: "duckdns.org"
+
+  - domain: "example.com"
+```
+
+- [ ] **Step 3: Create fixture for androdr-069 (overlay permission)**
+
+File: `app/src/test/resources/gate4-fixtures/overlay-permission.yml`
+
+```yaml
+rule_file: sigma_androdr_069_overlay_permission.yml
+service: app_scanner
+
+ioc_stubs:
+  known_good_app_db:
+    - "com.legitimate.overlay"
+
+true_positives:
+  - package_name: "com.shady.banker"
+    is_system_app: false
+    from_trusted_store: false
+    permissions:
+      - "android.permission.SYSTEM_ALERT_WINDOW"
+      - "android.permission.INTERNET"
+
+true_negatives:
+  # Known-good app with overlay permission → filtered
+  - package_name: "com.legitimate.overlay"
+    is_system_app: false
+    from_trusted_store: false
+    permissions:
+      - "android.permission.SYSTEM_ALERT_WINDOW"
+
+  # System app → excluded
+  - package_name: "com.android.systemui"
+    is_system_app: true
+    from_trusted_store: false
+    permissions:
+      - "android.permission.SYSTEM_ALERT_WINDOW"
+
+  # From trusted store → excluded
+  - package_name: "com.playstore.app"
+    is_system_app: false
+    from_trusted_store: true
+    permissions:
+      - "android.permission.SYSTEM_ALERT_WINDOW"
+
+  # No overlay permission → excluded
+  - package_name: "com.shady.nooverlay"
+    is_system_app: false
+    from_trusted_store: false
+    permissions:
+      - "android.permission.INTERNET"
+```
+
+- [ ] **Step 4: Create fixture for androdr-066 (boot persistence)**
+
+File: `app/src/test/resources/gate4-fixtures/boot-persistence.yml`
+
+```yaml
+rule_file: sigma_androdr_066_boot_persistence.yml
+service: receiver_audit
+
+ioc_stubs:
+  known_good_app_db:
+    - "com.whatsapp"
+
+true_positives:
+  - package_name: "com.shady.stalker"
+    intent_action: "android.intent.action.BOOT_COMPLETED"
+    is_system_app: false
+
+  - package_name: "com.shady.stalker"
+    intent_action: "android.intent.action.LOCKED_BOOT_COMPLETED"
+    is_system_app: false
+
+true_negatives:
+  # Known-good app → filtered
+  - package_name: "com.whatsapp"
+    intent_action: "android.intent.action.BOOT_COMPLETED"
+    is_system_app: false
+
+  # System app → excluded
+  - package_name: "com.android.phone"
+    intent_action: "android.intent.action.BOOT_COMPLETED"
+    is_system_app: true
+
+  # Different intent → excluded
+  - package_name: "com.shady.stalker"
+    intent_action: "android.intent.action.PACKAGE_ADDED"
+    is_system_app: false
+```
+
+- [ ] **Step 5: Create fixture for androdr-077 (popular app impersonation, renumbered)**
+
+File: `app/src/test/resources/gate4-fixtures/popular-app-impersonation.yml`
+
+```yaml
+rule_file: sigma_androdr_077_popular_app_impersonation.yml
+service: app_scanner
+
+ioc_stubs:
+  known_good_app_db:
+    - "com.whatsapp"
+
+true_positives:
+  - package_name: "com.whatsapp.fake"
+    is_sideloaded: true
+
+  - package_name: "com.instagram.premium"
+    is_sideloaded: true
+
+  - package_name: "org.telegram.mod"
+    is_sideloaded: true
+
+true_negatives:
+  # Known-good app → filtered
+  - package_name: "com.whatsapp"
+    is_sideloaded: true
+
+  # Not sideloaded → excluded
+  - package_name: "com.whatsapp.fake"
+    is_sideloaded: false
+
+  # Unrelated package → excluded
+  - package_name: "com.example.myapp"
+    is_sideloaded: true
+```
+
+- [ ] **Step 6: Commit fixtures**
+
+```bash
+git add app/src/test/resources/gate4-fixtures/cellebrite-cves.yml
+git add app/src/test/resources/gate4-fixtures/ddns-c2.yml
+git add app/src/test/resources/gate4-fixtures/overlay-permission.yml
+git add app/src/test/resources/gate4-fixtures/boot-persistence.yml
+git add app/src/test/resources/gate4-fixtures/popular-app-impersonation.yml
+git commit -m "test: add Gate 4 fixtures for 5 staging rules"
+```
+
+---
+
+## Task 4: Promote All 5 Staging Rules to Production
+
+**Files:**
+- Create: `app/src/main/res/raw/sigma_androdr_051_cellebrite_cves.yml`
+- Create: `app/src/main/res/raw/sigma_androdr_066_boot_persistence.yml`
+- Create: `app/src/main/res/raw/sigma_androdr_069_overlay_permission.yml`
+- Create: `app/src/main/res/raw/sigma_androdr_070_ddns_c2.yml`
+- Create: `app/src/main/res/raw/sigma_androdr_077_popular_app_impersonation.yml`
+
+- [ ] **Step 1: Copy all 5 fixed staging rules to production**
+
+```bash
+cp third-party/android-sigma-rules/staging/device_auditor/androdr_051_cellebrite_cves.yml \
+   app/src/main/res/raw/sigma_androdr_051_cellebrite_cves.yml
+
+cp third-party/android-sigma-rules/staging/receiver_audit/androdr_066_boot_persistence.yml \
+   app/src/main/res/raw/sigma_androdr_066_boot_persistence.yml
+
+cp third-party/android-sigma-rules/staging/app_scanner/androdr_069_overlay_permission.yml \
+   app/src/main/res/raw/sigma_androdr_069_overlay_permission.yml
+
+cp third-party/android-sigma-rules/staging/dns_monitor/androdr_070_ddns_c2.yml \
+   app/src/main/res/raw/sigma_androdr_070_ddns_c2.yml
+
+cp third-party/android-sigma-rules/staging/app_scanner/androdr_077_popular_app_impersonation.yml \
+   app/src/main/res/raw/sigma_androdr_077_popular_app_impersonation.yml
+```
+
+- [ ] **Step 2: Run Gradle gate to verify all 53 rules pass (48 existing + 5 new)**
+
+```bash
+./gradlew testDebugUnitTest --tests "com.androdr.sigma.BundledRulesSchemaCrossCheckTest"
+```
+
+Expected: All tests PASS. If any fail, read the error output — likely a field mismatch between the YAML and what `SigmaRuleParser` expects.
+
+- [ ] **Step 3: Run Gate 4 fixture tests to verify all new fixtures pass**
+
+```bash
+./gradlew testDebugUnitTest --tests "com.androdr.sigma.GateFourFixtureTest"
+```
+
+Expected: All parameterized tests PASS (3 existing + 5 new = 8 fixtures). If any fail, the fixture's TP/TN records don't match the rule's detection logic — adjust the fixture.
+
+- [ ] **Step 4: Commit promoted rules**
+
+```bash
+git add app/src/main/res/raw/sigma_androdr_051_cellebrite_cves.yml
+git add app/src/main/res/raw/sigma_androdr_066_boot_persistence.yml
+git add app/src/main/res/raw/sigma_androdr_069_overlay_permission.yml
+git add app/src/main/res/raw/sigma_androdr_070_ddns_c2.yml
+git add app/src/main/res/raw/sigma_androdr_077_popular_app_impersonation.yml
+git commit -m "feat: promote 5 AI-generated staging rules to production
+
+First AI-generated SIGMA rules promoted via the end-to-end pipeline.
+Rules: androdr-051 (Cellebrite CVEs), androdr-066 (boot persistence),
+androdr-069 (overlay permission), androdr-070 (DDNS C2),
+androdr-077 (popular app impersonation, renumbered from 071)."
+```
+
+---
+
+## Task 5: Run `/update-rules source stalkerware` End-to-End
+
+> **Executor note:** This task invokes the `/update-rules` AI skill, which dispatches feed ingesters and the rule author pipeline. Run this in the main session, not a subagent.
+
+**Files:**
+- Read: `third-party/android-sigma-rules/feed-state.json`
+- Read: `third-party/android-sigma-rules/ioc-data/package-names.yml` (existing stalkerware IOCs)
+
+- [ ] **Step 1: Record current feed state for stalkerware**
+
+```bash
+cat third-party/android-sigma-rules/feed-state.json
+```
+
+Note the `stalkerware_indicators.last_commit_sha` value (currently `348fd7b`).
+
+- [ ] **Step 2: Index current production rules to determine next available ID**
+
+```bash
+grep -h "^id:" app/src/main/res/raw/sigma_androdr_0*.yml | sort -t'-' -k2 -n | tail -5
+```
+
+After promoting staging rules, the highest numbered ID should be 077. The next available ID for new rules is **078**.
+
+- [ ] **Step 3: Invoke `/update-rules source stalkerware`**
+
+Run the skill:
+
+```
+/update-rules source stalkerware
+```
+
+This will:
+1. Run the stalkerware feed ingester against `github.com/AssoEchap/stalkerware-indicators`
+2. Diff against existing IOC data in `ioc-data/package-names.yml` and `ioc-data/c2-domains.yml`
+3. Produce SIRs (Signal Intelligence Records) for new findings
+4. Pass SIRs to the Rule Author to generate candidate rules
+5. Run each candidate through the 5-gate validator (including the new Gate 4 harness)
+6. Present results for approval
+
+- [ ] **Step 4: Review skill output**
+
+For each candidate rule produced:
+- Verify it passed all 5 gates (especially Gate 4 dry-run)
+- Check the detection logic makes sense
+- Confirm the rule ID starts at 078+
+- Approve rules that pass; reject or request modification for rules that fail
+
+If the feed has no new indicators since `last_commit_sha: 348fd7b`, the ingester may report "no new SIRs." In that case, the skill should still produce at least one candidate from existing un-ruled indicators. If it produces nothing:
+- Check whether the ingester is reading the correct remote
+- The stalkerware-indicators repo may genuinely have no new data since April 2
+- This is acceptable — the end-to-end proof comes from the staging rules already promoted
+- Skip to Task 7 (decision log)
+
+---
+
+## Task 6: Promote End-to-End Rule(s) from `/update-rules` Output
+
+> **Conditional:** Only execute if Task 5 produced approved candidate rules. If not, skip to Task 7.
+
+**Files:**
+- Create: `app/src/main/res/raw/sigma_androdr_078_*.yml` (or whatever the skill produces)
+- Create: `app/src/test/resources/gate4-fixtures/*.yml` (fixture for each promoted rule)
+
+- [ ] **Step 1: Save approved rule(s) to staging in the submodule**
+
+For each approved candidate, the `/update-rules` skill should have already written the rule file. If it wrote to staging, verify it's there:
+
+```bash
+ls third-party/android-sigma-rules/staging/*/androdr_078*
+```
+
+- [ ] **Step 2: Copy approved rule(s) to production**
+
+```bash
+cp third-party/android-sigma-rules/staging/<service>/androdr_078_<name>.yml \
+   app/src/main/res/raw/sigma_androdr_078_<name>.yml
+```
+
+- [ ] **Step 3: Write Gate 4 fixture for each promoted rule**
+
+Create a fixture in `app/src/test/resources/gate4-fixtures/` following the same structure as the fixtures in Task 3. The `/update-rules` validator (Gate 4) should have already generated TP/TN test cases — reuse those.
+
+- [ ] **Step 4: Run Gradle gate + Gate 4 fixture tests**
+
+```bash
+./gradlew testDebugUnitTest --tests "com.androdr.sigma.BundledRulesSchemaCrossCheckTest"
+./gradlew testDebugUnitTest --tests "com.androdr.sigma.GateFourFixtureTest"
+```
+
+Expected: All PASS.
+
+- [ ] **Step 5: Update feed-state.json with new cursor**
+
+The `/update-rules` skill should update `feed-state.json` automatically. Verify:
+
+```bash
+cat third-party/android-sigma-rules/feed-state.json | python3 -m json.tool
+```
+
+Check that `stalkerware_indicators.last_commit_sha` has been updated from `348fd7b` to the latest commit.
+
+- [ ] **Step 6: Commit submodule + promoted rule(s)**
+
+```bash
+cd third-party/android-sigma-rules
+git add -A
+git commit -m "feat: add rule(s) from stalkerware feed ingest run"
+cd ../..
+git add third-party/android-sigma-rules
+git add app/src/main/res/raw/sigma_androdr_078_*.yml
+git add app/src/test/resources/gate4-fixtures/*.yml
+git commit -m "feat: promote AI-generated rule(s) from end-to-end stalkerware ingest"
+```
+
+---
+
+## Task 7: Decision Log + Final Verification
+
+**Files:**
+- Create: `docs/decisions/2026-04-13-staging-rule-triage.md`
+
+- [ ] **Step 1: Write the decision log**
+
+File: `docs/decisions/2026-04-13-staging-rule-triage.md`
+
+```markdown
+# Staging Rule Triage — 2026-04-13
+
+**Context:** 5 AI-generated rules sat in `android-sigma-rules/staging/` since
+2026-04-02. Sub-plans 1a and 1b updated the validator and added Gate 4 harness
+support. This triage re-validates each rule and records promote/reject decisions.
+
+**Tracking:** Epic #104, sub-plan 1c (#107).
+
+## Triage Results
+
+| Rule | ID | Validator | Gate 4 | Decision | Notes |
+|------|----|-----------|--------|----------|-------|
+| Cellebrite CVEs | 051 | PASS (after adding `category`) | PASS | **Promoted** | Added `category: device_posture`. Strong detection, specific CVEs, Amnesty reference. |
+| DDNS C2 | 070 | PASS (after adding `category`) | PASS | **Promoted** | Added `category: incident`. `endswith` modifier correct for DDNS suffixes — not migrated to `ioc_lookup` because these are TLD-like patterns, not individual domain IOCs. |
+| Overlay Permission | 069 | PASS (after adding `category`) | PASS | **Promoted at medium** | Added `category: incident`, demoted `high` → `medium`. Sideload + known-good filter limits FP, but single permission is still broad. |
+| Boot Persistence | 066 | PASS (after adding `category`) | PASS | **Promoted at low** | Added `category: incident`, demoted `medium` → `low`. Boot receivers extremely common; useful as triage signal, not standalone alert. |
+| Popular App Impersonation | 071→077 | PASS (after renumber + `category`) | PASS | **Renumbered + Promoted** | Renumbered from 071 (collides with production `crash_loop_anti_forensics`) to 077 (next available). Added `category: incident`. |
+
+## Common Fix Applied
+
+All 5 rules were missing the top-level `category` field, which became required
+when sub-plan 1a synced the schema. This is the expected failure mode — staging
+rules predate the schema update. The build-time gate now prevents this class of
+drift.
+
+## End-to-End Pipeline Run
+
+[Fill in after Task 5/6 — record what `/update-rules source stalkerware` produced,
+which rules were approved, and any issues encountered during the run.]
+```
+
+- [ ] **Step 2: Ensure the `docs/decisions/` directory exists**
+
+```bash
+mkdir -p docs/decisions
+```
+
+- [ ] **Step 3: Run full unit test suite**
+
+```bash
+./gradlew testDebugUnitTest
+```
+
+Expected: All tests PASS. This confirms the 5 new production rules + any end-to-end rules are compatible with the Kotlin parser and Gate 4 harness.
+
+- [ ] **Step 4: Commit decision log**
+
+```bash
+git add docs/decisions/2026-04-13-staging-rule-triage.md
+git commit -m "docs: add staging rule triage decision log (#107)"
+```
+
+- [ ] **Step 5: Update decision log with end-to-end run results**
+
+Fill in the "End-to-End Pipeline Run" section of the decision log with actual results from Task 5/6 — what the ingester found, what rules were produced, which were approved/rejected, and any issues encountered.
+
+- [ ] **Step 6: Final PR preparation**
+
+```bash
+git log --oneline claude/android-edr-setup-rl68Y..HEAD
+```
+
+Verify the commit history is clean, then open PR:
+- Title: `feat: promote staging rules + end-to-end pipeline proof (#107)`
+- Body: reference epic #104, sub-plan 1c, include `Closes #107`
+- Base: `claude/android-edr-setup-rl68Y`
+
+---
+
+## Exit Criteria (from meta-plan)
+
+- [ ] All 5 staging rules re-validated; per-rule decision recorded in decision log
+- [ ] Rules promoted to `app/src/main/res/raw/` pass the build-time Gradle gate
+- [ ] `/update-rules source stalkerware` run end-to-end (even if no new rules produced)
+- [ ] At least one AI-generated rule in production (satisfied by staging promotions)
+- [ ] `feed-state.json` updated with correct cursor
+- [ ] Gate 4 fixtures exist for every promoted rule


### PR DESCRIPTION
## Summary

Two implementation plan documents were generated during sub-plan 1b (#106) and sub-plan 1c (#107) but never committed alongside those PRs. This adds them to the plan archive so the record matches what was actually executed.

- \`docs/superpowers/plans/2026-04-12-gate4-harness-and-ioc-source.md\` — plan for #106
- \`docs/superpowers/plans/2026-04-13-ai-rule-framework-01c-staging-rerun-and-proof.md\` — plan for #107

## Test plan

- [x] No code changes, only added documentation files
- [x] Both files were present in the working tree of \`feat/106-gate4-harness-ioc-validation\` during sub-plan 2 work but untracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)