### PR TITLE
Eliminate three FPs on Samsung Z Fold 2 (Netflix, Facebook, AndroDR self-flag)

### DIFF
--- a/app/src/main/java/com/androdr/ioc/KnownAppResolver.kt
+++ b/app/src/main/java/com/androdr/ioc/KnownAppResolver.kt
@@ -1,5 +1,6 @@
 package com.androdr.ioc
 
+import android.util.Log
 import com.androdr.data.db.KnownAppDbEntry
 import com.androdr.data.db.KnownAppEntryDao
 import com.androdr.data.model.KnownAppCategory
@@ -22,16 +23,53 @@ class KnownAppResolver @Inject constructor(
     }
 
     fun lookup(packageName: String): KnownAppEntry? {
-        val direct = cache.get()?.get(packageName) ?: bundled.lookup(packageName)
+        val direct = resolveFromSources(packageName)
         if (direct != null) return direct
         val basePkg = packageName.replaceFirst(RRO_SUFFIX_REGEX, "")
         if (basePkg != packageName && basePkg.isNotEmpty()) {
-            return cache.get()?.get(basePkg) ?: bundled.lookup(basePkg)
+            return resolveFromSources(basePkg)
         }
         return null
     }
 
+    // Plexus (cache source) writes every entry as USER_APP; UAD and bundled classify
+    // preloads as OEM/AOSP/GOOGLE. Room upsert race conditions let Plexus overwrite
+    // UAD occasionally, so at lookup time we prefer the more authoritative
+    // classification when both sources have the same package.
+    private fun resolveFromSources(packageName: String): KnownAppEntry? {
+        val cached = cache.get()?.get(packageName)
+        val bundledEntry = bundled.lookup(packageName)
+        if (cached == null) return bundledEntry
+        if (bundledEntry == null) return cached
+        val cachedRank = authority(cached.category)
+        val bundledRank = authority(bundledEntry.category)
+        if (cachedRank != bundledRank) {
+            // Feed-drift signal: upstream sources disagree on classification.
+            // Log once-per-lookup at debug to surface data-quality issues without
+            // silently masking them (see #147 regression-prevention reviewer note).
+            Log.d(
+                TAG,
+                "Feed conflict for $packageName: cache=${cached.category}/${cached.sourceId} " +
+                    "bundled=${bundledEntry.category}/${bundledEntry.sourceId}; " +
+                    "preferring ${if (cachedRank > bundledRank) "cache" else "bundled"}",
+            )
+        }
+        return if (cachedRank >= bundledRank) cached else bundledEntry
+    }
+
+    private fun authority(category: KnownAppCategory): Int = when (category) {
+        // Firmware-bundling categories — strongest classification.
+        KnownAppCategory.OEM,
+        KnownAppCategory.AOSP,
+        KnownAppCategory.GOOGLE -> 2
+        // User-facing app registries (Plexus, popular-apps lists) — weaker signal;
+        // should not override firmware classifications from UAD/bundled.
+        KnownAppCategory.USER_APP,
+        KnownAppCategory.POPULAR -> 1
+    }
+
     companion object {
+        private const val TAG = "KnownAppResolver"
         private val RRO_SUFFIX_REGEX = Regex("""\.auto_generated_rro_[\w-]+___$""")
     }
 }

--- a/app/src/main/java/com/androdr/ioc/OemPrefixResolver.kt
+++ b/app/src/main/java/com/androdr/ioc/OemPrefixResolver.kt
@@ -70,14 +70,6 @@ class OemPrefixResolver @Inject constructor(
         isOemPrefix(packageName, device)
 
     /**
-     * Returns true iff [packageName] is a partnership prefix in the applicable
-     * set for [device]. Partnership prefixes only classify as OEM when the
-     * app also has FLAG_SYSTEM (pre-installed). See spec §9 and #90.
-     */
-    fun isPartnershipPrefix(packageName: String, device: DeviceIdentity): Boolean =
-        applicablePrefixesFor(device).partnership.any { packageName.startsWith(it) }
-
-    /**
      * Returns true iff [installer] is a trusted app store. Trusted installers
      * are unconditional (every device), so [device] is accepted but only used
      * for the fallback `isOemPrefix` call.
@@ -97,7 +89,6 @@ class OemPrefixResolver @Inject constructor(
         perDeviceCache.getOrPut(device) {
             val d = data.get()
             val strict = mutableSetOf<String>()
-            val partnership = mutableSetOf<String>()
 
             // Unconditional always applies
             strict.addAll(d.unconditionalStrict)
@@ -106,14 +97,10 @@ class OemPrefixResolver @Inject constructor(
             for (block in d.conditional) {
                 if (block.matches(device)) {
                     strict.addAll(block.strictPrefixes)
-                    partnership.addAll(block.partnershipPrefixes)
                 }
             }
 
-            ApplicablePrefixes(
-                strict = strict.toSet(),
-                partnership = partnership.toSet(),
-            )
+            ApplicablePrefixes(strict = strict.toSet())
         }
 
     /**
@@ -128,10 +115,8 @@ class OemPrefixResolver @Inject constructor(
             val parsed = parseOemPrefixYaml(yaml)
 
             // Sanity checks — reject obviously malicious remote data
-            val allStrict = parsed.unconditionalStrict +
+            val allPrefixes = parsed.unconditionalStrict +
                 parsed.conditional.flatMap { it.strictPrefixes }
-            val allPartnership = parsed.conditional.flatMap { it.partnershipPrefixes }
-            val allPrefixes = allStrict + allPartnership
             if (allPrefixes.any { it.length < 4 }) {
                 Log.w(TAG, "Remote OEM prefix feed rejected: prefix too short")
                 return@withContext
@@ -175,7 +160,6 @@ class OemPrefixResolver @Inject constructor(
         val manufacturerMatch: Set<String>,
         val brandMatch: Set<String>,
         val strictPrefixes: Set<String>,
-        val partnershipPrefixes: Set<String>,
     ) {
         /**
          * A block matches a device iff the device's manufacturer is in
@@ -191,7 +175,6 @@ class OemPrefixResolver @Inject constructor(
     /** The effective allowlist for a specific device identity. */
     data class ApplicablePrefixes(
         val strict: Set<String>,
-        val partnership: Set<String>,
     )
 
     // ─── YAML parsing ──────────────────────────────────────────────────────
@@ -244,17 +227,17 @@ class OemPrefixResolver @Inject constructor(
                 val strictPrefixes = (block["strict_prefixes"] as? List<*>)
                     ?.filterIsInstance<String>()
                     ?.toSet() ?: emptySet()
-                val partnershipPrefixes = (block["partnership_prefixes"] as? List<*>)
-                    ?.filterIsInstance<String>()
-                    ?.toSet() ?: emptySet()
 
-                if (strictPrefixes.isNotEmpty() || partnershipPrefixes.isNotEmpty()) {
+                // `partnership_prefixes` is parsed-and-ignored for forward-compat with
+                // older bundled/remote YAML that still carries the block — see #147 for
+                // why the concept was retired (hand-maintained allowlist produced FPs;
+                // known_good_apps.json is the canonical trust anchor).
+                if (strictPrefixes.isNotEmpty()) {
                     conditionalBlocks += ConditionalBlock(
                         id = blockId,
                         manufacturerMatch = manufacturerMatch,
                         brandMatch = brandMatch,
                         strictPrefixes = strictPrefixes,
-                        partnershipPrefixes = partnershipPrefixes,
                     )
                 }
             }
@@ -278,16 +261,14 @@ class OemPrefixResolver @Inject constructor(
     @Suppress("UNCHECKED_CAST")
     private fun parseLegacyFlat(doc: Map<*, *>): ParsedOemData {
         val strictPrefixes = mutableSetOf<String>()
-        val partnershipPrefixes = mutableSetOf<String>()
         for ((key, value) in doc) {
             val keyStr = key.toString()
+            // Accept any `*_prefixes` list (oem, chipset, partnership, etc.) as
+            // unconditional in the legacy flat layout. Partnership semantics were
+            // retired in #147 — on the legacy path we can't know device manufacturer
+            // so treating them as unconditional is acceptable.
             if (keyStr.endsWith("_prefixes") && value is List<*>) {
-                val prefixes = value.filterIsInstance<String>()
-                if (keyStr.contains("partner")) {
-                    partnershipPrefixes.addAll(prefixes)
-                } else {
-                    strictPrefixes.addAll(prefixes)
-                }
+                strictPrefixes.addAll(value.filterIsInstance<String>())
             }
         }
         val installers = (doc["trusted_installers"] as? List<*>)
@@ -296,11 +277,8 @@ class OemPrefixResolver @Inject constructor(
             ?.take(MAX_INSTALLER_COUNT)
             ?.toSet() ?: emptySet()
 
-        // Legacy: all prefixes become unconditional. Partnership prefixes
-        // are dropped on the legacy fallback path — this is acceptable
-        // because the production YAML ships with the new structure.
         return ParsedOemData(
-            unconditionalStrict = strictPrefixes + partnershipPrefixes,
+            unconditionalStrict = strictPrefixes,
             conditional = emptyList(),
             trustedInstallers = installers,
         )

--- a/app/src/main/java/com/androdr/ioc/feeds/UadKnownAppFeed.kt
+++ b/app/src/main/java/com/androdr/ioc/feeds/UadKnownAppFeed.kt
@@ -33,10 +33,15 @@ class UadKnownAppFeed : KnownAppFeed {
             val results = mutableListOf<KnownAppEntry>()
             root.keys().forEach { packageName ->
                 val obj = root.optJSONObject(packageName) ?: return@forEach
+                // UAD-ng upstream JSON emits title-case list values.
+                // See uad_lists.json: values are "Oem", "Aosp", "Carrier", "Misc", "Google".
+                // Earlier revisions checked "OEM"/"AOSP" which silently dropped ~83% of
+                // UAD entries, causing Samsung-preloaded apps (Netflix, Facebook, etc.) to
+                // fall back to Plexus's USER_APP classification and trip App Impersonation FPs.
                 val listField = obj.optString("list")
                 val category = when (listField) {
-                    "OEM", "Carrier", "Misc" -> KnownAppCategory.OEM
-                    "AOSP"                   -> KnownAppCategory.AOSP
+                    "Oem", "Carrier", "Misc" -> KnownAppCategory.OEM
+                    "Aosp"                   -> KnownAppCategory.AOSP
                     "Google"                 -> KnownAppCategory.GOOGLE
                     else                     -> return@forEach
                 }

--- a/app/src/main/java/com/androdr/scanner/AppOpsScanner.kt
+++ b/app/src/main/java/com/androdr/scanner/AppOpsScanner.kt
@@ -25,18 +25,25 @@ class AppOpsScanner @Inject constructor(
     @ApplicationContext private val context: Context
 ) {
 
-    /** Dangerous ops to check per package. Values are AppOpsManager.OPSTR_* constants. */
-    private val dangerousOps = listOf(
-        AppOpsManager.OPSTR_CAMERA,
-        AppOpsManager.OPSTR_RECORD_AUDIO,
-        AppOpsManager.OPSTR_READ_CONTACTS,
-        AppOpsManager.OPSTR_READ_CALL_LOG,
-        AppOpsManager.OPSTR_FINE_LOCATION,
-        AppOpsManager.OPSTR_READ_SMS,
-        AppOpsManager.OPSTR_READ_EXTERNAL_STORAGE,
-        // Not a public OPSTR_* constant but valid on API 26+; the per-op try/catch handles
-        // any platform that doesn't recognise it.
-        "android:request_install_packages"
+    /**
+     * Dangerous ops to check, paired with the Android runtime permission that gates each.
+     * An op is only recorded if the package's manifest *declares* the matching permission —
+     * otherwise `unsafeCheckOpNoThrow` returns the default policy mode (often `MODE_ALLOWED`)
+     * for ops the app never requested, producing false-positive "camera/mic access" findings
+     * on apps that never declared those permissions. See #147.
+     *
+     * `android:request_install_packages` lacks a public `OPSTR_*` constant but is valid on
+     * API 26+; the per-op try/catch handles platforms that don't recognise it.
+     */
+    private val opPermissionPairs = listOf(
+        AppOpsManager.OPSTR_CAMERA               to "android.permission.CAMERA",
+        AppOpsManager.OPSTR_RECORD_AUDIO         to "android.permission.RECORD_AUDIO",
+        AppOpsManager.OPSTR_READ_CONTACTS        to "android.permission.READ_CONTACTS",
+        AppOpsManager.OPSTR_READ_CALL_LOG        to "android.permission.READ_CALL_LOG",
+        AppOpsManager.OPSTR_FINE_LOCATION        to "android.permission.ACCESS_FINE_LOCATION",
+        AppOpsManager.OPSTR_READ_SMS             to "android.permission.READ_SMS",
+        AppOpsManager.OPSTR_READ_EXTERNAL_STORAGE to "android.permission.READ_EXTERNAL_STORAGE",
+        "android:request_install_packages"       to "android.permission.REQUEST_INSTALL_PACKAGES",
     )
 
     // The inner op loop uses `continue` for null/unknown-op cases and for permission mode
@@ -58,8 +65,11 @@ class AppOpsScanner @Inject constructor(
                 val appInfo = pkgInfo.applicationInfo ?: continue
                 val isSystem = appInfo.flags and ApplicationInfo.FLAG_SYSTEM != 0
                 val uid = appInfo.uid
+                val declaredPermissions = pkgInfo.requestedPermissions?.toSet() ?: emptySet()
 
-                for (opStr in dangerousOps) {
+                for ((opStr, permission) in opPermissionPairs) {
+                    if (permission !in declaredPermissions) continue
+
                     val mode = try {
                         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                             opsManager.unsafeCheckOpNoThrow(opStr, uid, packageName)

--- a/app/src/main/java/com/androdr/scanner/AppScanner.kt
+++ b/app/src/main/java/com/androdr/scanner/AppScanner.kt
@@ -195,12 +195,12 @@ class AppScanner @Inject constructor(
 
         // Known-app resolver
         val knownApp = knownAppResolver.lookup(packageName)
-        // Primary: known-good DB (Plexus/UAD feeds, 14k+ apps)
+        // Primary: known-good DB (Plexus/UAD feeds, 14k+ apps, including Samsung/Xiaomi/etc.
+        //   partner preloads classified as OEM via UAD-ng's Oem/Carrier/Misc lists)
         // Fallback: OEM prefix matching (for apps not in DB yet)
         val isKnownOemApp = knownApp?.category in setOf(
             KnownAppCategory.OEM, KnownAppCategory.AOSP, KnownAppCategory.GOOGLE
         ) || oemPrefixResolver.isOemPrefix(packageName, localDevice)
-            || (isSystemApp && oemPrefixResolver.isPartnershipPrefix(packageName, localDevice))
 
         val isSideloaded = !isSystemApp && !fromTrustedStore && !isKnownOemApp
 

--- a/app/src/main/java/com/androdr/scanner/UsageStatsScanner.kt
+++ b/app/src/main/java/com/androdr/scanner/UsageStatsScanner.kt
@@ -105,8 +105,7 @@ class UsageStatsScanner @Inject constructor(
         val packageName = event.packageName ?: return
 
         // Skip OEM/system apps — only track user-installed app activity
-        if (oemPrefixResolver.isOemPrefix(packageName, localDevice) ||
-            oemPrefixResolver.isPartnershipPrefix(packageName, localDevice)) return
+        if (oemPrefixResolver.isOemPrefix(packageName, localDevice)) return
 
         // Resolve app label (cached to avoid repeated PM lookups)
         val appLabel = labelCache.getOrPut(packageName) {

--- a/app/src/main/res/raw/known_oem_prefixes.yml
+++ b/app/src/main/res/raw/known_oem_prefixes.yml
@@ -89,12 +89,13 @@ conditional:
       - "com.shannon."
       - "com.wsomacp"
       - "com.wssyncmldm"
-    # Apps pre-installed via Samsung partnerships — counts as OEM only
-    # when the app has FLAG_SYSTEM (pre-installed) AND the device is Samsung.
-    partnership_prefixes:
-      - "com.microsoft."
-      - "com.touchtype."
-      - "com.facebook."
+    # partnership_prefixes intentionally omitted. Samsung-bundled partner apps
+    # (Microsoft, Netflix, Facebook, Spotify, Booking, LinkedIn, etc.) are
+    # classified via the known_good_apps.json database (UAD-ng Oem/Carrier/Misc
+    # lists) — a community-maintained data source that scales without requiring
+    # AndroDR releases for every new Samsung partner deal. A closed allowlist
+    # here produced HIGH "firmware implant" false positives on any un-listed
+    # preload; see issue #147.
 
   xiaomi:
     manufacturer_match: ["xiaomi"]

--- a/app/src/main/res/raw/sigma_androdr_015_firmware_implant.yml
+++ b/app/src/main/res/raw/sigma_androdr_015_firmware_implant.yml
@@ -1,11 +1,13 @@
-title: System app with unknown origin
+title: Unrecognized system app
 id: androdr-015
 status: production
-description: System-level app does not match any known OEM or AOSP package prefix.
+description: Pre-installed system app that does not match any known OEM/AOSP/Google package in the known-good database.
 author: AndroDR
 date: 2026/03/27
-tags:
-    - attack.t1398
+# T1398 (Install Insecure or Malicious Configuration) was removed in #147
+# when this rule was downgraded from HIGH "Firmware Implant" to LOW
+# "Unrecognized System App" — T1398 implies malicious intent, which LOW
+# severity informational findings cannot support without corroborating signals.
 logsource:
     product: androdr
     service: app_scanner
@@ -14,13 +16,13 @@ detection:
         is_system_app: true
         is_known_oem_app: false
     condition: selection
-level: high
+level: low
 category: incident
 display:
     category: app_risk
     icon: memory
-    triggered_title: "Firmware Implant"
+    triggered_title: "Unrecognized System App"
     evidence_type: none
-    guidance: "CRITICAL -- possible firmware-level implant; seek expert forensic assistance"
+    guidance: "Review whether this preload is expected for your device model and carrier."
 remediation:
-    - "This app has system privileges but does not match any known manufacturer package."
+    - "This app was pre-installed on the device but is not in the known-good app database. This is normal for some carrier and partner preloads; verify the app name matches something you recognize."

--- a/app/src/test/java/com/androdr/ioc/KnownAppResolverTest.kt
+++ b/app/src/test/java/com/androdr/ioc/KnownAppResolverTest.kt
@@ -54,6 +54,7 @@ class KnownAppResolverTest {
             category = "USER_APP", sourceId = "plexus", fetchedAt = 1000L
         )
         coEvery { mockDao.getAll() } returns listOf(dbEntry)
+        every { mockBundled.lookup("com.whatsapp") } returns null
 
         resolver.refreshCache()
         val result = resolver.lookup("com.whatsapp")
@@ -136,6 +137,64 @@ class KnownAppResolverTest {
         val result = resolver.lookup(rro)
 
         assertEquals(base, result?.packageName)
+    }
+
+    @Test
+    fun `cache USER_APP does not override bundled OEM for same package`() = runTest {
+        // Regression: Plexus feed writes every entry as USER_APP and can race UAD writes
+        // in the Room DB. When bundled JSON has an authoritative OEM/AOSP/GOOGLE
+        // classification for the same package, that must win — otherwise Netflix/Facebook
+        // preloads on Samsung devices get mis-classified as USER_APP and trip
+        // rule-014 App Impersonation (HIGH).
+        val cachedUserApp = KnownAppDbEntry(
+            packageName = "com.facebook.katana", displayName = "Facebook",
+            category = "USER_APP", sourceId = "plexus", fetchedAt = 1000L
+        )
+        coEvery { mockDao.getAll() } returns listOf(cachedUserApp)
+        every { mockBundled.lookup("com.facebook.katana") } returns KnownAppEntry(
+            packageName = "com.facebook.katana", displayName = "Facebook",
+            category = KnownAppCategory.OEM, sourceId = "bundled", fetchedAt = 0L
+        )
+
+        resolver.refreshCache()
+        val result = resolver.lookup("com.facebook.katana")
+
+        assertEquals(KnownAppCategory.OEM, result?.category)
+    }
+
+    @Test
+    fun `cache OEM is preferred over bundled USER_APP`() = runTest {
+        // Symmetric case: fresh UAD fetch (cache) has OEM, older bundled has USER_APP.
+        // Cache's authoritative classification wins.
+        val cachedOem = KnownAppDbEntry(
+            packageName = "com.example.preload", displayName = "Preload",
+            category = "OEM", sourceId = "uad_ng", fetchedAt = 2000L
+        )
+        coEvery { mockDao.getAll() } returns listOf(cachedOem)
+        every { mockBundled.lookup("com.example.preload") } returns KnownAppEntry(
+            packageName = "com.example.preload", displayName = "Preload",
+            category = KnownAppCategory.USER_APP, sourceId = "bundled", fetchedAt = 0L
+        )
+
+        resolver.refreshCache()
+        val result = resolver.lookup("com.example.preload")
+
+        assertEquals(KnownAppCategory.OEM, result?.category)
+    }
+
+    @Test
+    fun `cache USER_APP is returned when bundled has no entry`() = runTest {
+        val cachedUserApp = KnownAppDbEntry(
+            packageName = "com.whatsapp", displayName = "WhatsApp",
+            category = "USER_APP", sourceId = "plexus", fetchedAt = 1000L
+        )
+        coEvery { mockDao.getAll() } returns listOf(cachedUserApp)
+        every { mockBundled.lookup("com.whatsapp") } returns null
+
+        resolver.refreshCache()
+        val result = resolver.lookup("com.whatsapp")
+
+        assertEquals(KnownAppCategory.USER_APP, result?.category)
     }
 
     @Test

--- a/app/src/test/java/com/androdr/ioc/OemPrefixResolverConditionalTest.kt
+++ b/app/src/test/java/com/androdr/ioc/OemPrefixResolverConditionalTest.kt
@@ -83,13 +83,6 @@ class OemPrefixResolverConditionalTest {
     }
 
     @Test
-    fun `partnership prefixes only apply on the matching OEM device`() {
-        assertTrue(resolver.isPartnershipPrefix("com.facebook.katana", samsung))
-        assertFalse(resolver.isPartnershipPrefix("com.facebook.katana", pixel))
-        assertFalse(resolver.isPartnershipPrefix("com.facebook.katana", xiaomi))
-    }
-
-    @Test
     fun `applicablePrefixesFor caches per device identity`() {
         val a = resolver.applicablePrefixesFor(pixel)
         val b = resolver.applicablePrefixesFor(pixel)

--- a/app/src/test/java/com/androdr/ioc/OemPrefixResolverTest.kt
+++ b/app/src/test/java/com/androdr/ioc/OemPrefixResolverTest.kt
@@ -92,16 +92,12 @@ class OemPrefixResolverTest {
     }
 
     @Test
-    fun `partnership prefixes are not strict OEM prefixes`() {
+    fun `partner prefixes are not strict OEM prefixes on any device`() {
+        // Former partnership concept retired in #147: Facebook/Microsoft preloads
+        // are now classified via the known_good_apps.json DB, not prefix matching.
+        // isOemPrefix must return false for these — they're user-space bundle IDs.
         assertFalse(resolver.isOemPrefix("com.facebook.katana", samsung))
         assertFalse(resolver.isOemPrefix("com.microsoft.office.word", samsung))
-    }
-
-    @Test
-    fun `partnership prefixes match isPartnershipPrefix on Samsung device`() {
-        assertTrue(resolver.isPartnershipPrefix("com.facebook.katana", samsung))
-        assertTrue(resolver.isPartnershipPrefix("com.microsoft.office.word", samsung))
-        assertTrue(resolver.isPartnershipPrefix("com.touchtype.swiftkey", samsung))
     }
 
     @Test

--- a/app/src/test/java/com/androdr/ioc/UadKnownAppFeedTest.kt
+++ b/app/src/test/java/com/androdr/ioc/UadKnownAppFeedTest.kt
@@ -10,9 +10,12 @@ class UadKnownAppFeedTest {
 
     private val feed = UadKnownAppFeed()
 
+    // UAD-ng upstream emits title-case list values ("Oem", "Aosp", "Carrier", "Misc", "Google").
+    // See: https://raw.githubusercontent.com/Universal-Debloater-Alliance/universal-android-debloater-next-generation/main/resources/assets/uad_lists.json
+
     @Test
-    fun `OEM entry maps to OEM category`() {
-        val json = """{"com.samsung.clock":{"list":"OEM","description":"Samsung Clock"}}"""
+    fun `Oem entry maps to OEM category`() {
+        val json = """{"com.samsung.clock":{"list":"Oem","description":"Samsung Clock"}}"""
         val results = feed.parseUadJson(json)
         assertEquals(1, results.size)
         assertEquals("com.samsung.clock", results[0].packageName)
@@ -30,14 +33,14 @@ class UadKnownAppFeedTest {
 
     @Test
     fun `Misc entry maps to OEM category`() {
-        val json = """{"com.example.misc":{"list":"Misc","description":"Misc App"}}"""
+        val json = """{"com.facebook.katana":{"list":"Misc","description":"Facebook"}}"""
         val results = feed.parseUadJson(json)
         assertEquals(KnownAppCategory.OEM, results[0].category)
     }
 
     @Test
-    fun `AOSP entry maps to AOSP category`() {
-        val json = """{"com.android.settings":{"list":"AOSP","description":"Settings"}}"""
+    fun `Aosp entry maps to AOSP category`() {
+        val json = """{"com.android.settings":{"list":"Aosp","description":"Settings"}}"""
         val results = feed.parseUadJson(json)
         assertEquals(KnownAppCategory.AOSP, results[0].category)
     }
@@ -47,6 +50,14 @@ class UadKnownAppFeedTest {
         val json = """{"com.google.android.gms":{"list":"Google","description":"Play Services"}}"""
         val results = feed.parseUadJson(json)
         assertEquals(KnownAppCategory.GOOGLE, results[0].category)
+    }
+
+    @Test
+    fun `Netflix preload in Misc list classifies as OEM not USER_APP`() {
+        val json = """{"com.netflix.mediaclient":{"list":"Misc","description":"Netflix"}}"""
+        val results = feed.parseUadJson(json)
+        assertEquals(1, results.size)
+        assertEquals(KnownAppCategory.OEM, results[0].category)
     }
 
     @Test

--- a/app/src/test/java/com/androdr/scanner/AppOpsScannerTest.kt
+++ b/app/src/test/java/com/androdr/scanner/AppOpsScannerTest.kt
@@ -2,10 +2,13 @@ package com.androdr.scanner
 
 import android.app.AppOpsManager
 import android.content.Context
+import android.content.pm.ApplicationInfo
+import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -27,5 +30,63 @@ class AppOpsScannerTest {
         every { mockContext.packageManager } returns mockPm
         every { mockPm.getInstalledPackages(any<Int>()) } returns emptyList()
         assertTrue(AppOpsScanner(mockContext).collectTelemetry().isEmpty())
+    }
+
+    @Test
+    fun `skips package that did not request camera even when MODE_ALLOWED is returned`() = runTest {
+        // Regression: unsafeCheckOpNoThrow returns MODE_ALLOWED as the default for
+        // OPSTR_CAMERA on most Android builds, even for packages that never declared
+        // android.permission.CAMERA in their manifest. That produced FP where AndroDR
+        // flagged itself for camera access despite having no camera permission. See #147.
+        val mockOps: AppOpsManager = mockk(relaxed = true)
+        val mockPm: PackageManager = mockk(relaxed = true)
+        every { mockContext.getSystemService(Context.APP_OPS_SERVICE) } returns mockOps
+        every { mockContext.packageManager } returns mockPm
+        every { mockPm.getInstalledPackages(any<Int>()) } returns listOf(
+            fakePackage("com.androdr", requestedPermissions = emptyArray())
+        )
+        every { mockOps.unsafeCheckOpNoThrow(any(), any(), any()) } returns AppOpsManager.MODE_ALLOWED
+
+        val results = AppOpsScanner(mockContext).collectTelemetry()
+
+        assertTrue(
+            "Expected no telemetry for package without camera/mic declared permissions; got $results",
+            results.none { it.operation == AppOpsManager.OPSTR_CAMERA || it.operation == AppOpsManager.OPSTR_RECORD_AUDIO }
+        )
+    }
+
+    @Test
+    fun `records camera op when package declared CAMERA permission and MODE_ALLOWED`() = runTest {
+        val mockOps: AppOpsManager = mockk(relaxed = true)
+        val mockPm: PackageManager = mockk(relaxed = true)
+        every { mockContext.getSystemService(Context.APP_OPS_SERVICE) } returns mockOps
+        every { mockContext.packageManager } returns mockPm
+        every { mockPm.getInstalledPackages(any<Int>()) } returns listOf(
+            fakePackage("com.example.camera", requestedPermissions = arrayOf("android.permission.CAMERA"))
+        )
+        every { mockOps.unsafeCheckOpNoThrow(any(), any(), any()) } returns AppOpsManager.MODE_ALLOWED
+
+        val results = AppOpsScanner(mockContext).collectTelemetry()
+
+        assertEquals(
+            1, results.count { it.operation == AppOpsManager.OPSTR_CAMERA && it.packageName == "com.example.camera" }
+        )
+    }
+
+    private fun fakePackage(
+        packageName: String,
+        requestedPermissions: Array<String>,
+        isSystem: Boolean = false,
+    ): PackageInfo {
+        val appInfo = ApplicationInfo().apply {
+            this.packageName = packageName
+            this.uid = 10_000
+            this.flags = if (isSystem) ApplicationInfo.FLAG_SYSTEM else 0
+        }
+        return PackageInfo().apply {
+            this.packageName = packageName
+            this.applicationInfo = appInfo
+            this.requestedPermissions = requestedPermissions
+        }
     }
 }

--- a/app/src/test/resources/raw/known_oem_prefixes.yml
+++ b/app/src/test/resources/raw/known_oem_prefixes.yml
@@ -89,12 +89,9 @@ conditional:
       - "com.shannon."
       - "com.wsomacp"
       - "com.wssyncmldm"
-    # Apps pre-installed via Samsung partnerships — counts as OEM only
-    # when the app has FLAG_SYSTEM (pre-installed) AND the device is Samsung.
-    partnership_prefixes:
-      - "com.microsoft."
-      - "com.touchtype."
-      - "com.facebook."
+    # partnership_prefixes retired in #147. Samsung-bundled partner apps
+    # (Microsoft, Netflix, Facebook, etc.) are classified via the
+    # known_good_apps.json database (UAD-ng Oem/Carrier/Misc lists).
 
   xiaomi:
     manufacturer_match: ["xiaomi"]


### PR DESCRIPTION
## Summary

User report on a Samsung Galaxy Z Fold 2 (SM-F916B, Android 13) produced
`OVERALL RISK: CRITICAL` driven by three independent false positives:

| # | Finding | Severity | Root cause |
|---|---------|----------|------------|
| 1 | Netflix → "Firmware Implant" | HIGH → CRITICAL | Samsung partnership allowlist doesn't list Netflix; rule 015 overclaims severity |
| 2 | Facebook → "App Impersonation" | HIGH | UAD feed ingester has wrong-case match; Plexus's USER_APP classification wins the DB write race |
| 3 | AndroDR → Camera + Microphone access | MEDIUM | AppOps scanner treats default policy mode as usage; AndroDR doesn't even declare those permissions |

## Fixes

- **UadKnownAppFeed**: match real UAD-ng title-case values (`"Oem"`, `"Aosp"` etc.). Upstream check confirmed: 4141 `Oem` + 270 `Aosp` entries (83% of feed) were being silently dropped at runtime.
- **KnownAppResolver**: add authority ranking — `OEM`/`AOSP`/`GOOGLE` beats `USER_APP`/`POPULAR` on conflict, with debug logging when sources disagree (surfaces feed drift instead of hiding it).
- **AppOpsScanner**: pair each op with its required permission and skip packages that don't declare it. `MODE_ALLOWED` is the default policy, not an access record — confirmed by `cmd appops get com.androdr CAMERA` returning "No operations. Default mode: allow" on the actual device.
- **Rule 015**: downgrade HIGH → LOW, rename "Firmware Implant" → "Unrecognized System App", drop the alarming "seek expert forensic assistance" guidance and the misleading T1398 tag. Userspace detection cannot support a firmware-implant claim without Verified Boot / Play Integrity / Key Attestation.
- **`partnership_prefixes` retired**: the Samsung hand-maintained allowlist is deleted along with `isPartnershipPrefix()` and its callers. `known_good_apps.json` (UAD-ng + Plexus bundled) is the canonical trust anchor. The YAML parser ignores any remaining `partnership_prefixes` blocks for forward-compat with older remote feeds.

## On-device verification

Installed the branch on the reporting device (SM-F916B). Fresh scan:

- **Before**: `OVERALL RISK: CRITICAL`, 3 app findings (Netflix, Facebook, AndroDR-self).
- **After**: `OVERALL RISK: MEDIUM`, 0 app findings. Apps tab shows "No risks found". Legitimate device-posture findings (stale patch, 18 unpatched CVEs) preserved.

## Test plan

- [x] `./gradlew testDebugUnitTest` — full suite passes
- [x] `./gradlew lintDebug assembleDebug` — clean
- [x] New unit tests: UAD capitalization against real upstream values, resolver authority ranking (OEM-over-USER_APP), AppOpsScanner permission-filter (positive + negative)
- [x] End-to-end verification on the original reporting device — scan result changed from CRITICAL to MEDIUM, 0 app findings

## Follow-ups (out of scope)

- #148 — bug-report analysis completes silently (observed during verification)
- Future: telemetry/rule split at `AppScanner.kt:200` could emit atomic fields instead of the composite `is_known_oem_app` boolean (architect reviewer noted; non-regression, architectural improvement)
- Future: positive-trust signing-cert DB for Samsung/Google platform certs (would strengthen rule 015 beyond the current known-good-DB anchor)

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)