### PR TITLE
feat(pipeline): ingesters write to ioc-data via dispatcher cross-dedup (Phase 4 of #117)

### DIFF
--- a/.claude/commands/update-rules-ingest-abusech.md
+++ b/.claude/commands/update-rules-ingest-abusech.md
@@ -80,3 +80,61 @@ extra key to `feed-state-schema.json` first, then re-enable it here.
 - If HTTP 401 is returned, treat it as an auth failure and abort with an error (the key is likely expired or revoked — this is NOT "no new data")
 - If a sub-feed returns nothing new, that's fine — return empty SIR list for it
 - Tag IOCs from each sub-feed with the sub-feed name in `source.feed` detail
+
+## IOC data output (added for #117)
+
+Emit a JSON object extending the existing SIR array:
+
+```json
+{
+  "sirs": [ ... existing SIR array ... ],
+  "candidate_ioc_entries": [
+    {
+      "file": "ioc-data/c2-domains.yml",
+      "entry": {
+        "indicator": "c2.example.com",
+        "family": "ExampleMalware",
+        "category": "MALWARE",
+        "severity": "CRITICAL",
+        "source": "threatfox",
+        "description": "..."
+      }
+    },
+    {
+      "file": "ioc-data/malware-hashes.yml",
+      "entry": {
+        "indicator": "abc123...sha256",
+        "family": "ExampleApk",
+        "category": "MALWARE",
+        "severity": "HIGH",
+        "source": "malwarebazaar",
+        "description": "..."
+      }
+    }
+  ],
+  "upstream_snapshot_hash_set": [
+    ["C2_DOMAIN", "c2.example.com"],
+    ["APK_HASH", "abc123...sha256"]
+  ]
+}
+```
+
+### candidate_ioc_entries
+
+- ThreatFox domain entries → `ioc-data/c2-domains.yml`, source `threatfox`.
+- MalwareBazaar APK-hash entries → `ioc-data/malware-hashes.yml`, source
+  `malwarebazaar`.
+
+### upstream_snapshot_hash_set
+
+The full `(type, normalized_value)` set from both ThreatFox recent JSON
+and MalwareBazaar recent CSV. Normalize domains to lowercase, strip
+protocol and trailing `.`. Normalize hashes to lowercase hex.
+
+### Self-dedup
+
+As with stalkerware: emit a `candidate_ioc_entry` only for entries that
+are net-new since the last cursor. The `last_seen_timestamp` cursor in
+`feed-state.json` is the source of truth for "new."
+
+Cross-dedup across concurrent ingesters is the dispatcher's job.

--- a/.claude/commands/update-rules-ingest-amnesty.md
+++ b/.claude/commands/update-rules-ingest-amnesty.md
@@ -57,3 +57,40 @@ Note: per-investigation tracking is still git-based (existing_rule_sources); `la
 - NEVER invent IOCs — only include what the repo files contain
 - If an investigation has no Android-relevant IOCs (iOS only), skip it
 - Preserve the investigation directory name as provenance in the SIR source URL
+
+## IOC data output (added for #117)
+
+```json
+{
+  "sirs": [ ... ],
+  "candidate_ioc_entries": [
+    {
+      "file": "ioc-data/package-names.yml",
+      "entry": {
+        "indicator": "com.example.nationstate",
+        "family": "ExampleSpy",
+        "category": "NATION_STATE_SPYWARE",
+        "severity": "CRITICAL",
+        "source": "amnesty-investigations",
+        "description": "..."
+      }
+    }
+  ],
+  "upstream_snapshot_hash_set": [
+    ["PACKAGE_NAME", "com.example.nationstate"]
+  ]
+}
+```
+
+### Notes
+
+- AmnestyTech is NOT in `kotlin-mirror-feeds.yml`, so the cross-dedup
+  filter in Step 6.5 of update-rules.md will almost never remove entries
+  sourced here. This is by design: AmnestyTech is the pipeline's unique
+  contribution.
+- Use `source: "amnesty-investigations"` (matches `allowed-sources.json`).
+- Target file depends on indicator type: packages → `package-names.yml`;
+  domains → `c2-domains.yml`; cert hashes → `cert-hashes.yml`;
+  APK hashes → `malware-hashes.yml`.
+
+Cross-dedup across concurrent ingesters is the dispatcher's job.

--- a/.claude/commands/update-rules-ingest-asb.md
+++ b/.claude/commands/update-rules-ingest-asb.md
@@ -58,3 +58,42 @@ For actively exploited CVEs, create a separate SIR with:
 - NEVER invent CVE IDs — only include what the bulletin lists
 - If the bulletin page can't be parsed, return empty SIRs with an error note
 - Include the bulletin URL as a reference in every SIR
+
+## IOC data output (added for #117)
+
+The ASB ingester primarily produces CVE-ID SIRs, which feed
+**device-posture rules** (patch-level-relative checks), not
+`ioc_lookup`-style equality matching. CVE data flow stays in
+`CveRepository` per the spec's out-of-scope section; this ingester does
+NOT write CVE entries to `ioc-data/*.yml`.
+
+If the bulletin discloses concrete IOCs (e.g., a malicious package name
+tied to a specific CVE), emit them as candidate entries targeting the
+appropriate file, same pattern as other ingesters:
+
+```json
+{
+  "sirs": [ ... ],
+  "candidate_ioc_entries": [
+    {
+      "file": "ioc-data/package-names.yml",
+      "entry": {
+        "indicator": "com.asb.disclosed",
+        "family": "CVE-YYYY-NNNN-related",
+        "category": "MALWARE",
+        "severity": "HIGH",
+        "source": "android-security-bulletin",
+        "description": "..."
+      }
+    }
+  ],
+  "upstream_snapshot_hash_set": [
+    ["PACKAGE_NAME", "com.asb.disclosed"]
+  ]
+}
+```
+
+Most ASB runs will emit `candidate_ioc_entries: []` since bulletins
+typically disclose CVE-IDs without concrete IOCs.
+
+Cross-dedup across concurrent ingesters is the dispatcher's job.

--- a/.claude/commands/update-rules-ingest-attack.md
+++ b/.claude/commands/update-rules-ingest-attack.md
@@ -61,3 +61,24 @@ This ingester produces SIRs that help the Rule Author identify detection GAPS â€
 - NEVER generate SIGMA rules â€” only SIRs
 - Focus on techniques with Android platform applicability
 - Note when a technique maps to something AndroDR can detect vs. a gap
+
+## IOC data output (added for #117)
+
+ATT&CK Mobile produces technique-level intel (attack.tNNNN IDs), not
+concrete IOCs. `candidate_ioc_entries: []` is the expected output for
+this ingester.
+
+Do NOT manufacture IOC entries from technique descriptions; that risks
+high-FP entries (technique descriptions reference packages as examples,
+not as indicators). ATT&CK's contribution is TAG-level metadata for
+rules, not indicator-level data.
+
+```json
+{
+  "sirs": [ ... ],
+  "candidate_ioc_entries": [],
+  "upstream_snapshot_hash_set": []
+}
+```
+
+Cross-dedup across concurrent ingesters is the dispatcher's job.

--- a/.claude/commands/update-rules-ingest-citizenlab.md
+++ b/.claude/commands/update-rules-ingest-citizenlab.md
@@ -41,3 +41,37 @@ You receive:
 - Skip investigations with no Android-relevant indicators
 - CSV is the primary format — prefer it over STIX XML or OpenIOC
 - Set `confidence: "high"` — Citizen Lab data is peer-reviewed
+
+## IOC data output (added for #117)
+
+```json
+{
+  "sirs": [ ... ],
+  "candidate_ioc_entries": [
+    {
+      "file": "ioc-data/package-names.yml",
+      "entry": {
+        "indicator": "com.citizenlab.flagged",
+        "family": "<malware-family>",
+        "category": "NATION_STATE_SPYWARE",
+        "severity": "CRITICAL",
+        "source": "citizenlab-indicators",
+        "description": "..."
+      }
+    }
+  ],
+  "upstream_snapshot_hash_set": [
+    ["PACKAGE_NAME", "com.citizenlab.flagged"]
+  ]
+}
+```
+
+### Notes
+
+- Citizen Lab is NOT in `kotlin-mirror-feeds.yml`. Same rationale as
+  AmnestyTech: pipeline's unique contribution, rarely filtered.
+- Use `source: "citizenlab-indicators"`.
+- Repo is dormant since 2020 per README; emit candidates only when new
+  content is actually detected (no time-based triggers).
+
+Cross-dedup across concurrent ingesters is the dispatcher's job.

--- a/.claude/commands/update-rules-ingest-nvd.md
+++ b/.claude/commands/update-rules-ingest-nvd.md
@@ -69,3 +69,23 @@ NVD API response, and set `last_seen_timestamp` to now (ISO 8601 UTC).
 - Respect NVD rate limits: max 5 requests per 30 seconds without API key, 50 with key
 - If the NVD API returns an error or rate limit, log it and return empty SIRs
 - Only include CVEs that genuinely affect Android (CPE-verified), not just keyword matches
+
+## IOC data output (added for #117)
+
+Same situation as ASB: NVD entries are primarily CVEs (device-posture
+rules, handled by `CveRepository`), not `ioc_lookup` IOCs. Most NVD runs
+emit `candidate_ioc_entries: []`.
+
+If an NVD entry references a concrete IOC (e.g., CVE references a
+malicious package name in its description), emit it as a candidate,
+same pattern:
+
+```json
+{
+  "sirs": [ ... ],
+  "candidate_ioc_entries": [],
+  "upstream_snapshot_hash_set": []
+}
+```
+
+Cross-dedup across concurrent ingesters is the dispatcher's job.

--- a/.claude/commands/update-rules-ingest-stalkerware.md
+++ b/.claude/commands/update-rules-ingest-stalkerware.md
@@ -59,3 +59,55 @@ You receive the `stalkerware_indicators` cursor with:
 - NEVER generate SIGMA rules — only SIRs
 - Include ALL indicator types from the YAML (package names, certs, domains, hashes)
 - Stalkerware rules should include standard ATT&CK techniques for surveillance
+
+## IOC data output (added for #117)
+
+In addition to SIRs, emit a JSON object with two new fields:
+
+```json
+{
+  "sirs": [ ... existing SIR array ... ],
+  "candidate_ioc_entries": [
+    {
+      "file": "ioc-data/package-names.yml",
+      "entry": {
+        "indicator": "com.example.spy",
+        "family": "ExampleSpyware",
+        "category": "STALKERWARE",
+        "severity": "CRITICAL",
+        "source": "stalkerware-indicators",
+        "description": "..."
+      }
+    }
+  ],
+  "upstream_snapshot_hash_set": [
+    ["PACKAGE_NAME", "com.example.spy"]
+  ]
+}
+```
+
+### candidate_ioc_entries
+
+For each newly-discovered package name in the upstream (the ones that
+produce SIRs), emit one candidate entry targeting
+`ioc-data/package-names.yml`. `source: "stalkerware-indicators"` for every
+entry. Set `category` from the AssoEchap `type` field (`stalkerware` →
+`STALKERWARE`, `spyware` → `SPYWARE`, `monitor` → `MONITORING`).
+
+### upstream_snapshot_hash_set
+
+The full `(type, normalized_value)` set fetched from `ioc.yaml`. For this
+ingester, type is always `PACKAGE_NAME`; normalize by trimming whitespace
+(Android package names are case-sensitive; do NOT lowercase).
+
+### Self-dedup
+
+A package already present in the upstream as of this run is by definition
+not net-new for this ingester. Since every `candidate_ioc_entry` here IS
+derived from the upstream pull, self-dedup produces an empty
+`candidate_ioc_entries` for stalkerware unless the upstream has ADDED new
+entries since the last run. That is correct and expected — the delta for
+this ingester comes from new upstream additions between cursor runs.
+
+Cross-dedup across concurrent ingesters is the dispatcher's job
+(Step 6.5 of update-rules.md). Do NOT attempt cross-ingester dedup here.

--- a/.claude/commands/update-rules.md
+++ b/.claude/commands/update-rules.md
@@ -106,6 +106,42 @@ For any rule that failed validation:
 3. Run the Validator again on the updated candidate
 4. If it fails a second time, mark it as a failed candidate
 
+## Step 6.5: Centralized cross-dedup for IOC candidates (added for #117)
+
+Before surfacing candidates in Step 7, filter `candidate_ioc_entries`
+against the **authoritative upstream coverage set** for this run.
+
+### 6.5.1 Collect per-ingester snapshots
+
+Every completed ingester returns `upstream_snapshot_hash_set` alongside its
+SIRs and `candidate_ioc_entries` (see individual ingester skills). Take
+the union of every snapshot as `U_ingesters`.
+
+### 6.5.2 Fetch any missing mirror feeds
+
+Read `third-party/android-sigma-rules/validation/kotlin-mirror-feeds.yml`.
+For every feed listed there whose `id` does NOT appear in any completed
+ingester (e.g., only the stalkerware ingester ran but ThreatFox is still
+a Kotlin-mirrored upstream that candidates must be checked against), fetch
+the feed into a `(type, normalized_value)` set using the parser identified
+by the `parser` field. Take the union with `U_ingesters` → `U_authoritative`.
+
+### 6.5.3 Filter candidates
+
+For each candidate across all ingesters, drop it if
+`(type, normalized_value)` is in `U_authoritative`. The survivors form the
+**approved delta** that proceeds to Step 7.
+
+### 6.5.4 Safety checks before Step 7
+
+- If `U_authoritative` is empty (all upstreams failed to fetch), abort the
+  run with a clear error. Do NOT proceed with unfiltered candidates — that
+  would inject duplicates into ioc-data/*.yml.
+- If any candidate's `source` field corresponds to a feed listed in
+  `kotlin-mirror-feeds.yml` but the candidate survives the filter, log a
+  WARN — this is typically a normalization mismatch worth investigating
+  (the entry is in upstream under a different normalization).
+
 ## Step 7: Present Results
 
 Format the output as follows:
@@ -141,6 +177,28 @@ Feeds checked: N | New SIRs: N | Rules generated: N
 Passed: N | Failed: N | IOC updates: +N entries
 ```
 
+### 7.1 IOC-only candidates (added for #117)
+
+Some candidates from Step 6.5 have no accompanying rule — they're pure IOC
+data targeting the generic `sigma_androdr_001_package_ioc`,
+`_002_cert_hash_ioc`, `_003_domain_ioc`, or `_004_apk_hash_ioc` rules,
+which match anything in their lookup DB. Present these as first-class
+approval candidates:
+
+```
+IOC-ONLY CANDIDATE — via androdr-NNN generic ioc_lookup rule
+Target file:  ioc-data/<file>.yml
+Type:         <type>
+Source:       <source-id>
+Indicator(s): <count>
+  - <indicator 1>  (<family>, <severity>)
+  - <indicator 2>  ...
+  [...]
+```
+
+User actions for an IOC-only candidate: same as for a rule candidate —
+**Approve**, **Modify** (edit entries), or **Reject**.
+
 ## Step 8: Process User Decisions
 
 For each passing candidate, ask the user to:
@@ -154,6 +212,43 @@ After all decisions:
 - Update `ioc-data/*.yml` files if ingesters found new indicators
 - Commit all changes to the sigma repo with descriptive messages
 
+### 8.1 Commit IOC candidates (added for #117)
+
+For each approved candidate (rule OR IOC-only):
+
+1. Append approved IOC entries to the target `ioc-data/<file>.yml` file.
+   Preserve the file's header; append entries under the existing
+   `entries:` list.
+
+2. Run validators on every touched file. Abort the commit on any failure:
+   ```bash
+   cd third-party/android-sigma-rules
+   python3 validation/validate-ioc-data.py ioc-data/<file>.yml
+   python3 validation/validate-ioc-complementarity.py --file ioc-data/<file>.yml --mode strict
+   ```
+   If either validator exits non-zero, revert the append and report to the
+   user. Do NOT commit.
+
+3. Update `feed-state.json`: for each ingester that contributed approved
+   candidates, set its `ioc_data_last_write` to the current ISO 8601
+   timestamp (the schema supports this as an optional field per cursor).
+
+4. Commit the ioc-data change(s) + rule change(s) + feed-state update as
+   a single atomic commit. Commit message format:
+   ```
+   feat(rules+ioc): add <threat-name> (source: <source-id>) [Phase 4 of #117]
+   ```
+
+### 8.2 Safety rules
+
+- NEVER commit an ioc-data write that validate-ioc-complementarity.py
+  rejects in strict mode.
+- NEVER pass --allow-upstream-unreachable in automated
+  (non-interactive) pipeline runs; it's for operator-controlled retry
+  only.
+- NEVER modify `kotlin-mirror-feeds.yml` in the same commit as an
+  ioc-data write.
+
 ## Safety Rules
 
 - NEVER write rules directly to `rules/production/` — staging only
@@ -161,3 +256,6 @@ After all decisions:
 - NEVER modify AndroDR application code (Kotlin sources)
 - NEVER commit API keys or credentials to any file
 - Report feed failures separately from "no new data" results
+- NEVER commit an ioc-data/*.yml write that validate-ioc-complementarity.py rejects
+- NEVER pass --allow-upstream-unreachable in automated pipeline runs
+- NEVER modify kotlin-mirror-feeds.yml in the same commit as an ioc-data write


### PR DESCRIPTION
## Summary

Phase 4 of issue #117's complementary IOC pipeline work. This is the
**runtime enablement** phase — it extends the 7 `update-rules-ingest-*`
ingester skills and the `update-rules` dispatcher skill so the pipeline
actually writes pipeline-discovered IOCs into `ioc-data/*.yml`, which
AndroDR's `PublicRepoIocFeed` was already fetching.

Before this PR: the pipeline emits SIRs for rule authoring but doesn't
populate `ioc-data/*.yml` at all — so the rule-repo hop (already wired at
runtime) was starved of content.

After this PR: each ingester additionally emits `candidate_ioc_entries`
+ an `upstream_snapshot_hash_set`; the dispatcher runs centralized
cross-dedup against the union of ingester snapshots + freshly-fetched
mirror feeds; approved IOCs get committed to `ioc-data/*.yml` atomically
with their rules, gated by both `validate-ioc-data.py` (Phase 1) and
`validate-ioc-complementarity.py` (Phase 3).

## What changed

**Dispatcher (`update-rules.md`) — commit f52bdab:**
- **Step 6.5 (NEW)** — centralized cross-dedup between Steps 6 and 7.
  Must run in the dispatcher (not in individual ingesters) because
  subagents don't share memory. Collects every ingester's snapshot,
  fetches any kotlin-mirror-feeds.yml entries no ingester covered,
  unions into authoritative set, filters candidates. Aborts if the
  authoritative set is empty.
- **Step 7.1 (NEW)** — IOC-only approval UX for candidates that target
  the generic `sigma_androdr_00{1..4}_*_ioc` rules. Same
  Approve/Modify/Reject flow as rule candidates; first-class, not a
  footnote.
- **Step 8.1 (NEW)** — atomic write flow: append to
  `ioc-data/<file>.yml`, run both validators, abort on failure, stamp
  `feed-state.json`'s `ioc_data_last_write` per contributing ingester,
  commit with `feat(rules+ioc): add <threat> (source: <src>)` format.
- **Safety Rules** — 3 new NEVERs: never bypass the complementarity
  validator, never use `--allow-upstream-unreachable` in automated runs,
  never co-mingle `ioc-data` writes with `kotlin-mirror-feeds.yml`
  edits in one commit.

**7 ingester skills — commit 369da62:**

Each gets an appended `## IOC data output (added for #117)` section
documenting the 3-field contract (sirs, candidate_ioc_entries,
upstream_snapshot_hash_set) and per-ingester target files + source
values:

| Ingester | Target file(s) | `source:` |
|---|---|---|
| `stalkerware` | `package-names.yml` | `stalkerware-indicators` |
| `abusech` | `c2-domains.yml` + `malware-hashes.yml` | `threatfox` + `malwarebazaar` |
| `amnesty` | multi-target | `amnesty-investigations` |
| `citizenlab` | `package-names.yml` | `citizenlab-indicators` |
| `asb` | `package-names.yml` (usually empty) | `android-security-bulletin` |
| `nvd` | `[]` (usually empty; CVEs flow via CveRepository) | — |
| `attack` | `[]` (always empty by design) | — |

Self-dedup is ingester-local (drop candidates already in the ingester's
own upstream fetch). Cross-dedup across concurrent ingesters is always
the dispatcher's job.

## Out of scope for this PR

- **Skill-execution dogfooding on live upstreams** — the plan's Task 27
  Step 1 calls for iterative `/update-rules source stalkerware` runs to
  shake out normalizer drift. That requires Claude Code to pick up the
  new skill markdown, which happens on next session start after this
  merges. Deferred to Phase 5 post-merge verification (plan's Phase 5
  Tasks 28-30).
- **CVE-data routing** — out of scope per the spec (CVE matching is
  patch-level-relative range query, not equality-lookup `ioc_lookup`).
  Stays in `CveRepository`.
- **HaGeZi / UAD / Plexus / Zimperium Kotlin feed retirement** —
  permanent under Option F; this PR does not touch them.

## Test plan

- [x] Dispatcher `update-rules.md`: Step 6.5/7.1/8.1/8.2 + Safety Rules
  present, in correct order, consistent with ingester contract
- [x] 7 ingester skills: all have matching `## IOC data output` section;
  all field names / target files / source values verified against
  `allowed-sources.json` and `ioc-data/` directory listing
- [x] No `apk-hashes.yml` drift — all references use `malware-hashes.yml`
- [x] Generic `sigma_androdr_00{1..4}_*_ioc.yml` rules exist in
  `res/raw/` (verified)
- [x] Markdown well-formed (fence counts even, headers consistent)
- [ ] Live-feed dogfooding — deferred to Phase 5

Related: #117 (closed by spec PR #123)

🤖 Generated with [Claude Code](https://claude.com/claude-code)