### PR TITLE
fix(privacy): replace hallucinated email with real contact

### DIFF
--- a/cloudflare-worker.js
+++ b/cloudflare-worker.js
@@ -194,7 +194,7 @@ export default {
     <h3>Changes to This Policy</h3>
     <p>If this policy changes, the updated version will be published here and the "last updated" date will be revised.</p>
     <h3>Contact</h3>
-    <p>For privacy questions: <a href="mailto:privacy@androdr.dev">privacy@androdr.dev</a><br>
+    <p>For privacy questions: <a href="mailto:yhamad.dev@gmail.com">yhamad.dev@gmail.com</a><br>
     GitHub: <a href="https://github.com/yasirhamza/AndroDR/issues">github.com/yasirhamza/AndroDR/issues</a></p>
   </section>
   <footer>

--- a/docs/PRIVACY_POLICY.md
+++ b/docs/PRIVACY_POLICY.md
@@ -194,5 +194,5 @@ If this policy changes, the updated version will be published in the repository 
 ## Contact
 
 For privacy questions or concerns:
-- Email: privacy@androdr.dev
+- Email: yhamad.dev@gmail.com
 - GitHub: github.com/yasirhamza/AndroDR/issues


### PR DESCRIPTION
## Summary
- Privacy policy referenced `privacy@androdr.dev`, a domain the project does not own
- Replaced with `yhamad.dev@gmail.com` in `docs/PRIVACY_POLICY.md` and `cloudflare-worker.js`
- Cloudflare Worker already deployed with the new value

## Test plan
- [x] Verified live at https://androdr.yasirhamza.workers.dev/#privacy
- [ ] CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)