### PR TITLE
feat(scanner): emit device_admin_grant forensic timeline events (#79)

### DIFF
--- a/app/src/main/java/com/androdr/data/db/ForensicTimelineEventDao.kt
+++ b/app/src/main/java/com/androdr/data/db/ForensicTimelineEventDao.kt
@@ -44,6 +44,9 @@ interface ForensicTimelineEventDao {
     @Query("SELECT DISTINCT packageName FROM forensic_timeline WHERE category = 'package_install'")
     suspend fun getInstalledPackagesAlreadyEmitted(): List<String>
 
+    @Query("SELECT DISTINCT packageName FROM forensic_timeline WHERE category = 'device_admin_grant'")
+    suspend fun getAdminGrantedPackagesAlreadyEmitted(): List<String>
+
     @Query("SELECT * FROM forensic_timeline ORDER BY startTimestamp ASC LIMIT 10000")
     suspend fun getAllForExport(): List<ForensicTimelineEvent>
 

--- a/app/src/main/java/com/androdr/scanner/DeviceAdminGrantEmitter.kt
+++ b/app/src/main/java/com/androdr/scanner/DeviceAdminGrantEmitter.kt
@@ -1,0 +1,95 @@
+package com.androdr.scanner
+
+import android.app.admin.DevicePolicyManager
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import com.androdr.data.db.ForensicTimelineEventDao
+import com.androdr.data.model.ForensicTimelineEvent
+import com.androdr.data.model.TelemetrySource
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Emits one ForensicTimelineEvent per newly observed device-admin package on
+ * each scan. Mirrors [InstallEventEmitter]: the forensic_timeline table
+ * itself is the dedup store — any package already present with
+ * category = "device_admin_grant" is skipped.
+ *
+ * Timestamps are "now" (the observation time), not the real grant time —
+ * Android does not expose grant timestamps to third-party apps. Rows carry
+ * timestampPrecision = "approximate" to make this explicit.
+ */
+@Singleton
+class DeviceAdminGrantEmitter @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val timelineDao: ForensicTimelineEventDao,
+) {
+
+    /**
+     * Reads the current active-admin set from [DevicePolicyManager] and
+     * returns timeline rows for packages not already present in the
+     * forensic_timeline table with category = "device_admin_grant".
+     */
+    suspend fun emitNew(scanId: Long): List<ForensicTimelineEvent> {
+        val dpm = context.getSystemService(DevicePolicyManager::class.java)
+            ?: return emptyList()
+        // activeAdmins returns ComponentNames; multiple receivers under one
+        // package (or work-profile vs primary-owner admins on the profile
+        // where AndroDR runs) collapse to a single row per package via the
+        // .distinct() call inside buildEvents.
+        val packages = dpm.activeAdmins?.map { it.packageName } ?: return emptyList()
+        if (packages.isEmpty()) return emptyList()
+        return buildEvents(scanId, packages, System.currentTimeMillis(), ::resolveAppLabel)
+    }
+
+    /**
+     * Internal test seam: pure logic over an explicit active-admin list,
+     * a fixed `now`, and a label resolver. Keeps the unit tests free of
+     * Android system-service mocking.
+     */
+    internal suspend fun buildEvents(
+        scanId: Long,
+        activeAdminPackages: List<String>,
+        now: Long,
+        labelFor: (String) -> String,
+    ): List<ForensicTimelineEvent> {
+        val unique = activeAdminPackages.distinct()
+        if (unique.isEmpty()) return emptyList()
+        val alreadyEmitted = timelineDao
+            .getAdminGrantedPackagesAlreadyEmitted()
+            .toHashSet()
+        return unique
+            .filter { it !in alreadyEmitted }
+            .map { pkg ->
+                val label = labelFor(pkg)
+                ForensicTimelineEvent(
+                    scanResultId = scanId,
+                    startTimestamp = now,
+                    timestampPrecision = "approximate",
+                    kind = "event",
+                    category = "device_admin_grant",
+                    source = "device_admin_emitter",
+                    description = "App granted device admin: $label ($pkg)",
+                    packageName = pkg,
+                    appName = label,
+                    telemetrySource = TelemetrySource.LIVE_SCAN,
+                )
+            }
+    }
+
+    // Mirrors PackageLifecycleReceiver.resolveAppLabel.
+    @Suppress("SwallowedException", "DEPRECATION")
+    private fun resolveAppLabel(pkg: String): String = try {
+        val pm = context.packageManager
+        val info = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            pm.getApplicationInfo(pkg, PackageManager.ApplicationInfoFlags.of(0))
+        } else {
+            pm.getApplicationInfo(pkg, 0)
+        }
+        pm.getApplicationLabel(info).toString()
+    } catch (e: PackageManager.NameNotFoundException) {
+        pkg
+    }
+}

--- a/app/src/main/java/com/androdr/scanner/ScanOrchestrator.kt
+++ b/app/src/main/java/com/androdr/scanner/ScanOrchestrator.kt
@@ -51,6 +51,7 @@ class ScanOrchestrator @Inject constructor(
     private val dnsEventDao: DnsEventDao,
     private val forensicTimelineEventDao: ForensicTimelineEventDao,
     private val installEventEmitter: InstallEventEmitter,
+    private val deviceAdminGrantEmitter: DeviceAdminGrantEmitter,
     private val sigmaRuleEngine: SigmaRuleEngine,
     private val sigmaCorrelationEngine: SigmaCorrelationEngine,
     private val indicatorResolver: IndicatorResolver,
@@ -365,7 +366,12 @@ class ScanOrchestrator @Inject constructor(
         // such members. Fixed in `saveScanWithCorrelation`.
         val installEvents = runCatching {
             installEventEmitter.emitNew(result.id, appTelemetry)
-        }.getOrDefault(emptyList())
+        }.onFailure { Log.w(TAG, "installEventEmitter failed: ${it.message}", it) }
+            .getOrDefault(emptyList())
+        val adminGrantEvents = runCatching {
+            deviceAdminGrantEmitter.emitNew(result.id)
+        }.onFailure { Log.w(TAG, "deviceAdminGrantEmitter failed: ${it.message}", it) }
+            .getOrDefault(emptyList())
         val correlationRules = sigmaRuleEngine.getCorrelationRules()
         val maxRuleWindowMs = correlationRules.maxOfOrNull { it.timespanMs } ?: 0L
         val lookbackEvents = if (maxRuleWindowMs > 0) {
@@ -378,7 +384,7 @@ class ScanOrchestrator @Inject constructor(
         runCatching {
             scanRepository.saveScanWithCorrelation(
                 scan = result,
-                findingTimelineEvents = installEvents + findingTimelineEvents,
+                findingTimelineEvents = installEvents + adminGrantEvents + findingTimelineEvents,
                 replaceUsageStatsEvents = taggedUsageEvents,
                 lookbackEvents = lookbackEvents
             ) { eventsWithIds ->
@@ -397,7 +403,8 @@ class ScanOrchestrator @Inject constructor(
                 }
             }
             Log.i(TAG, "Persisted scan ${result.id} with ${findingTimelineEvents.size} finding, " +
-                "${installEvents.size} install, $correlationSignalCount signal, " +
+                "${installEvents.size} install, ${adminGrantEvents.size} admin_grant, " +
+                "$correlationSignalCount signal, " +
                 "${taggedUsageEvents.size} usage events (single transaction)")
         }.onFailure { Log.e(TAG, "Failed to persist scan results", it) }
 

--- a/app/src/test/java/com/androdr/scanner/DeviceAdminGrantEmitterTest.kt
+++ b/app/src/test/java/com/androdr/scanner/DeviceAdminGrantEmitterTest.kt
@@ -1,0 +1,164 @@
+package com.androdr.scanner
+
+import android.app.admin.DevicePolicyManager
+import android.content.ComponentName
+import android.content.Context
+import com.androdr.data.db.ForensicTimelineEventDao
+import com.androdr.data.model.TelemetrySource
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DeviceAdminGrantEmitterTest {
+
+    private val idLabel: (String) -> String = { it }
+
+    private fun emitter(known: List<String>): Pair<DeviceAdminGrantEmitter, ForensicTimelineEventDao> {
+        val dao = mockk<ForensicTimelineEventDao>(relaxed = true)
+        coEvery { dao.getAdminGrantedPackagesAlreadyEmitted() } returns known
+        val context = mockk<Context>(relaxed = true)
+        return DeviceAdminGrantEmitter(context, dao) to dao
+    }
+
+    @Test
+    fun `first scan with two active admins emits two rows`() = runTest {
+        val (emitter, _) = emitter(known = emptyList())
+        val rows = emitter.buildEvents(
+            scanId = 1L,
+            activeAdminPackages = listOf("com.a", "com.b"),
+            now = 100_000L,
+            labelFor = idLabel,
+        )
+        assertEquals(2, rows.size)
+        assertEquals("com.a", rows[0].packageName)
+        assertEquals("device_admin_grant", rows[0].category)
+        assertEquals("approximate", rows[0].timestampPrecision)
+        assertEquals(100_000L, rows[0].startTimestamp)
+        assertEquals("event", rows[0].kind)
+        assertEquals(TelemetrySource.LIVE_SCAN, rows[0].telemetrySource)
+        assertEquals(1L, rows[0].scanResultId)
+    }
+
+    @Test
+    fun `subsequent scan with no change emits zero rows`() = runTest {
+        val (emitter, _) = emitter(known = listOf("com.a", "com.b"))
+        val rows = emitter.buildEvents(2L, listOf("com.a", "com.b"), 100_000L, idLabel)
+        assertTrue(rows.isEmpty())
+    }
+
+    @Test
+    fun `one newly-added admin emits exactly one row`() = runTest {
+        val (emitter, _) = emitter(known = listOf("com.a"))
+        val rows = emitter.buildEvents(3L, listOf("com.a", "com.b"), 100_000L, idLabel)
+        assertEquals(1, rows.size)
+        assertEquals("com.b", rows[0].packageName)
+    }
+
+    @Test
+    fun `duplicate ComponentNames under one package collapse to a single row`() = runTest {
+        val (emitter, _) = emitter(known = emptyList())
+        val rows = emitter.buildEvents(4L, listOf("com.a", "com.a"), 100_000L, idLabel)
+        assertEquals(1, rows.size)
+        assertEquals("com.a", rows[0].packageName)
+    }
+
+    @Test
+    fun `previously-emitted package is not re-emitted after uninstall and reinstall`() = runTest {
+        // DAO row persists for com.a even after uninstall.  User reinstalls the
+        // same package and re-grants admin.  The table-as-dedup-store must
+        // suppress re-emission — mirrors InstallEventEmitter semantics.
+        val (emitter, _) = emitter(known = listOf("com.a"))
+        val rows = emitter.buildEvents(5L, listOf("com.a"), 100_000L, idLabel)
+        assertTrue(rows.isEmpty())
+    }
+
+    @Test
+    fun `DevicePolicyManager unavailable returns empty list without DAO call`() = runTest {
+        val dao = mockk<ForensicTimelineEventDao>(relaxed = true)
+        val context = mockk<Context>(relaxed = true)
+        every { context.getSystemService(DevicePolicyManager::class.java) } returns null
+        val result = DeviceAdminGrantEmitter(context, dao).emitNew(scanId = 1L)
+        assertTrue(result.isEmpty())
+        coVerify(exactly = 0) { dao.getAdminGrantedPackagesAlreadyEmitted() }
+    }
+
+    @Test
+    fun `null activeAdmins returns empty list without DAO call`() = runTest {
+        val dao = mockk<ForensicTimelineEventDao>(relaxed = true)
+        val context = mockk<Context>(relaxed = true)
+        val dpm = mockk<DevicePolicyManager>()
+        every { context.getSystemService(DevicePolicyManager::class.java) } returns dpm
+        every { dpm.activeAdmins } returns null
+        val result = DeviceAdminGrantEmitter(context, dao).emitNew(scanId = 1L)
+        assertTrue(result.isEmpty())
+        coVerify(exactly = 0) { dao.getAdminGrantedPackagesAlreadyEmitted() }
+    }
+
+    @Test
+    fun `empty activeAdmins list returns empty list without DAO call`() = runTest {
+        val dao = mockk<ForensicTimelineEventDao>(relaxed = true)
+        val context = mockk<Context>(relaxed = true)
+        val dpm = mockk<DevicePolicyManager>()
+        every { context.getSystemService(DevicePolicyManager::class.java) } returns dpm
+        every { dpm.activeAdmins } returns emptyList<ComponentName>()
+        val result = DeviceAdminGrantEmitter(context, dao).emitNew(scanId = 1L)
+        assertTrue(result.isEmpty())
+        coVerify(exactly = 0) { dao.getAdminGrantedPackagesAlreadyEmitted() }
+    }
+
+    @Test
+    fun `emitted row source and description are correct`() = runTest {
+        val (emitter, _) = emitter(known = emptyList())
+        val rows = emitter.buildEvents(
+            1L, listOf("com.evil"), 100_000L, labelFor = { "Evil App" }
+        )
+        assertEquals(1, rows.size)
+        assertEquals("device_admin_emitter", rows[0].source)
+        assertEquals("Evil App", rows[0].appName)
+        assertTrue(rows[0].description.contains("Evil App"))
+        assertTrue(rows[0].description.contains("com.evil"))
+    }
+
+    @Test
+    fun `dedup DAO query is invoked when there are admins to consider`() = runTest {
+        // Refactor guard: if someone changes the category string in
+        // DeviceAdminGrantEmitter or in the DAO query (or unwires them
+        // from each other), this test would still pass on output but
+        // the verify call below catches the mismatch.
+        val (emitter, dao) = emitter(known = listOf("com.a"))
+        emitter.buildEvents(1L, listOf("com.a", "com.b"), 100_000L, idLabel)
+        coVerify(exactly = 1) { dao.getAdminGrantedPackagesAlreadyEmitted() }
+    }
+
+    @Test
+    fun `emitter does not insert via DAO — persistence is the orchestrator's job`() = runTest {
+        // Refactor guard: ensures the emitter never starts persisting
+        // independently of saveScanWithCorrelation (which would double-write
+        // every admin row and bypass the correlation transaction's ID
+        // assignment).
+        val (emitter, dao) = emitter(known = emptyList())
+        emitter.buildEvents(1L, listOf("com.a", "com.b"), 100_000L, idLabel)
+        coVerify(exactly = 0) { dao.insert(any()) }
+        coVerify(exactly = 0) { dao.insertAll(any()) }
+    }
+
+    @Test
+    fun `label resolution failure falls back to package name`() = runTest {
+        // Not strictly a unit for the emitter itself; documents the contract
+        // that labelFor can return the package name unchanged when the label
+        // resolver throws NameNotFoundException in production.
+        val (emitter, _) = emitter(known = emptyList())
+        val rows = emitter.buildEvents(
+            1L, listOf("com.missing"), 100_000L, labelFor = { pkg -> pkg }
+        )
+        assertEquals(1, rows.size)
+        assertEquals("com.missing", rows[0].appName)
+        assertFalse(rows[0].description.isBlank())
+    }
+}

--- a/app/src/test/java/com/androdr/scanner/ScanOrchestratorErrorHandlingTest.kt
+++ b/app/src/test/java/com/androdr/scanner/ScanOrchestratorErrorHandlingTest.kt
@@ -132,6 +132,7 @@ class ScanOrchestratorErrorHandlingTest {
             dnsEventDao = dnsEventDao,
             forensicTimelineEventDao = mockk(relaxed = true),
             installEventEmitter = mockk(relaxed = true),
+            deviceAdminGrantEmitter = mockk(relaxed = true),
             sigmaRuleEngine = sigmaRuleEngine,
             sigmaCorrelationEngine = mockk(relaxed = true),
             indicatorResolver = indicatorResolver,

--- a/app/src/test/java/com/androdr/sigma/SigmaCorrelationEngineTest.kt
+++ b/app/src/test/java/com/androdr/sigma/SigmaCorrelationEngineTest.kt
@@ -81,6 +81,27 @@ class SigmaCorrelationEngineTest {
     }
 
     @Test
+    fun `first-scan seeding — historic install plus fresh admin-now does not fire corr-001`() {
+        // Issue #79 seeding-strategy guard. On the first AndroDR scan after
+        // install, DeviceAdminGrantEmitter stamps pre-existing admins with
+        // timestamp = now. A genuine historic install (firstInstallTime) may
+        // sit weeks or months before that. corr-001's 1h window must reject
+        // that pair, otherwise every device with any pre-existing admin would
+        // produce a false "install-then-admin" finding on first scan.
+        val thirtyDaysMs = 30L * 24L * 3_600_000L
+        val events = listOf(
+            event(1, 1_000L, "package_install"),                    // "real" historic install
+            event(2, 1_000L + thirtyDaysMs, "device_admin_grant")    // "now" on first scan
+        )
+        val binds = bindings(1L to setOf("atom-install"), 2L to setOf("atom-admin"))
+        val signals = SigmaCorrelationEngine().evaluate(listOf(installRule), events, binds)
+        assertTrue(
+            "historic install plus seed-timestamp admin must not fire corr-001",
+            signals.isEmpty()
+        )
+    }
+
+    @Test
     fun `event_count fires when threshold met within window`() {
         val events = listOf(
             event(1, 1000, "permission_use"),

--- a/docs/superpowers/specs/2026-04-22-issue-79-device-admin-grant-emitter-design.md
+++ b/docs/superpowers/specs/2026-04-22-issue-79-device-admin-grant-emitter-design.md
@@ -1,0 +1,233 @@
+# Issue #79 — `device_admin_grant` forensic timeline emitter
+
+- **Issue:** #79 (`Add forensic_timeline emitter for device admin grant events`)
+- **Date:** 2026-04-22
+- **Status:** Draft — revised after two-reviewer cycle 2026-04-22
+- **Target branch:** `main`
+- **Scope estimate:** ~150 LOC + tests, one PR
+
+## Background
+
+Sprint #75 shipped the atom rule `androdr-atom-device-admin-grant` and the
+correlation rule `androdr-corr-001` (install-then-admin). Both require
+`ForensicTimelineEvent` rows with `category = "device_admin_grant"`.
+
+**No code currently emits that category.** Confirmed by grep over `app/src/main`
+(2026-04-22): the category string appears only in rule YAML, test fixtures, and
+a test-comment explicitly noting "no producer of category='device_admin_grant'".
+`androdr-corr-001` loads and parses but never fires on real events.
+
+## Decision
+
+Add a runtime-poll emitter that mirrors the existing `InstallEventEmitter`
+pattern: at scan time, read the current active-admin set via
+`DevicePolicyManager.getActiveAdmins()`, diff against packages that already
+have a `device_admin_grant` row in `forensic_timeline`, and insert one new
+row per newly-observed admin package.
+
+**Rejected alternatives:**
+
+- **Broadcast-receiver / event-driven.** Android does not broadcast
+  `ACTION_DEVICE_ADMIN_ENABLED` to third-party apps — it fires only on the
+  admin's own `DeviceAdminReceiver`. Third-party apps cannot observe the event
+  in real time without being the admin themselves.
+- **Bug-report module parsing `dumpsys device_policy`.** Dumpsys lists active
+  admins but does not include grant timestamps. Useful for reconstructing
+  "who is admin now" but provides no time data for correlation. May be added
+  later for historic reconstruction; not in scope here.
+
+## Design
+
+### Component
+
+New file: `app/src/main/java/com/androdr/scanner/DeviceAdminGrantEmitter.kt`
+
+```kotlin
+@Singleton
+class DeviceAdminGrantEmitter @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val timelineDao: ForensicTimelineEventDao,
+) {
+    suspend fun emitNew(scanId: Long): List<ForensicTimelineEvent> {
+        val dpm = context.getSystemService(DevicePolicyManager::class.java)
+            ?: return emptyList()
+        val activeAdminPackages = (dpm.activeAdmins ?: emptyList())
+            .map { it.packageName }
+            .distinct()
+        val alreadyEmitted = timelineDao
+            .getAdminGrantedPackagesAlreadyEmitted()
+            .toHashSet()
+        val now = System.currentTimeMillis()
+        return activeAdminPackages
+            .filter { it !in alreadyEmitted }
+            .map { pkg ->
+                val label = resolveAppLabel(pkg)
+                ForensicTimelineEvent(
+                    scanResultId = scanId,
+                    startTimestamp = now,
+                    timestampPrecision = "approximate", // now != real grant time
+                    kind = "event",
+                    category = "device_admin_grant",
+                    source = "device_admin_emitter",
+                    description = "App granted device admin: $label ($pkg)",
+                    packageName = pkg,
+                    appName = label,
+                    telemetrySource = TelemetrySource.LIVE_SCAN,
+                )
+            }
+    }
+
+    // Mirrors PackageLifecycleReceiver.resolveAppLabel; duplicated rather
+    // than extracted — a shared helper is a separate refactor.
+    private fun resolveAppLabel(pkg: String): String = try {
+        val pm = context.packageManager
+        val info = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            pm.getApplicationInfo(pkg, PackageManager.ApplicationInfoFlags.of(0))
+        } else {
+            pm.getApplicationInfo(pkg, 0)
+        }
+        pm.getApplicationLabel(info).toString()
+    } catch (_: PackageManager.NameNotFoundException) { pkg }
+}
+```
+
+`minSdk = 26` (confirmed in `app/build.gradle.kts`), so the typed
+`getSystemService(DevicePolicyManager::class.java)` overload (API 23+) is safe.
+
+### DAO addition
+
+`ForensicTimelineEventDao.kt`:
+
+```kotlin
+@Query("SELECT DISTINCT packageName FROM forensic_timeline WHERE category = 'device_admin_grant'")
+suspend fun getAdminGrantedPackagesAlreadyEmitted(): List<String>
+```
+
+Matches the existing `getInstalledPackagesAlreadyEmitted()` exactly (no
+`packageName != ''` filter — a `device_admin_grant` row without a package
+cannot exist because `ComponentName.getPackageName()` is non-null).
+
+### Wiring
+
+In `ScanOrchestrator.kt` the install emitter is called immediately before the
+correlation-aware save (see lines 366–381). Admin events must join the **same**
+concatenation that passes through `saveScanWithCorrelation`, so Room assigns
+real IDs before the correlation engine runs:
+
+```kotlin
+val installEvents = runCatching {
+    installEventEmitter.emitNew(result.id, appTelemetry)
+}.getOrDefault(emptyList())
+
+val adminGrantEvents = runCatching {
+    deviceAdminGrantEmitter.emitNew(result.id)
+}.getOrDefault(emptyList())
+
+// ... correlation rule discovery + lookback window unchanged ...
+
+scanRepository.saveScanWithCorrelation(
+    scan = result,
+    findingTimelineEvents =
+        installEvents + adminGrantEvents + findingTimelineEvents,
+    ...
+)
+```
+
+Admin emit runs **after** install emit so that for a new install + grant in
+the same scan, install appears earlier in the batch. `saveScanWithCorrelation`
+assigns IDs via `insertAll`, then invokes the correlation block with
+`eventsWithIds`; `corr-001` (`temporal_ordered`) keys off `startTimestamp`
+directly, so list order is cosmetic — but keeping it stable aids debugging.
+
+### Three design decisions
+
+1. **State storage: none new.** The `forensic_timeline` table itself is the
+   dedup store. Same approach as `InstallEventEmitter`. No new Room table, no
+   SharedPreferences.
+
+2. **First-scan seeding: emit on first sight with `timestamp = now`.** On the
+   first post-install scan, every currently-active admin gets one
+   `device_admin_grant` row with timestamp = now. Pre-existing admins that were
+   granted months ago get a "now" timestamp, not their real grant time (Android
+   does not expose that). This does **not** produce false correlations with
+   `corr-001` because `package_install` rows use the real `firstInstallTime`
+   (historic), and the correlation window (~1h) will not span a multi-month
+   gap. New installs followed by admin grants within the same scan interval
+   correlate correctly.
+
+3. **Revocations: out of scope.** Emitting `device_admin_revoked` when an
+   admin disappears from `getActiveAdmins()` would be a useful forensic signal
+   (attacker removing MDM to evade), but it is a distinct event category and
+   requires separate rule work. Tracked as follow-up after this lands.
+
+## Tests
+
+New file: `app/src/test/java/com/androdr/scanner/DeviceAdminGrantEmitterTest.kt`
+
+Modelled on `InstallEventEmitterTest`, cases:
+
+1. **First scan with two active admins → emits two rows.**
+2. **Second scan, no change → emits zero rows.**
+3. **Second scan with one newly-added admin → emits one row for that admin only.**
+4. **`DevicePolicyManager` unavailable (`getSystemService` returns null) → empty list, no DAO call.**
+5. **`getActiveAdmins()` returns null → empty list.**
+6. **Two `ComponentName`s under the same package → one row (guards against future removal of `.distinct()`).**
+7. **Package previously emitted, then uninstalled → no re-emission on re-appearance. Confirms table-as-dedup-store holds across uninstalls, matching `InstallEventEmitter` semantics.**
+
+Mock `DevicePolicyManager` via an injected provider so each case can stage
+a custom `activeAdmins` list.
+
+### Correlation false-fire guard
+
+Add a focused test to `AllCorrelationRulesFireTest` or a new
+`Corr001SeedingTest`:
+
+- Stage: `package_install` row with `startTimestamp = now - 30d` (historic
+  `firstInstallTime`) for package `com.victim`.
+- Stage: `device_admin_grant` row with `startTimestamp = now` (fresh seed
+  emission) for the same package.
+- Run `SigmaCorrelationEngine.evaluate(corr001Rules, ...)`.
+- Assert: **no signal emitted.** `corr-001` is `temporal_ordered` with a
+  short timespan; the ~30-day gap must exceed the window.
+
+This directly tests the seeding claim in the "First-scan seeding" decision.
+
+### Wiring test
+
+Confirm `ScanOrchestrator` calls `deviceAdminGrantEmitter.emitNew(scanId)`
+and that the returned events are included in the
+`installEvents + adminGrantEvents + findingTimelineEvents` concatenation
+passed to `saveScanWithCorrelation`. Assert admin emit invocation happens
+after install emit (ordering test — shallow, uses `inOrder` verification).
+
+## Validation
+
+- `./gradlew :app:testDebugUnitTest` — unit tests pass
+- `./gradlew :app:assembleDebug` — builds
+- `./gradlew :app:lintDebug` — clean
+- Real-device verification: install AndroDR, run scan (no rows), grant admin
+  to a test app, run scan again → one `device_admin_grant` row appears in the
+  timeline with the test app's package. Install a fresh package + grant it
+  admin within the correlation window → `androdr-corr-001` (install-then-admin)
+  fires as a finding.
+
+## Accepted risks
+
+- **Concurrent-scan race.** If `ScanOrchestrator` ever runs two scans in
+  parallel, both emitters can observe an admin as "new" and insert two rows
+  (no unique index on `(category, packageName)`, and
+  `OnConflictStrategy.IGNORE` is keyed on `id` only). This is the same race
+  `InstallEventEmitter` carries and has not been observed in practice;
+  accepted here for parity. A follow-up could add a uniqueness constraint
+  covering both emitters.
+
+## Out of scope
+
+- `device_admin_revoked` emitter (follow-up issue).
+- Bug-report path (`DeviceAdminModule` parsing `dumpsys device_policy`) for
+  historic reconstruction.
+- Exposing grant timestamp beyond "first observed" — Android does not provide
+  the true grant time to third-party apps.
+- Multi-user / work-profile admins. `getActiveAdmins()` returns only the
+  admins active on the profile where AndroDR runs; cross-profile admins are
+  invisible. Revisit when multi-user support is in scope.


### PR DESCRIPTION
## Summary
- Adds `DeviceAdminGrantEmitter` — at scan time, reads `DevicePolicyManager.getActiveAdmins()`, diffs against packages already present in `forensic_timeline` with `category = "device_admin_grant"`, and emits one row per newly-observed admin package.
- Unblocks `androdr-corr-001` (install-then-admin): the correlation rule has loaded and parsed since Sprint #75 but never fired because no code emitted the required category.
- Mirrors the existing `InstallEventEmitter` pattern exactly — table-as-dedup-store, no new Room table, no SharedPreferences.

Closes #79

## Design decisions (full rationale in the spec doc)
- **State: the `forensic_timeline` table itself.** New DAO query `getAdminGrantedPackagesAlreadyEmitted()` mirrors the existing `getInstalledPackagesAlreadyEmitted()`.
- **First-scan seeding: emit with `now` timestamp.** Android doesn't expose the real grant time to third-party apps, so pre-existing admins get `startTimestamp = System.currentTimeMillis()` and `timestampPrecision = "approximate"`. A corr-001 false-fire guard test pins that historic install + fresh seed-timestamp admin does not fire.
- **Revocations out of scope.** `device_admin_revoked` is a separate event category needing its own atom rule; follow-up issue.

## Files
- NEW `app/src/main/java/com/androdr/scanner/DeviceAdminGrantEmitter.kt`
- NEW `app/src/test/java/com/androdr/scanner/DeviceAdminGrantEmitterTest.kt` (12 cases)
- NEW `docs/superpowers/specs/2026-04-22-issue-79-device-admin-grant-emitter-design.md`
- `ForensicTimelineEventDao.kt` — one query added
- `ScanOrchestrator.kt` — emitter wired into the `saveScanWithCorrelation` transaction; failures now log before falling back to empty list (applied to the pre-existing install emit path for consistency)
- `SigmaCorrelationEngineTest.kt` — seeding-strategy guard test
- `ScanOrchestratorErrorHandlingTest.kt` — mechanical constructor update

## Review cycle
Went through two rounds:
- Spec reviewers (architect + code-reviewer) caught: wiring must flow through `saveScanWithCorrelation` for ID assignment (not a separate `insertAll`); `timestampPrecision = "approximate"`; reuse `resolveAppLabel` pattern; match DAO query style exactly; admin emit after install emit.
- Implementation reviewers caught: silent-failure observability gap (`runCatching` without log) and two refactor-guard test holes (DAO-call pin, emitter-never-inserts pin). All three fixed.

## Test plan
- [x] `./gradlew :app:testDebugUnitTest` — all unit tests pass (new: 12 emitter cases + 1 corr-001 seeding guard)
- [x] `./gradlew :app:lintDebug` — clean
- [x] `./gradlew :app:assembleDebug` — builds
- [ ] Real-device verification (owner):
  - Install AndroDR; first scan should emit one `device_admin_grant` row per pre-existing admin at scan time.
  - Install a fresh package + grant admin within the correlation window; `androdr-corr-001` fires as a finding in the timeline.
  - Second scan of same device: zero new `device_admin_grant` rows (dedup works).

🤖 Generated with [Claude Code](https://claude.com/claude-code)