### PR TITLE
Ingest stalkerware-indicators cert hashes + emit SHA-1

### DIFF
--- a/app/src/main/java/com/androdr/data/model/AppTelemetry.kt
+++ b/app/src/main/java/com/androdr/data/model/AppTelemetry.kt
@@ -4,6 +4,11 @@ data class AppTelemetry(
     val packageName: String,
     val appName: String,
     val certHash: String?,
+    // SHA-1 of the same signing-cert bytes used for certHash (SHA-256). Required to
+    // match community feeds (stalkerware-indicators, MVT) that index cert IOCs by
+    // SHA-1 — the Android ecosystem convention (apksigner --print-certs emits SHA-1
+    // by default).
+    val certHashSha1: String?,
     val apkHash: String?,
     val isSystemApp: Boolean,
     val fromTrustedStore: Boolean,
@@ -35,6 +40,7 @@ data class AppTelemetry(
         "package_name" to packageName,
         "app_name" to appName,
         "cert_hash" to certHash,
+        "cert_hash_sha1" to certHashSha1,
         "apk_hash" to apkHash,
         "is_system_app" to isSystemApp,
         "from_trusted_store" to fromTrustedStore,

--- a/app/src/main/java/com/androdr/di/AppModule.kt
+++ b/app/src/main/java/com/androdr/di/AppModule.kt
@@ -35,6 +35,7 @@ import com.androdr.ioc.feeds.HaGeZiTifFeed
 import com.androdr.ioc.feeds.MalwareBazaarCertFeed
 import com.androdr.ioc.feeds.MvtIndicatorsFeed
 import com.androdr.ioc.feeds.PlexusKnownAppFeed
+import com.androdr.ioc.feeds.StalkerwareCertHashFeed
 import com.androdr.ioc.feeds.StalkerwareIndicatorsFeed
 import com.androdr.ioc.feeds.ThreatFoxDomainFeed
 import com.androdr.ioc.feeds.UadKnownAppFeed
@@ -101,7 +102,7 @@ object AppModule {
     @Provides
     @Singleton
     fun provideCertHashIocFeeds(): @JvmSuppressWildcards List<CertHashIocFeed> =
-        listOf(MalwareBazaarCertFeed())
+        listOf(MalwareBazaarCertFeed(), StalkerwareCertHashFeed())
 
     @Provides
     @Singleton

--- a/app/src/main/java/com/androdr/ioc/feeds/StalkerwareCertHashFeed.kt
+++ b/app/src/main/java/com/androdr/ioc/feeds/StalkerwareCertHashFeed.kt
@@ -1,0 +1,118 @@
+package com.androdr.ioc.feeds
+
+import android.util.Log
+import com.androdr.data.model.CertHashIocEntry
+import com.androdr.ioc.CertHashIocFeed
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.net.HttpURLConnection
+import java.net.URL
+
+/**
+ * Fetches signing-certificate SHA-1 IOCs from the community-maintained
+ * AssoEchap/stalkerware-indicators GitHub repository, companion to
+ * [StalkerwareIndicatorsFeed] (which consumes the `packages:` field).
+ *
+ * `ioc.yaml` entries carry a `certificates:` list of 40-char hex SHA-1
+ * fingerprints of the dev's signing certificate — stable across stalkerware
+ * versions and therefore a stronger pivot than package names. MVT and other
+ * mobile-forensics tooling converge on SHA-1 cert matching (see #151).
+ *
+ *   - name: TheTruthSpy
+ *     type: stalkerware
+ *     certificates:
+ *     - 31A6ECECD97CF39BC4126B8745CD94A7C30BF81C
+ *     - ...
+ */
+class StalkerwareCertHashFeed : CertHashIocFeed {
+
+    override val sourceId = SOURCE_ID
+
+    @Suppress("TooGenericExceptionCaught")
+    override suspend fun fetch(): List<CertHashIocEntry> = withContext(Dispatchers.IO) {
+        try {
+            val connection = (URL(YAML_URL).openConnection() as HttpURLConnection).apply {
+                connectTimeout = 15_000
+                readTimeout = 15_000
+                requestMethod = "GET"
+                setRequestProperty("User-Agent", "AndroDR/1.0")
+            }
+            try {
+                if (connection.responseCode != HttpURLConnection.HTTP_OK) {
+                    Log.w(TAG, "HTTP ${connection.responseCode} from stalkerware-indicators")
+                    return@withContext emptyList()
+                }
+                val now = System.currentTimeMillis()
+                parseYaml(connection.inputStream.bufferedReader().readText(), now)
+            } finally {
+                connection.disconnect()
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to fetch stalkerware cert indicators: ${e.message}")
+            emptyList()
+        }
+    }
+
+    /**
+     * Delegates the YAML walk to [StalkerwareYamlParser], then filters each
+     * family's `certificates:` entries to valid SHA-1 fingerprints before
+     * emitting [CertHashIocEntry]. Keeping parse and validation separate lets
+     * the sibling [StalkerwareIndicatorsFeed] reuse the same parser without
+     * inheriting cert-specific validation.
+     */
+    internal fun parseYaml(yaml: String, fetchedAt: Long): List<CertHashIocEntry> {
+        val results = mutableListOf<CertHashIocEntry>()
+        for (family in StalkerwareYamlParser.parse(yaml)) {
+            val category = categoryFor(family.type)
+            val familyName = family.name.ifBlank { "Unknown stalkerware family" }
+            for (cert in family.certificates) {
+                if (!isValidSha1Hex(cert)) continue
+                results += CertHashIocEntry(
+                    certHash = cert,
+                    familyName = familyName,
+                    category = category,
+                    severity = "CRITICAL",
+                    description = "Signing cert SHA-1 listed in stalkerware-indicators " +
+                        "(type: ${family.type}). " +
+                        "See https://github.com/AssoEchap/stalkerware-indicators",
+                    source = sourceId,
+                    fetchedAt = fetchedAt,
+                )
+            }
+        }
+        return results
+    }
+
+    private fun categoryFor(type: String): String = when {
+        type.contains("stalker", ignoreCase = true) -> "STALKERWARE"
+        type.contains("spy", ignoreCase = true)     -> "SPYWARE"
+        type.contains("monitor", ignoreCase = true) -> "MONITORING"
+        else -> "STALKERWARE"
+    }
+
+    /**
+     * Accepts only 40-char lowercase hex strings with enough character
+     * diversity to rule out obvious garbage (upstream poisoning defence:
+     * a malicious PR to AssoEchap that inserts `0000…` should not match
+     * every unsigned app's default cert).
+     */
+    private fun isValidSha1Hex(cert: String): Boolean {
+        if (cert.length != SHA1_HEX_LEN) return false
+        if (!cert.all { it in '0'..'9' || it in 'a'..'f' }) return false
+        // Reject low-entropy fingerprints (e.g. all-zeros, all-ones, "abab…").
+        return cert.toSet().size >= MIN_UNIQUE_HEX_CHARS
+    }
+
+    companion object {
+        private const val TAG = "StalkerwareCertHashFeed"
+        const val SOURCE_ID = "stalkerware_indicators_certs"
+        private const val SHA1_HEX_LEN = 40
+        // Real SHA-1 fingerprints of signing certs typically contain 13-16
+        // distinct hex chars out of 16. 4 is a very forgiving floor that still
+        // rejects synthetic low-entropy strings like "abab..." or "0000…" or
+        // "1111…f000…".
+        private const val MIN_UNIQUE_HEX_CHARS = 4
+        private const val YAML_URL =
+            "https://raw.githubusercontent.com/AssoEchap/stalkerware-indicators/master/ioc.yaml"
+    }
+}

--- a/app/src/main/java/com/androdr/ioc/feeds/StalkerwareIndicatorsFeed.kt
+++ b/app/src/main/java/com/androdr/ioc/feeds/StalkerwareIndicatorsFeed.kt
@@ -52,61 +52,34 @@ class StalkerwareIndicatorsFeed : IocFeed {
     }
 
     /**
-     * Minimal line-based YAML parser for the AssoEchap ioc.yaml structure.
-     * No external YAML library required — the format is regular enough to
-     * parse with a simple state machine.
+     * Delegates YAML walking to [StalkerwareYamlParser] and emits one
+     * [IocEntry] per package name per family. The cert half of the same
+     * feed is consumed by [StalkerwareCertHashFeed].
      */
     internal fun parseYaml(yaml: String, fetchedAt: Long): List<IocEntry> {
         val results = mutableListOf<IocEntry>()
-        var currentType = "stalkerware"
-        var currentName = ""
-        var inPackages = false
-
-        for (line in yaml.lines()) {
-            when {
-                line.startsWith("- name:") -> {
-                    currentName = line.removePrefix("- name:").trim()
-                    inPackages = false
+        for (family in StalkerwareYamlParser.parse(yaml)) {
+            val category = when {
+                family.type.contains("stalker", ignoreCase = true) -> "STALKERWARE"
+                family.type.contains("spy", ignoreCase = true)     -> "SPYWARE"
+                family.type.contains("monitor", ignoreCase = true) -> "MONITORING"
+                else -> "STALKERWARE"
+            }
+            for (pkg in family.packages) {
+                val displayName = family.name.ifBlank {
+                    pkg.substringAfterLast('.').replaceFirstChar { it.uppercase() }
                 }
-                line.trimStart().startsWith("type:") -> {
-                    currentType = line.trimStart().removePrefix("type:").trim()
-                    inPackages = false
-                }
-                line.trimStart() == "packages:" -> {
-                    inPackages = true
-                }
-                inPackages && line.trimStart().startsWith("- ") && !line.startsWith("- name:") -> {
-                    val pkg = line.trimStart().removePrefix("- ").trim()
-                    // Only process lines that look like package names (contain a dot, no spaces)
-                    if (pkg.contains('.') && !pkg.contains(' ')) {
-                        val category = when {
-                            currentType.contains("stalker", ignoreCase = true) -> "STALKERWARE"
-                            currentType.contains("spy", ignoreCase = true)     -> "SPYWARE"
-                            currentType.contains("monitor", ignoreCase = true) -> "MONITORING"
-                            else -> "STALKERWARE"
-                        }
-                        val displayName = currentName.ifBlank {
-                            pkg.substringAfterLast('.').replaceFirstChar { it.uppercase() }
-                        }
-                        results.add(
-                            IocEntry(
-                                packageName = pkg,
-                                name = displayName,
-                                category = category,
-                                severity = "CRITICAL",
-                                description = "Listed in the community stalkerware-indicators " +
-                                    "database (type: $currentType). " +
-                                    "See https://github.com/AssoEchap/stalkerware-indicators",
-                                source = sourceId,
-                                fetchedAt = fetchedAt
-                            )
-                        )
-                    }
-                }
-                // Any non-package-list line resets the inPackages flag
-                inPackages && !line.trimStart().startsWith("- ") && line.isNotBlank() -> {
-                    inPackages = false
-                }
+                results += IocEntry(
+                    packageName = pkg,
+                    name = displayName,
+                    category = category,
+                    severity = "CRITICAL",
+                    description = "Listed in the community stalkerware-indicators " +
+                        "database (type: ${family.type}). " +
+                        "See https://github.com/AssoEchap/stalkerware-indicators",
+                    source = sourceId,
+                    fetchedAt = fetchedAt,
+                )
             }
         }
         return results

--- a/app/src/main/java/com/androdr/ioc/feeds/StalkerwareYamlParser.kt
+++ b/app/src/main/java/com/androdr/ioc/feeds/StalkerwareYamlParser.kt
@@ -1,0 +1,113 @@
+package com.androdr.ioc.feeds
+
+/**
+ * Shared line-based YAML parser for the AssoEchap/stalkerware-indicators
+ * `ioc.yaml` format. Used by [StalkerwareIndicatorsFeed] (which filters to
+ * the `packages:` block) and [StalkerwareCertHashFeed] (which filters to the
+ * `certificates:` block).
+ *
+ * The upstream schema is regular enough that a minimal state machine beats
+ * pulling in a full YAML library:
+ *
+ *   - name: TheTruthSpy
+ *     type: stalkerware
+ *     packages:
+ *     - com.apspy.app
+ *     certificates:
+ *     - 31A6ECECD97CF39BC4126B8745CD94A7C30BF81C
+ *     websites:
+ *     - copy9.com
+ *     c2:
+ *       ips:
+ *       - 1.2.3.4
+ */
+internal object StalkerwareYamlParser {
+
+    /** One family's parsed record. */
+    internal data class FamilyEntry(
+        val name: String,
+        val type: String,
+        val packages: List<String>,
+        val certificates: List<String>,
+    )
+
+    /**
+     * Parses [yaml] into a list of [FamilyEntry]. Each `- name:` at column 0
+     * opens a new family; subsequent lines populate that family until the
+     * next `- name:`. Unknown blocks (c2, websites, distribution, …) are
+     * skipped without disrupting state.
+     *
+     * Cert fingerprints are normalized to lowercase hex (colons and spaces
+     * stripped) but **not** validated — callers decide whether to accept a
+     * given cert string.
+     */
+    @Suppress("LoopWithTooManyJumpStatements", "NestedBlockDepth")
+    internal fun parse(yaml: String): List<FamilyEntry> {
+        val results = mutableListOf<FamilyEntry>()
+        var currentName = ""
+        // Default to "stalkerware" until the family declares its type.
+        var currentType = "stalkerware"
+        var currentPackages = mutableListOf<String>()
+        var currentCerts = mutableListOf<String>()
+        var inBlock: Block = Block.NONE
+
+        fun flush() {
+            if (currentName.isNotBlank() || currentPackages.isNotEmpty() || currentCerts.isNotEmpty()) {
+                results += FamilyEntry(
+                    name = currentName,
+                    type = currentType,
+                    packages = currentPackages.toList(),
+                    certificates = currentCerts.toList(),
+                )
+            }
+            currentName = ""
+            // Reset type per family — otherwise an entry without `type:` would
+            // inherit the previous family's classification.
+            currentType = "stalkerware"
+            currentPackages = mutableListOf()
+            currentCerts = mutableListOf()
+            inBlock = Block.NONE
+        }
+
+        for (line in yaml.lines()) {
+            val trimmed = line.trimStart()
+            when {
+                line.startsWith("- name:") -> {
+                    flush()
+                    currentName = line.removePrefix("- name:").trim()
+                }
+                trimmed.startsWith("type:") -> {
+                    currentType = trimmed.removePrefix("type:").trim()
+                    inBlock = Block.NONE
+                }
+                trimmed == "packages:" -> inBlock = Block.PACKAGES
+                trimmed == "certificates:" -> inBlock = Block.CERTIFICATES
+                // Any other block-header ("websites:", "c2:", "distribution:",
+                // "ips:", etc.) exits both packages and certificates blocks.
+                trimmed.endsWith(":") && !trimmed.startsWith("- ") -> inBlock = Block.NONE
+                // List item inside a tracked block.
+                trimmed.startsWith("- ") && !line.startsWith("- name:") -> {
+                    val value = trimmed.removePrefix("- ").trim()
+                    when (inBlock) {
+                        Block.PACKAGES -> if (value.contains('.') && !value.contains(' ')) {
+                            currentPackages += value
+                        }
+                        Block.CERTIFICATES -> {
+                            val normalized = value.lowercase().replace(":", "").replace(" ", "")
+                            currentCerts += normalized
+                        }
+                        Block.NONE -> Unit
+                    }
+                }
+                // Reset tracked block on a non-list, non-blank line at column 0
+                // or lower indent — prevents a stray line between entries from
+                // re-opening the previous block.
+                line.isNotBlank() && !trimmed.startsWith("- ") -> inBlock = Block.NONE
+            }
+        }
+        flush()
+        return results
+    }
+
+    private enum class Block { NONE, PACKAGES, CERTIFICATES }
+}

--- a/app/src/main/java/com/androdr/scanner/AppScanner.kt
+++ b/app/src/main/java/com/androdr/scanner/AppScanner.kt
@@ -162,11 +162,11 @@ class AppScanner @Inject constructor(
 
         val isSystemApp = appInfo.flags and ApplicationInfo.FLAG_SYSTEM != 0
 
-        // Cert hash — skip for system apps (AOSP test key causes false positives)
+        // Cert hashes (SHA-256 + SHA-1) — skip for system apps (AOSP test key causes FPs)
         @Suppress("TooGenericExceptionCaught", "SwallowedException")
-        val certHash = if (!isSystemApp) {
+        val certHashes = if (!isSystemApp) {
             try {
-                extractCertHash(pkg)
+                extractCertHashes(pkg)
             } catch (e: Exception) {
                 Log.w(TAG, "collectTelemetry: cert hash extraction failed for $packageName: ${e.message}")
                 null
@@ -174,6 +174,8 @@ class AppScanner @Inject constructor(
         } else {
             null
         }
+        val certHash = certHashes?.sha256
+        val certHashSha1 = certHashes?.sha1
 
         // APK file hash for VirusTotal lookup
         @Suppress("TooGenericExceptionCaught", "SwallowedException")
@@ -249,6 +251,7 @@ class AppScanner @Inject constructor(
             packageName = packageName,
             appName = appName,
             certHash = certHash,
+            certHashSha1 = certHashSha1,
             apkHash = apkHash,
             isSystemApp = isSystemApp,
             fromTrustedStore = fromTrustedStore,
@@ -284,7 +287,17 @@ class AppScanner @Inject constructor(
         return digest.digest().joinToString("") { "%02x".format(it) }
     }
 
-    private fun extractCertHash(packageInfo: android.content.pm.PackageInfo): String? {
+    /**
+     * Returns SHA-256 + SHA-1 of the first signing cert. SHA-1 is required to
+     * match community feeds (stalkerware-indicators, MVT) that index by SHA-1,
+     * per the Android ecosystem convention (apksigner prints SHA-1 by default).
+     * Both hashes are of the same certificate bytes.
+     *
+     * Tripwire: if a 3rd algorithm is added (e.g. BLAKE3 64-hex collides with
+     * SHA-256 by length), switch from per-algo AppTelemetry fields to
+     * `Map<String, String>` keyed by algorithm and update rule 002 to iterate.
+     */
+    private fun extractCertHashes(packageInfo: android.content.pm.PackageInfo): CertHashes? {
         val signatures = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
             packageInfo.signingInfo?.apkContentsSigners
         } else {
@@ -292,9 +305,15 @@ class AppScanner @Inject constructor(
             packageInfo.signatures
         }
         val cert = signatures?.firstOrNull() ?: return null
-        val digest = MessageDigest.getInstance("SHA-256")
-        return digest.digest(cert.toByteArray()).joinToString("") { "%02x".format(it) }
+        val certBytes = cert.toByteArray()
+        val sha256 = MessageDigest.getInstance("SHA-256").digest(certBytes)
+            .joinToString("") { "%02x".format(it) }
+        val sha1 = MessageDigest.getInstance("SHA-1").digest(certBytes)
+            .joinToString("") { "%02x".format(it) }
+        return CertHashes(sha256 = sha256, sha1 = sha1)
     }
+
+    private data class CertHashes(val sha256: String, val sha1: String)
 
     /**
      * Returns the installer package name for [packageName], handling API-level differences

--- a/app/src/main/res/raw/sigma_androdr_002_cert_hash_ioc.yml
+++ b/app/src/main/res/raw/sigma_androdr_002_cert_hash_ioc.yml
@@ -10,9 +10,17 @@ logsource:
     product: androdr
     service: app_scanner
 detection:
-    selection:
+    # Single cert_hash_ioc_db holds fingerprints keyed by raw hex. SHA-256
+    # (64 hex chars) and SHA-1 (40 hex chars) cannot collide by length, so a
+    # unified table is safe. AppScanner emits both hashes of the same cert
+    # bytes so either algorithm can match. Community feeds
+    # (stalkerware-indicators, MVT) ship SHA-1 per Android ecosystem
+    # convention; bundled known_bad_certs.json uses SHA-256.
+    selection_sha256:
         cert_hash|ioc_lookup: cert_hash_ioc_db
-    condition: selection
+    selection_sha1:
+        cert_hash_sha1|ioc_lookup: cert_hash_ioc_db
+    condition: selection_sha256 or selection_sha1
 level: critical
 category: incident
 display:

--- a/app/src/test/java/com/androdr/ioc/feeds/StalkerwareCertHashFeedTest.kt
+++ b/app/src/test/java/com/androdr/ioc/feeds/StalkerwareCertHashFeedTest.kt
@@ -1,0 +1,232 @@
+package com.androdr.ioc.feeds
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class StalkerwareCertHashFeedTest {
+
+    private val feed = StalkerwareCertHashFeed()
+
+    @Test
+    fun `parses real TheTruthSpy entry with multiple cert SHA-1s`() {
+        val yaml = """
+            - name: TheTruthSpy
+              type: stalkerware
+              packages:
+              - com.apspy.app
+              certificates:
+              - 31A6ECECD97CF39BC4126B8745CD94A7C30BF81C
+              - 36E6671BC4397F475A350905D9A649A5ADE97BB2
+              websites:
+              - copy9.com
+        """.trimIndent()
+
+        val results = feed.parseYaml(yaml, fetchedAt = 42L)
+
+        assertEquals(2, results.size)
+        // Hashes must be normalized to lowercase for consistent matching against
+        // AppScanner telemetry (which emits lowercase hex).
+        assertEquals("31a6ececd97cf39bc4126b8745cd94a7c30bf81c", results[0].certHash)
+        assertEquals("36e6671bc4397f475a350905d9a649a5ade97bb2", results[1].certHash)
+        assertTrue(results.all { it.familyName == "TheTruthSpy" })
+        assertTrue(results.all { it.category == "STALKERWARE" })
+        assertTrue(results.all { it.severity == "CRITICAL" })
+        assertTrue(results.all { it.source == "stalkerware_indicators_certs" })
+        assertTrue(results.all { it.fetchedAt == 42L })
+    }
+
+    @Test
+    fun `skips websites and packages fields — only certificates are emitted`() {
+        val yaml = """
+            - name: FakeFamily
+              type: stalkerware
+              packages:
+              - com.fake.app
+              websites:
+              - fake.example.com
+              certificates:
+              - 0123456789abcdef0123456789abcdef01234567
+        """.trimIndent()
+
+        val results = feed.parseYaml(yaml, fetchedAt = 0L)
+
+        assertEquals(1, results.size)
+        assertEquals("0123456789abcdef0123456789abcdef01234567", results[0].certHash)
+    }
+
+    @Test
+    fun `multiple families each contribute their own cert hashes`() {
+        val yaml = """
+            - name: FamA
+              type: stalkerware
+              certificates:
+              - 1111aaaa2222bbbb3333cccc4444dddd5555eeee
+            - name: FamB
+              type: spyware
+              certificates:
+              - 2222bbbb3333cccc4444dddd5555eeee6666ffff
+        """.trimIndent()
+
+        val results = feed.parseYaml(yaml, fetchedAt = 0L)
+
+        assertEquals(2, results.size)
+        assertEquals("FamA", results[0].familyName)
+        assertEquals("STALKERWARE", results[0].category)
+        assertEquals("FamB", results[1].familyName)
+        assertEquals("SPYWARE", results[1].category)
+    }
+
+    @Test
+    fun `rejects malformed entries — non-hex and wrong length`() {
+        val yaml = """
+            - name: Bad
+              type: stalkerware
+              certificates:
+              - NOT-A-HEX-CERT-FINGERPRINT-AT-ALL
+              - 1234
+              - 1111aaaa2222bbbb3333cccc4444dddd5555eeee
+        """.trimIndent()
+
+        val results = feed.parseYaml(yaml, fetchedAt = 0L)
+
+        assertEquals(1, results.size)
+        assertEquals("1111aaaa2222bbbb3333cccc4444dddd5555eeee", results[0].certHash)
+    }
+
+    @Test
+    fun `colons and spaces in cert strings are stripped before validation`() {
+        // Some communities write SHA-1s with colons (aa:bb:cc:…). Accept that format.
+        val yaml = """
+            - name: Formatted
+              type: stalkerware
+              certificates:
+              - AB:CD:EF:01:23:45:67:89:AB:CD:EF:01:23:45:67:89:AB:CD:EF:01
+        """.trimIndent()
+
+        val results = feed.parseYaml(yaml, fetchedAt = 0L)
+
+        assertEquals(1, results.size)
+        assertEquals("abcdef0123456789abcdef0123456789abcdef01", results[0].certHash)
+    }
+
+    @Test
+    fun `empty yaml returns empty list`() {
+        assertTrue(feed.parseYaml("", fetchedAt = 0L).isEmpty())
+    }
+
+    @Test
+    fun `yaml with no certificates fields returns empty list`() {
+        val yaml = """
+            - name: NoCerts
+              type: stalkerware
+              packages:
+              - com.example.app
+              websites:
+              - example.com
+        """.trimIndent()
+
+        assertTrue(feed.parseYaml(yaml, fetchedAt = 0L).isEmpty())
+    }
+
+    @Test
+    fun `entering packages block exits cert block`() {
+        // Order-independence: if packages block appears after certificates in one
+        // entry, we still correctly exit the cert block.
+        val yaml = """
+            - name: OrderTest
+              type: stalkerware
+              certificates:
+              - 1111aaaa2222bbbb3333cccc4444dddd5555eeee
+              packages:
+              - com.example.app
+              - 2222bbbb3333cccc4444dddd5555eeee6666ffff
+        """.trimIndent()
+
+        val results = feed.parseYaml(yaml, fetchedAt = 0L)
+
+        assertEquals(1, results.size)
+        assertEquals("1111aaaa2222bbbb3333cccc4444dddd5555eeee", results[0].certHash)
+        // Must NOT ingest the 2222... as a cert — it's under `packages:` in this entry.
+        assertFalse(results.any { it.certHash.startsWith("2222") })
+    }
+
+    @Test
+    fun `rejects low-entropy hex — all-zeros and all-ones`() {
+        // Upstream-poisoning defence: a malicious PR to AssoEchap that inserts
+        // 000…0 or FFF…F as a "cert" would otherwise match every app that
+        // happens to produce those digest values, plus signal-free bogus data.
+        val yaml = """
+            - name: Poisoned
+              type: stalkerware
+              certificates:
+              - 0000000000000000000000000000000000000000
+              - ffffffffffffffffffffffffffffffffffffffff
+              - abababababababababababababababababababab
+              - 1111aaaa2222bbbb3333cccc4444dddd5555eeee
+        """.trimIndent()
+
+        val results = feed.parseYaml(yaml, fetchedAt = 0L)
+
+        // Only the high-entropy fingerprint survives.
+        assertEquals(1, results.size)
+        assertEquals("1111aaaa2222bbbb3333cccc4444dddd5555eeee", results[0].certHash)
+    }
+
+    @Test
+    fun `c2 and distribution blocks between families do not leak into next family`() {
+        // Real ioc.yaml entries carry c2 / distribution / websites blocks
+        // before/after the cert block. State reset between families must survive.
+        val yaml = """
+            - name: FamA
+              type: stalkerware
+              certificates:
+              - 1111aaaa2222bbbb3333cccc4444dddd5555eeee
+              websites:
+              - fama.example.com
+              c2:
+                ips:
+                - 1.2.3.4
+                domains:
+                - c2.fama.com
+              distribution:
+                - app.fama.com
+            - name: FamB
+              type: spyware
+              certificates:
+              - 2222bbbb3333cccc4444dddd5555eeee6666ffff
+        """.trimIndent()
+
+        val results = feed.parseYaml(yaml, fetchedAt = 0L)
+
+        assertEquals(2, results.size)
+        assertEquals("FamA", results[0].familyName)
+        assertEquals("STALKERWARE", results[0].category)
+        assertEquals("FamB", results[1].familyName)
+        assertEquals("SPYWARE", results[1].category)
+    }
+
+    @Test
+    fun `family without explicit type defaults to stalkerware and does not inherit previous family type`() {
+        // Previously the parser held a module-level currentType variable that
+        // leaked across families. If FamB omits `type:`, it must default to
+        // stalkerware, not inherit FamA's `spyware`.
+        val yaml = """
+            - name: FamA
+              type: spyware
+              certificates:
+              - 1111aaaa2222bbbb3333cccc4444dddd5555eeee
+            - name: FamB
+              certificates:
+              - 2222bbbb3333cccc4444dddd5555eeee6666ffff
+        """.trimIndent()
+
+        val results = feed.parseYaml(yaml, fetchedAt = 0L)
+
+        assertEquals(2, results.size)
+        assertEquals("SPYWARE", results[0].category)
+        // FamB has no `type:` — must default to stalkerware, not inherit SPYWARE.
+        assertEquals("STALKERWARE", results[1].category)
+    }
+}

--- a/app/src/test/java/com/androdr/sigma/LogsourceTaxonomyCrossCheckTest.kt
+++ b/app/src/test/java/com/androdr/sigma/LogsourceTaxonomyCrossCheckTest.kt
@@ -68,7 +68,7 @@ class LogsourceTaxonomyCrossCheckTest {
     /** Services whose toFieldMap() is a member function on the data class. */
     private fun memberFunctionFieldMaps(): Map<String, Set<String>> = mapOf(
         "app_scanner" to AppTelemetry(
-            packageName = "x", appName = "x", certHash = null, apkHash = null,
+            packageName = "x", appName = "x", certHash = null, certHashSha1 = null, apkHash = null,
             isSystemApp = false, fromTrustedStore = false, installer = null,
             isSideloaded = false, isKnownOemApp = false, permissions = emptyList(),
             surveillancePermissionCount = 0, hasAccessibilityService = false,

--- a/app/src/test/java/com/androdr/sigma/SigmaRuleEngineDisabledRuleTest.kt
+++ b/app/src/test/java/com/androdr/sigma/SigmaRuleEngineDisabledRuleTest.kt
@@ -41,6 +41,7 @@ class SigmaRuleEngineDisabledRuleTest {
         packageName = "com.test.app",
         appName = "Test App",
         certHash = null,
+        certHashSha1 = null,
         apkHash = null,
         isSystemApp = false,
         fromTrustedStore = false,


### PR DESCRIPTION
## Summary

- AndroDR was already fetching \`AssoEchap/stalkerware-indicators/ioc.yaml\` daily via \`StalkerwareIndicatorsFeed\`, but the parser only consumed the \`packages:\` block and silently threw away the \`certificates:\` half of the data. That field carries SHA-1 signing-cert fingerprints per stalkerware family — a stronger pivot than package names (stable across versions and distribution channels) and the canonical pattern used by MVT / Citizen Lab / Amnesty Security Lab for known-bad cert IOC matching.
- Required enabling change: \`AppScanner\` now emits SHA-1 of the signing cert alongside the existing SHA-256, exposed as \`cert_hash_sha1\` in \`app_scanner\` telemetry. Community cert feeds across the Android ecosystem use SHA-1 (the \`apksigner --print-certs\` default) — without it no stalkerware-indicators cert IOC could ever match.
- Rule 002 (Malicious Certificate) now matches either algorithm against the unified \`cert_hash_ioc_db\`; keys are length-disjoint (SHA-1=40 hex, SHA-256=64) so a single table is safe.

## Research-validated context

Deep research (full transcript in #147 thread) against MVT source, Citizen Lab published investigations, and Amnesty Security Lab reports confirmed:
- **No positive-trust cert DB exists** in the mobile-forensics field. MVT ships only known-bad cert matching (\`check_app_certificate_hash\`). Citizen Lab's Paragon/Graphite Android methodology uses artifact-based detection, not cert allowlists.
- **Stalkerware-indicators is the canonical community feed** for known-bad Android cert hashes, indexed by SHA-1.
- **Unknown certs → recorded for review, never flagged by default** (MVT posture; AndroDR's PR #149 posture already matches this).

This PR operationalizes that research instead of the earlier "build known-good cert DB" plan, which would duplicate work the ecosystem has explicitly chosen not to do.

## What landed

- New \`StalkerwareCertHashFeed\` implementing \`CertHashIocFeed\` — parses \`certificates:\` per family, emits \`CertHashIocEntry\` entries with severity CRITICAL and category {STALKERWARE|SPYWARE|MONITORING} from the upstream \`type:\` field.
- New \`StalkerwareYamlParser\` — extracted from the existing single-feed parser; the two stalkerware feeds now share one state machine (addresses architect-reviewer debt flag). Family \`type:\` resets per \`- name:\` entry so missing \`type:\` lines don't inherit prior classification (code-reviewer fix).
- Upstream-poisoning defence: cert hashes with <4 unique hex characters are rejected. Defends against a malicious PR to AssoEchap that inserts \`000…0\` / \`FFF…F\` to match every app producing those digest bytes.
- \`AppScanner.extractCertHashes\` refactored to return both SHA-256 and SHA-1 of the same cert bytes. Dead single-algo wrapper removed.
- \`AppTelemetry\` gains \`certHashSha1: String?\` field and \`cert_hash_sha1\` map key.
- Rule 002 extended to \`selection_sha256 or selection_sha1\`; tripwire comment flags refactor needed if a 3rd algorithm with a colliding length is ever added.
- Submodule bump covers the taxonomy addition (android-sigma-rules#11) and the bundled rule-002 sibling update (android-sigma-rules#12). Both merged; pointer moved to \`5249097\`.
- DI wiring: new feed registered alongside \`MalwareBazaarCertFeed\` in \`provideCertHashIocFeeds\`.

## Test plan

- [x] New parser tests: 11 cases covering real TheTruthSpy entry, block-ordering variations, colon-formatted hashes, \`c2:\`/\`distribution:\` inter-family noise, missing \`type:\` (no inheritance), low-entropy hex rejection, malformed inputs
- [x] Existing telemetry + cross-check tests updated for the new \`certHashSha1\` field
- [x] \`./gradlew testDebugUnitTest lintDebug\` — full suite green (local "CI" equivalent; remote Actions still shadowbanned per #147 thread)
- [x] Two-reviewer cycle completed — all flagged must-fix items addressed in the commit (submodule-side rule update, \`currentType\` leak, entropy filter, shared parser extraction)

## Follow-ups (explicitly out of scope)

- Extend \`MvtIndicatorsFeed\` to emit cert-hash IOCs from STIX \`app:cert.sha1/sha256\` patterns (currently emits domain IOCs only). Natural sibling; deferred to keep this PR scoped.
- \`cert_hashes: Map<String, String>\` keyed by algorithm — refactor tripwire if a 3rd algorithm is ever added (see comment in \`AppScanner.extractCertHashes\` and rule 002).

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)