### PR TITLE
fix(ioc): fetch malware-hashes.yml from public repo (#142)

### DIFF
--- a/app/src/main/java/com/androdr/ioc/PublicRepoIocFeed.kt
+++ b/app/src/main/java/com/androdr/ioc/PublicRepoIocFeed.kt
@@ -31,6 +31,7 @@ class PublicRepoIocFeed @Inject constructor(
             total += fetchAndUpsertPackages(now)
             total += fetchAndUpsertDomains(now)
             total += fetchAndUpsertCertHashes(now)
+            total += fetchAndUpsertApkHashes(now)
             total += fetchAndUpsertPopularApps(now)
             Log.i(TAG, "Public repo IOC feed: $total entries upserted")
         } catch (e: Exception) {
@@ -94,6 +95,29 @@ class PublicRepoIocFeed @Inject constructor(
             val hash = entry["indicator"]?.toString()?.lowercase() ?: return@mapNotNull null
             Indicator(
                 type = IndicatorResolver.TYPE_CERT_HASH, value = hash,
+                name = entry["family"]?.toString() ?: "",
+                campaign = entry["category"]?.toString() ?: "MALWARE",
+                severity = entry["severity"]?.toString() ?: "CRITICAL",
+                description = entry["description"]?.toString() ?: "",
+                source = SOURCE_ID, fetchedAt = fetchedAt
+            )
+        }
+
+        if (indicators.isNotEmpty()) {
+            indicatorDao.upsertAll(indicators)
+        }
+        return indicators.size
+    }
+
+    @Suppress("TooGenericExceptionCaught", "SwallowedException")
+    private suspend fun fetchAndUpsertApkHashes(fetchedAt: Long): Int {
+        val yaml = fetchUrl("${BASE_URL}ioc-data/malware-hashes.yml") ?: return 0
+        val entries = parseIocYaml(yaml)
+
+        val indicators = entries.mapNotNull { entry ->
+            val hash = entry["indicator"]?.toString()?.lowercase() ?: return@mapNotNull null
+            Indicator(
+                type = IndicatorResolver.TYPE_APK_HASH, value = hash,
                 name = entry["family"]?.toString() ?: "",
                 campaign = entry["category"]?.toString() ?: "MALWARE",
                 severity = entry["severity"]?.toString() ?: "CRITICAL",


### PR DESCRIPTION
## Summary

- Adds `fetchAndUpsertApkHashes()` to `PublicRepoIocFeed.kt`, mirroring the existing cert-hashes fetcher. Closes the gap where `ioc-data/malware-hashes.yml` (45+ Zimperium/research-sourced APK SHA-256 hashes on `android-sigma-rules/rules@main`) was never loaded on-device — `TYPE_APK_HASH` indicators came only from MalwareBazaar's direct API feed.
- Single-file change, 24 inserted lines. No DAO / schema / DI modifications. Complementarity with MalwareBazaar upstream is enforced YAML-side by `validate-ioc-complementarity.py --mode strict` (already wired into the sigma-rules CI).
- Two-reviewer cycle (code + architect) both APPROVE with no BLOCKER/HIGH findings. Pre-existing MEDIUM items (asymmetric stale-sweep, last-writer-wins collision semantics on dual-writer types) filed as follow-up #143.

## Test plan

- [x] `./gradlew assembleDebug testDebugUnitTest lintDebug` — BUILD SUCCESSFUL
- [x] `./gradlew :app:testDebugUnitTest --tests com.androdr.ioc.PublicRepoIocFeedTest` — all green (existing `parseIocYaml` tests cover the YAML parsing branch; new mapping is 5 lines identical to the already-shipped cert-hashes mapping)
- [ ] On-device smoke test: after merge + a publish cycle, run `scripts/smoke-test.sh` and grep logcat for `PublicRepoIocFeed: N entries upserted` where N jumps by ~75 (30 ClayRat + 45 from today's `/update-rules` run). Spot-check one APK hash like `019cd4ca...566` (PixRevolution dropper) ends up in `indicators WHERE type='apk_hash'` via `adb shell run-as com.androdr.debug`.

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)