### PR TITLE
docs: spec for docs refresh (architecture + privacy consolidation)

### DIFF
--- a/docs/superpowers/plans/2026-04-24-docs-refresh-pr-a-privacy-pipeline.md
+++ b/docs/superpowers/plans/2026-04-24-docs-refresh-pr-a-privacy-pipeline.md
@@ -1,0 +1,866 @@
+# Docs Refresh PR A — Privacy Publishing Pipeline Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Establish `docs/PRIVACY_POLICY.md` in the AndroDR repo as the single source of truth for the privacy policy, auto-render it into the `androdr-site` public site at build time, archive the dead `androdr-privacy` mirror repo, and fix the hallucinated contact email everywhere.
+
+**Architecture:** Cross-repo pipeline. AndroDR is the authoritative edit surface; a workflow fires `repository_dispatch` on privacy markdown change; the `androdr-site` repo's render workflow fetches the markdown (authenticated GH API, required because of the account shadowban), converts it to HTML via a small Python script with structural assertions, replaces a fenced region in `index.html`, and pushes — existing GitHub Pages workflow handles the rest. Cloudflare Worker mirror picks up the change via its normal pull.
+
+**Tech Stack:** Python 3 + `markdown` PyPI package (with `tables` extension), GitHub Actions, `gh` CLI.
+
+**Spec:** `docs/superpowers/specs/2026-04-24-docs-refresh-design.md` §5.
+
+---
+
+## File structure
+
+**Repo: `yasirhamza/androdr-site` (separate repo, local checkout at /tmp for plan execution)**
+- Create: `scripts/render_privacy.py` — markdown-to-HTML-fragment renderer with structural assertions
+- Create: `scripts/requirements.txt` — pinned dependency for renderer
+- Create: `scripts/test_render_privacy.py` — tests for the renderer
+- Create: `scripts/fixtures/sample_privacy.md` — minimal test fixture
+- Create: `.github/workflows/render-privacy.yml` — triggers rendering (push, dispatch, cron, manual)
+- Modify: `index.html` — add `<!-- ANDRODR:PRIVACY:START -->` / `<!-- ANDRODR:PRIVACY:END -->` fences around existing `<section class="privacy">`
+- Delete: `.github/workflows/static.yml` — duplicate of `pages.yml`
+
+**Repo: `yasirhamza/AndroDR`**
+- Modify: `docs/PRIVACY_POLICY.md` — content update (email fix, active feeds, timeline, bugreport retention language, Data Safety alignment expansion, last-updated date)
+- Modify: `docs/play-store/store-listing.md` — email fix (`privacy@androdr.dev` → `yhamad.dev@gmail.com`)
+- Create: `.github/workflows/notify-privacy-sync.yml` — fires `repository_dispatch` to `androdr-site` on privacy markdown change
+
+**Repo: `yasirhamza/androdr-privacy`**
+- Replace: `index.md` with single-line forwarding pointer
+- Archive via `gh repo archive`
+
+---
+
+## Cutover sequence
+
+Because this is cross-repo and has visible public effects, land changes in this order:
+
+1. Tasks 1–6 land in a single PR against `yasirhamza/androdr-site`. First merge of this PR triggers the render workflow; the workflow will regenerate the privacy HTML from AndroDR's *current* `docs/PRIVACY_POLICY.md` (old content). That is safe — it normalizes the already-live content into the fenced region, no regression.
+2. Tasks 7–9 land in a single PR against `yasirhamza/AndroDR`. Merge fires the `repository_dispatch`; the site re-renders with the updated content; Cloudflare mirror catches up on next pull.
+3. Task 10 (archive mirror repo) runs after both PRs are merged and verified.
+
+---
+
+## Task 1: Fence the privacy section in `androdr-site/index.html`
+
+**Repo:** `yasirhamza/androdr-site`
+**Files:**
+- Modify: `index.html` around the `<section class="privacy" id="privacy">` block
+
+- [ ] **Step 1: Clone `androdr-site` if not already local**
+
+Run:
+```bash
+cd /tmp && [ -d androdr-site-work ] || gh repo clone yasirhamza/androdr-site androdr-site-work
+cd /tmp/androdr-site-work
+git checkout -b docs/privacy-pipeline
+```
+
+- [ ] **Step 2: Locate the privacy section**
+
+Run: `grep -n 'section class="privacy"' index.html`
+Expected: one match on a line around 219 (`<section class="privacy" id="privacy">`).
+
+- [ ] **Step 3: Wrap with fence comments**
+
+Edit `index.html`. Replace:
+```html
+  <section class="privacy" id="privacy">
+```
+with:
+```html
+  <!-- ANDRODR:PRIVACY:START -->
+  <section class="privacy" id="privacy">
+```
+
+And replace the matching closing `</section>` (the one on the line immediately before the `<!-- Footer -->` comment or the `<footer>` tag) with:
+```html
+  </section>
+  <!-- ANDRODR:PRIVACY:END -->
+```
+
+Verify with: `grep -c 'ANDRODR:PRIVACY' index.html`
+Expected: `2`
+
+- [ ] **Step 4: Confirm the fence brackets exactly one privacy section**
+
+Run: `python3 -c "import re,sys; html=open('index.html').read(); m=re.search(r'<!-- ANDRODR:PRIVACY:START -->(.*?)<!-- ANDRODR:PRIVACY:END -->', html, re.DOTALL); print('lines:', m.group(1).count(chr(10)) if m else 'NO MATCH')"`
+Expected: `lines: <some number > 150>` (the fenced region is the bulk of the privacy content).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add index.html
+git commit -m "site: fence privacy section for render-privacy workflow"
+```
+
+---
+
+## Task 2: Create `scripts/requirements.txt` in `androdr-site`
+
+**Repo:** `yasirhamza/androdr-site`
+**Files:**
+- Create: `scripts/requirements.txt`
+
+- [ ] **Step 1: Create the requirements file**
+
+```bash
+mkdir -p scripts
+cat > scripts/requirements.txt <<'EOF'
+markdown==3.6
+EOF
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add scripts/requirements.txt
+git commit -m "site: pin markdown dependency for render-privacy script"
+```
+
+---
+
+## Task 3: Write tests for `render_privacy.py` (fail first)
+
+**Repo:** `yasirhamza/androdr-site`
+**Files:**
+- Create: `scripts/fixtures/sample_privacy.md`
+- Create: `scripts/test_render_privacy.py`
+
+- [ ] **Step 1: Create test fixture**
+
+Create `scripts/fixtures/sample_privacy.md`:
+```markdown
+# AndroDR Privacy Policy
+
+_Last updated: 2026-04-01_
+
+## Our Philosophy
+
+AndroDR is an open-source security tool.
+
+## What AndroDR Does
+
+It scans.
+
+| Data | Purpose |
+|------|---------|
+| App list | Threat detection |
+| DNS queries | Blocklist check |
+
+## Contact
+
+- Email: yhamad.dev@gmail.com
+```
+
+- [ ] **Step 2: Write test file**
+
+Create `scripts/test_render_privacy.py`:
+```python
+"""Tests for render_privacy.py — the markdown-to-HTML fragment renderer."""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+import render_privacy
+
+FIXTURE = Path(__file__).parent / "fixtures" / "sample_privacy.md"
+
+
+def test_render_wraps_in_privacy_section():
+    html = render_privacy.render(FIXTURE.read_text())
+    assert html.startswith('<section class="privacy" id="privacy">')
+    assert html.rstrip().endswith("</section>")
+
+
+def test_render_produces_h2_for_top_sections():
+    html = render_privacy.render(FIXTURE.read_text())
+    h2_count = len(re.findall(r"<h2[^>]*>", html))
+    assert h2_count == 3  # Our Philosophy, What AndroDR Does, Contact
+
+
+def test_render_produces_table_block():
+    html = render_privacy.render(FIXTURE.read_text())
+    assert "<table>" in html
+    assert "<th>Data</th>" in html
+
+
+def test_render_extracts_last_updated():
+    last_updated = render_privacy.extract_last_updated(FIXTURE.read_text())
+    assert last_updated == "2026-04-01"
+
+
+def test_render_injects_last_updated_into_fragment():
+    html = render_privacy.render(FIXTURE.read_text())
+    assert "Last updated: 2026-04-01" in html
+
+
+def test_assert_structural_invariants_pass_matching_fixture():
+    html = render_privacy.render(FIXTURE.read_text())
+    # Should not raise
+    render_privacy.assert_structural_invariants(html, expected_h2=3, expected_tables=1)
+
+
+def test_assert_structural_invariants_raises_on_h2_mismatch():
+    html = render_privacy.render(FIXTURE.read_text())
+    with pytest.raises(AssertionError, match="h2"):
+        render_privacy.assert_structural_invariants(html, expected_h2=99, expected_tables=1)
+
+
+def test_assert_structural_invariants_raises_on_table_mismatch():
+    html = render_privacy.render(FIXTURE.read_text())
+    with pytest.raises(AssertionError, match="table"):
+        render_privacy.assert_structural_invariants(html, expected_h2=3, expected_tables=99)
+
+
+def test_replace_fenced_region():
+    template = """<body>
+<!-- ANDRODR:PRIVACY:START -->
+<section class="privacy" id="privacy">OLD</section>
+<!-- ANDRODR:PRIVACY:END -->
+</body>"""
+    new_section = '<section class="privacy" id="privacy">NEW</section>'
+    result = render_privacy.replace_fenced_region(template, new_section)
+    assert "OLD" not in result
+    assert "NEW" in result
+    assert "<!-- ANDRODR:PRIVACY:START -->" in result
+    assert "<!-- ANDRODR:PRIVACY:END -->" in result
+
+
+def test_replace_fenced_region_preserves_fences():
+    template = "<!-- ANDRODR:PRIVACY:START -->\nOLD\n<!-- ANDRODR:PRIVACY:END -->"
+    result = render_privacy.replace_fenced_region(template, "NEW")
+    assert result.count("<!-- ANDRODR:PRIVACY:START -->") == 1
+    assert result.count("<!-- ANDRODR:PRIVACY:END -->") == 1
+
+
+def test_replace_fenced_region_raises_when_fence_missing():
+    template = "<body>no fences</body>"
+    with pytest.raises(ValueError, match="fence"):
+        render_privacy.replace_fenced_region(template, "x")
+```
+
+- [ ] **Step 3: Run tests and confirm they fail with import error**
+
+Run:
+```bash
+cd /tmp/androdr-site-work/scripts
+python3 -m pip install markdown==3.6 pytest -q
+python3 -m pytest test_render_privacy.py -v
+```
+Expected: all 11 tests fail because `render_privacy` module doesn't exist yet (`ModuleNotFoundError` or `ImportError`).
+
+- [ ] **Step 4: Commit failing tests**
+
+```bash
+cd /tmp/androdr-site-work
+git add scripts/fixtures/sample_privacy.md scripts/test_render_privacy.py
+git commit -m "site: tests for privacy render script (red)"
+```
+
+---
+
+## Task 4: Implement `render_privacy.py`
+
+**Repo:** `yasirhamza/androdr-site`
+**Files:**
+- Create: `scripts/render_privacy.py`
+
+- [ ] **Step 1: Write the implementation**
+
+Create `scripts/render_privacy.py`:
+```python
+"""Render docs/PRIVACY_POLICY.md (from the AndroDR repo) into an HTML fragment
+for injection into index.html in the androdr-site repo.
+
+Usage:
+    python3 render_privacy.py <markdown-path> <index-html-path>
+
+The script:
+  1. Parses the markdown into an HTML fragment with the 'tables' extension.
+  2. Wraps it in <section class="privacy" id="privacy">...</section>
+     so existing CSS in index.html applies unchanged.
+  3. Asserts structural invariants (expected <h2> and <table> counts); exits
+     non-zero if they don't match. Update EXPECTED_H2 / EXPECTED_TABLES in the
+     same commit that deliberately changes the privacy structure.
+  4. Replaces the fenced region (<!-- ANDRODR:PRIVACY:START --> ... END -->)
+     in index.html with the new section.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import markdown
+
+# Locked on 2026-04-24 against docs/PRIVACY_POLICY.md. Update in the same
+# commit that deliberately adds/removes a top-level section or table.
+EXPECTED_H2 = 18
+EXPECTED_TABLES = 3
+
+FENCE_START = "<!-- ANDRODR:PRIVACY:START -->"
+FENCE_END = "<!-- ANDRODR:PRIVACY:END -->"
+
+LAST_UPDATED_RE = re.compile(r"^_Last updated:\s*(\d{4}-\d{2}-\d{2})_\s*$", re.MULTILINE)
+
+
+def extract_last_updated(md_text: str) -> str | None:
+    """Pull the YYYY-MM-DD from a line like `_Last updated: 2026-04-24_`."""
+    m = LAST_UPDATED_RE.search(md_text)
+    return m.group(1) if m else None
+
+
+def render(md_text: str) -> str:
+    """Convert markdown to an HTML fragment wrapped in <section class="privacy">.
+
+    The rendered fragment mirrors the structure the current index.html already
+    uses, so the existing .privacy CSS selectors apply without change. The top
+    `# AndroDR Privacy Policy` H1 in the markdown is dropped (the H2 "Privacy
+    Policy" title lives in the HTML template), and the `_Last updated: ..._`
+    line is rendered as a `<p><em>Last updated: YYYY-MM-DD</em></p>` at the
+    top of the fragment so the date stays visible.
+    """
+    last_updated = extract_last_updated(md_text)
+    # Strip the H1 and the last-updated line; we'll re-inject the date below.
+    body = re.sub(r"^#\s+.*\n", "", md_text, count=1)
+    body = LAST_UPDATED_RE.sub("", body, count=1).lstrip()
+    inner = markdown.markdown(body, extensions=["tables"])
+    if last_updated:
+        inner = f'<p><em>Last updated: {last_updated}</em></p>\n{inner}'
+    return f'<section class="privacy" id="privacy">\n<h2>Privacy Policy</h2>\n{inner}\n</section>'
+
+
+def assert_structural_invariants(html: str, expected_h2: int = EXPECTED_H2,
+                                 expected_tables: int = EXPECTED_TABLES) -> None:
+    """Raise AssertionError if rendered HTML deviates from expected structure."""
+    h2_count = len(re.findall(r"<h2[^>]*>", html))
+    # First <h2> is the "Privacy Policy" title we injected; source markdown
+    # contributes the rest.
+    source_h2 = h2_count - 1
+    assert source_h2 == expected_h2, (
+        f"expected {expected_h2} h2 headings from source, got {source_h2}. "
+        f"If this change is deliberate, update EXPECTED_H2 in render_privacy.py."
+    )
+    table_count = html.count("<table>")
+    assert table_count == expected_tables, (
+        f"expected {expected_tables} table blocks, got {table_count}. "
+        f"If this change is deliberate, update EXPECTED_TABLES in render_privacy.py."
+    )
+
+
+def replace_fenced_region(template: str, new_section: str) -> str:
+    """Replace everything between FENCE_START and FENCE_END with new_section.
+
+    Preserves the fence comments themselves. Raises if either fence is missing.
+    """
+    if FENCE_START not in template or FENCE_END not in template:
+        raise ValueError(
+            f"fence markers not found in template; expected both "
+            f"{FENCE_START!r} and {FENCE_END!r}"
+        )
+    pattern = re.compile(
+        re.escape(FENCE_START) + r".*?" + re.escape(FENCE_END),
+        re.DOTALL,
+    )
+    replacement = f"{FENCE_START}\n{new_section}\n{FENCE_END}"
+    return pattern.sub(replacement, template, count=1)
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 3:
+        print(f"usage: {argv[0]} <markdown-path> <index-html-path>", file=sys.stderr)
+        return 2
+    md_path = Path(argv[1])
+    html_path = Path(argv[2])
+    md_text = md_path.read_text(encoding="utf-8")
+    rendered = render(md_text)
+    assert_structural_invariants(rendered)
+    template = html_path.read_text(encoding="utf-8")
+    updated = replace_fenced_region(template, rendered)
+    if updated == template:
+        print("no change")
+        return 0
+    html_path.write_text(updated, encoding="utf-8")
+    print(f"updated {html_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))
+```
+
+- [ ] **Step 2: Run tests — should now pass**
+
+Run:
+```bash
+cd /tmp/androdr-site-work/scripts
+python3 -m pytest test_render_privacy.py -v
+```
+Expected: all 11 tests PASS.
+
+- [ ] **Step 3: Dry-run against real privacy markdown**
+
+Run:
+```bash
+cd /tmp/androdr-site-work
+cp /home/yasir/AndroDR/docs/PRIVACY_POLICY.md /tmp/live-privacy.md
+python3 scripts/render_privacy.py /tmp/live-privacy.md index.html
+```
+Expected: script prints `updated index.html` and exits 0.
+
+- [ ] **Step 4: Verify the rendered HTML looks reasonable**
+
+Run:
+```bash
+grep -c '<h3' index.html
+grep -c '<table>' index.html
+grep -c 'yhamad.dev@gmail.com\|privacy@androdr.dev' index.html
+```
+Expected: some `<h3>` count, 3 `<table>` blocks, and `yhamad.dev@gmail.com` present. (Current markdown still has `privacy@androdr.dev` — that gets fixed in Task 7.)
+
+- [ ] **Step 5: Revert the dry-run edit to index.html**
+
+The render in Step 3 modified index.html for preview only. We want the committed state to still have the unmodified fenced region (from Task 1), not pre-applied content. Revert:
+```bash
+git checkout -- index.html
+```
+
+- [ ] **Step 6: Commit the script**
+
+```bash
+git add scripts/render_privacy.py
+git commit -m "site: add render_privacy.py (tests now green)"
+```
+
+---
+
+## Task 5: Create the `render-privacy.yml` workflow in `androdr-site`
+
+**Repo:** `yasirhamza/androdr-site`
+**Files:**
+- Create: `.github/workflows/render-privacy.yml`
+
+- [ ] **Step 1: Write the workflow**
+
+Create `.github/workflows/render-privacy.yml`:
+```yaml
+name: Render privacy from AndroDR
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'scripts/render_privacy.py'
+      - 'scripts/requirements.txt'
+      - '.github/workflows/render-privacy.yml'
+  repository_dispatch:
+    types: [privacy-updated]
+  schedule:
+    # Daily safety net in case a repository_dispatch was missed.
+    - cron: '17 5 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: render-privacy
+  cancel-in-progress: false
+
+jobs:
+  render:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout androdr-site
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install renderer dependencies
+        run: python -m pip install -r scripts/requirements.txt
+
+      - name: Fetch PRIVACY_POLICY.md from AndroDR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api repos/yasirhamza/AndroDR/contents/docs/PRIVACY_POLICY.md \
+            --jq '.content' | base64 -d > /tmp/PRIVACY_POLICY.md
+          test -s /tmp/PRIVACY_POLICY.md
+
+      - name: Capture source SHA
+        id: src
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          SHA=$(gh api repos/yasirhamza/AndroDR/commits/main --jq '.sha' | cut -c1-7)
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Render privacy into index.html
+        run: python3 scripts/render_privacy.py /tmp/PRIVACY_POLICY.md index.html
+
+      - name: Commit if changed
+        run: |
+          if git diff --quiet -- index.html; then
+            echo "no change — privacy content already in sync"
+            exit 0
+          fi
+          git config user.name 'androdr-site-bot'
+          git config user.email 'yhamad.dev@gmail.com'
+          git add index.html
+          git commit -m "docs(privacy): sync from AndroDR@${{ steps.src.outputs.sha }}"
+          git push
+```
+
+- [ ] **Step 2: Lint the YAML**
+
+Run: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/render-privacy.yml'))"`
+Expected: no output, exit 0.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/render-privacy.yml
+git commit -m "site: render-privacy workflow (push/dispatch/cron/manual triggers)"
+```
+
+---
+
+## Task 6: Delete duplicate `static.yml` workflow, open the site PR
+
+**Repo:** `yasirhamza/androdr-site`
+**Files:**
+- Delete: `.github/workflows/static.yml`
+
+- [ ] **Step 1: Verify `pages.yml` is sufficient for deploy**
+
+Run:
+```bash
+cat .github/workflows/pages.yml
+cat .github/workflows/static.yml
+diff <(grep -v '^#\|^$\|name:' .github/workflows/pages.yml) <(grep -v '^#\|^$\|name:' .github/workflows/static.yml)
+```
+Expected: the two files are near-identical pages-deploy jobs. If there is a unique step in `static.yml`, stop and ask the user before deleting.
+
+- [ ] **Step 2: Delete `static.yml`**
+
+```bash
+git rm .github/workflows/static.yml
+git commit -m "site: remove duplicate static.yml deploy workflow"
+```
+
+- [ ] **Step 3: Push and open PR**
+
+```bash
+git push -u origin docs/privacy-pipeline
+gh pr create --repo yasirhamza/androdr-site \
+  --title "privacy: render from AndroDR markdown via repository_dispatch" \
+  --body "$(cat <<'EOF'
+Establishes single-source-of-truth pipeline for the privacy policy.
+
+- Fences the existing privacy section with ANDRODR:PRIVACY markers
+- Adds scripts/render_privacy.py (with tests) to convert markdown → HTML fragment
+- Adds render-privacy.yml workflow (push / repository_dispatch / daily cron / manual)
+- Removes duplicate static.yml in favor of pages.yml
+
+First merge will trigger a render of the current AndroDR PRIVACY_POLICY.md
+(unchanged content; just normalizes the already-live copy into the fenced
+region). A subsequent AndroDR PR updates the markdown content and fires the
+dispatch.
+
+Spec: https://github.com/yasirhamza/AndroDR/blob/main/docs/superpowers/specs/2026-04-24-docs-refresh-design.md §5
+EOF
+)"
+```
+
+- [ ] **Step 4: Watch the workflow after merge**
+
+After the PR merges, confirm `render-privacy.yml` runs successfully on the push-to-main trigger and produces a `docs(privacy): sync from AndroDR@<sha>` commit (or "no change — privacy content already in sync" if no diff).
+
+```bash
+gh run list --repo yasirhamza/androdr-site --workflow render-privacy.yml --limit 3
+```
+
+Expected: at least one successful run. If it failed, inspect logs with `gh run view --repo yasirhamza/androdr-site <run-id> --log`.
+
+---
+
+## Task 7: Update `docs/PRIVACY_POLICY.md` content
+
+**Repo:** `yasirhamza/AndroDR`
+**Files:**
+- Modify: `docs/PRIVACY_POLICY.md`
+
+- [ ] **Step 1: Create branch in AndroDR repo**
+
+```bash
+cd /home/yasir/AndroDR
+git checkout main
+git pull --ff-only
+git checkout -b docs/privacy-content-update
+```
+
+- [ ] **Step 2: Update the `_Last updated:_` line**
+
+Use Edit to change `_Last updated: 2026-03-26_` → `_Last updated: 2026-04-24_`.
+
+- [ ] **Step 3: Replace all `privacy@androdr.dev` with `yhamad.dev@gmail.com`**
+
+Run: `grep -n "privacy@androdr.dev" docs/PRIVACY_POLICY.md`
+Expected: one match on line 197.
+
+Use Edit (replace_all=true) to change `privacy@androdr.dev` → `yhamad.dev@gmail.com`.
+
+- [ ] **Step 4: Update "What AndroDR Does" to mention SIGMA engine + STIX2**
+
+Edit the "What AndroDR Does" section so its last bullet cluster includes:
+- "Uses auditable YAML [SIGMA](https://github.com/SigmaHQ/sigma)-style detection rules — detection logic is not hidden in compiled code"
+- "Imports and exports STIX2-compatible indicators for interoperability with other forensic tools"
+
+- [ ] **Step 5: Extend "Data That Stays On Your Device" table**
+
+Append two rows to the table:
+```
+| Forensic timeline events (e.g., device admin grants) | Displayed in the timeline screen and exportable as part of reports | On-device Room database |
+| Bug report analysis findings | Displayed with scan results; raw bug report file is not retained | On-device Room database |
+```
+
+- [ ] **Step 6: Update "Network Requests" table**
+
+Remove the "Cert hash IOCs (planned)" stub row. Add or update these rows to reflect the current ingesters:
+
+```
+| MalwareBazaar APK hashes + cert hashes | abuse.ch MalwareBazaar public API | Hashes of known malicious APKs and the cert hashes that signed them | 1 API request per refresh |
+| ThreatFox indicators | abuse.ch ThreatFox public API | Command-and-control domain and IP indicators | 1 API request per refresh |
+| Stalkerware cert-hash indicators | AssoEchap/stalkerware-indicators (GitHub) | Cert hashes of known stalkerware signers | 1 HTTP GET |
+```
+
+Keep the existing rows for stalkerware package names, mvt-indicators (but note the dispatcher/cross-dedup wording), and the UAD / Plexus known-app databases.
+
+Append this paragraph below the table:
+> IOC ingesters run in a dispatcher that deduplicates indicators across feeds before writing to the on-device database. Each feed is independently auditable in `app/src/main/java/com/androdr/ioc/feeds/`.
+
+- [ ] **Step 7: Tighten "Bug Report Analysis" section**
+
+Ensure the section explicitly says:
+> AndroDR retains only the analysis *findings* — flagged app names, indicator matches, detected patterns — in the scan result. The original bug report ZIP is not stored on-device after analysis completes.
+
+- [ ] **Step 8: Expand "Google Play Data Safety Alignment"**
+
+Update the bullet list to mirror the declarations in `docs/play-store/18-data-safety-form.md` (read that file first and align the language). At minimum:
+- Data collected — installed apps (on-device), device info (bugreport analysis findings, user-initiated reports only), diagnostic info (app logcat in user-initiated reports only)
+- Data shared — none (explicit user-initiated sharing only)
+- Data encrypted in transit — N/A (no user data transmitted)
+- Data deletion — clear app data / uninstall
+- Optional data collection — none
+
+- [ ] **Step 9: Sanity-check the result**
+
+Run:
+```bash
+grep -c "^## " docs/PRIVACY_POLICY.md
+grep -c "^|" docs/PRIVACY_POLICY.md
+grep -c "privacy@androdr.dev" docs/PRIVACY_POLICY.md
+grep -c "yhamad.dev@gmail.com" docs/PRIVACY_POLICY.md
+```
+Expected: heading count still `18` (no structural break); table row count `≥ 22`; zero matches for `privacy@androdr.dev`; at least one match for `yhamad.dev@gmail.com`.
+
+If the heading count changed, update `EXPECTED_H2` in `androdr-site/scripts/render_privacy.py` within the same cross-repo coordination before merging (raise to user).
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add docs/PRIVACY_POLICY.md
+git commit -m "docs(privacy): refresh content — active feeds, timeline, bugreport retention, correct contact"
+```
+
+---
+
+## Task 8: Sweep contact email in `docs/play-store/store-listing.md`
+
+**Repo:** `yasirhamza/AndroDR`
+**Files:**
+- Modify: `docs/play-store/store-listing.md`
+
+- [ ] **Step 1: Locate the bad email**
+
+Run: `grep -n "privacy@androdr.dev" docs/play-store/store-listing.md`
+Expected: one match on line 58.
+
+- [ ] **Step 2: Replace**
+
+Use Edit to change `privacy@androdr.dev` → `yhamad.dev@gmail.com`.
+
+- [ ] **Step 3: Verify no more occurrences anywhere in repo**
+
+Run: `grep -rn "privacy@androdr.dev" . --exclude-dir=.git --exclude-dir=.claude`
+Expected: zero output.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/play-store/store-listing.md
+git commit -m "docs(play-store): correct contact email in store listing"
+```
+
+---
+
+## Task 9: Add `notify-privacy-sync.yml` workflow in AndroDR
+
+**Repo:** `yasirhamza/AndroDR`
+**Files:**
+- Create: `.github/workflows/notify-privacy-sync.yml`
+
+- [ ] **Step 1: Write the workflow**
+
+Create `.github/workflows/notify-privacy-sync.yml`:
+```yaml
+name: Notify androdr-site of privacy changes
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/PRIVACY_POLICY.md'
+
+permissions:
+  contents: read
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fire repository_dispatch to androdr-site
+        env:
+          GH_TOKEN: ${{ secrets.PRIVACY_SYNC_TOKEN }}
+        run: |
+          gh api repos/yasirhamza/androdr-site/dispatches \
+            --method POST \
+            -f event_type=privacy-updated \
+            -f 'client_payload[source_sha]=${{ github.sha }}'
+```
+
+- [ ] **Step 2: Flag the token requirement to the user**
+
+The default `GITHUB_TOKEN` **cannot** dispatch to another repo. This workflow needs a Personal Access Token (classic, with `repo` scope) or a fine-grained token scoped to `yasirhamza/androdr-site` with `Contents: read` + `Metadata: read` + `Actions: write`. Store it as `PRIVACY_SYNC_TOKEN` in AndroDR repo secrets.
+
+Print this instruction so the user (or a follow-up task) handles it:
+
+Run: `echo "MANUAL STEP: create PAT with dispatch scope on androdr-site, add as PRIVACY_SYNC_TOKEN secret in AndroDR repo"`
+
+- [ ] **Step 3: Lint the YAML**
+
+Run: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/notify-privacy-sync.yml'))"`
+Expected: no output, exit 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/notify-privacy-sync.yml
+git commit -m "ci: dispatch privacy-updated event to androdr-site on PRIVACY_POLICY change"
+```
+
+- [ ] **Step 5: Push branch and open AndroDR PR**
+
+```bash
+git push -u origin docs/privacy-content-update
+gh pr create \
+  --title "docs(privacy): refresh policy + wire up site auto-render" \
+  --body "$(cat <<'EOF'
+## Summary
+- Refreshes \`docs/PRIVACY_POLICY.md\` content (active feeds including MalwareBazaar APK/cert hashes and ThreatFox, timeline events, bugreport retention language, Data Safety alignment expansion)
+- Fixes hallucinated \`privacy@androdr.dev\` contact (replaced with \`yhamad.dev@gmail.com\`) in the privacy policy and in docs/play-store/store-listing.md
+- Adds notify-privacy-sync.yml workflow that fires \`repository_dispatch\` to androdr-site when the privacy markdown changes, so the public site auto-renders
+
+Depends on androdr-site PR (https://github.com/yasirhamza/androdr-site/pulls) landing first; once that is in, merging this PR will propagate content to the public site within minutes.
+
+Closes no issues directly; implements spec §5 (PR A) of docs/superpowers/specs/2026-04-24-docs-refresh-design.md
+
+## Test plan
+- [ ] PRIVACY_SYNC_TOKEN secret created in AndroDR repo (PAT with dispatch scope on androdr-site)
+- [ ] CI build check green
+- [ ] After merge, notify-privacy-sync workflow runs successfully
+- [ ] After merge, androdr-site render-privacy workflow fires and produces a \`docs(privacy): sync from AndroDR@<sha>\` commit
+- [ ] Live site (GitHub Pages + Cloudflare mirror) reflects the new content within 5–10 minutes
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Task 10: Archive the `androdr-privacy` repo
+
+**Repo:** `yasirhamza/androdr-privacy`
+
+Run after Tasks 1–9 are merged and the pipeline is verified end-to-end.
+
+- [ ] **Step 1: Replace `index.md` with a forwarding pointer**
+
+```bash
+cd /tmp
+rm -rf androdr-privacy-archive
+gh repo clone yasirhamza/androdr-privacy androdr-privacy-archive
+cd androdr-privacy-archive
+cat > index.md <<'EOF'
+# AndroDR Privacy Policy — Moved
+
+The canonical AndroDR privacy policy now lives at
+https://github.com/yasirhamza/AndroDR/blob/main/docs/PRIVACY_POLICY.md
+and is rendered publicly at https://yasirhamza.github.io/androdr-site/#privacy
+(mirrored at https://androdr.yasirhamza.workers.dev ).
+
+This repository is archived and no longer accepts changes.
+EOF
+git add index.md
+git commit -m "chore: archive — point to canonical privacy policy in AndroDR repo"
+git push
+```
+
+- [ ] **Step 2: Archive the repo**
+
+Run:
+```bash
+gh repo archive yasirhamza/androdr-privacy --yes
+```
+Expected: confirmation that the repo is now archived.
+
+- [ ] **Step 3: Verify**
+
+Run: `gh api repos/yasirhamza/androdr-privacy --jq '{archived, updated_at}'`
+Expected: `"archived": true`.
+
+---
+
+## End-to-end verification
+
+Run after both PRs are merged and Task 10 completes.
+
+- [ ] **Step 1: Live site reflects content update**
+
+Open https://androdr.yasirhamza.workers.dev in a browser. Confirm the `#privacy` section shows `Last updated: 2026-04-24` and the correct contact email `yhamad.dev@gmail.com`. Also confirm the MalwareBazaar row no longer says `(planned)`.
+
+- [ ] **Step 2: Cross-repo grep is clean**
+
+Run: `grep -rn "privacy@androdr\.dev" /home/yasir/AndroDR --exclude-dir=.git --exclude-dir=.claude`
+Expected: zero output.
+
+- [ ] **Step 3: Archive is visible**
+
+Open https://github.com/yasirhamza/androdr-privacy. Confirm the repo shows the "Archived" banner and the `index.md` pointer is visible.
+
+- [ ] **Step 4: Trigger a trivial propagation test**
+
+Make a whitespace-only commit to `docs/PRIVACY_POLICY.md` on a throwaway branch in AndroDR, merge it, and confirm the site re-renders within ~5 minutes.
+
+If all four verification steps pass, PR A is complete. Proceed to PR B plan.

--- a/docs/superpowers/plans/2026-04-24-docs-refresh-pr-a-privacy-pipeline.md
+++ b/docs/superpowers/plans/2026-04-24-docs-refresh-pr-a-privacy-pipeline.md
@@ -2,59 +2,67 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Establish `docs/PRIVACY_POLICY.md` in the AndroDR repo as the single source of truth for the privacy policy, auto-render it into the `androdr-site` public site at build time, archive the dead `androdr-privacy` mirror repo, and fix the hallucinated contact email everywhere.
+**Goal:** Establish `docs/PRIVACY_POLICY.md` in the AndroDR repo as the single source of truth for the privacy policy, auto-render it into two derived artifacts (`cloudflare-worker.js` in AndroDR and `index.html` in `androdr-site`), archive the dead `androdr-privacy` mirror repo, and fix the hallucinated contact email everywhere.
 
-**Architecture:** Cross-repo pipeline. AndroDR is the authoritative edit surface; a workflow fires `repository_dispatch` on privacy markdown change; the `androdr-site` repo's render workflow fetches the markdown (authenticated GH API, required because of the account shadowban), converts it to HTML via a small Python script with structural assertions, replaces a fenced region in `index.html`, and pushes — existing GitHub Pages workflow handles the rest. Cloudflare Worker mirror picks up the change via its normal pull.
+**Architecture:** Cross-repo pipeline with **one canonical renderer** in AndroDR (`scripts/render_privacy.py`) used by two workflows:
 
-**Tech Stack:** Python 3 + `markdown` PyPI package (with `tables` extension), GitHub Actions, `gh` CLI.
+- `.github/workflows/render-privacy-worker.yml` in AndroDR renders `cloudflare-worker.js` on push when privacy content changes. Commit message reminds the maintainer to `wrangler deploy`.
+- `.github/workflows/render-privacy.yml` in `androdr-site` fetches the markdown AND the renderer from AndroDR at run time (authenticated — the account shadowban blocks anonymous `raw.githubusercontent.com`) and renders `index.html`. It fires on `repository_dispatch` from AndroDR, with a daily cron as safety net.
+
+**Tech Stack:** Python 3 + `markdown` PyPI package (with `tables` extension), GitHub Actions, `gh` CLI. Worker deployment is manual (`wrangler deploy`).
 
 **Spec:** `docs/superpowers/specs/2026-04-24-docs-refresh-design.md` §5.
 
 ---
 
+## Cutover sequence (critical — read before starting)
+
+Two PRs, merged in this order:
+
+1. **Site PR first** (tasks 1–3): small PR in `yasirhamza/androdr-site`. On merge, the new render workflow fires once and **fails as expected** because the renderer doesn't exist on AndroDR main yet. This is a known, acceptable first-run failure — see Task 3 Step 4.
+2. **AndroDR PR second** (tasks 4–12): larger PR in `yasirhamza/AndroDR`. On merge: the worker-render workflow produces an updated `cloudflare-worker.js`; the notify workflow dispatches to the site; the site render workflow now succeeds.
+3. **Manual `wrangler deploy`** (task 13) to push the updated Worker live.
+4. **Archive `androdr-privacy`** (task 14).
+
+---
+
 ## File structure
 
-**Repo: `yasirhamza/androdr-site` (separate repo, local checkout at /tmp for plan execution)**
-- Create: `scripts/render_privacy.py` — markdown-to-HTML-fragment renderer with structural assertions
-- Create: `scripts/requirements.txt` — pinned dependency for renderer
-- Create: `scripts/test_render_privacy.py` — tests for the renderer
-- Create: `scripts/fixtures/sample_privacy.md` — minimal test fixture
-- Create: `.github/workflows/render-privacy.yml` — triggers rendering (push, dispatch, cron, manual)
-- Modify: `index.html` — add `<!-- ANDRODR:PRIVACY:START -->` / `<!-- ANDRODR:PRIVACY:END -->` fences around existing `<section class="privacy">`
+### `yasirhamza/androdr-site` (site PR)
+- Modify: `index.html` — fence the privacy section with `<!-- ANDRODR:PRIVACY:START -->` / `<!-- ANDRODR:PRIVACY:END -->`
+- Create: `.github/workflows/render-privacy.yml` — fetches renderer + markdown from AndroDR, renders `index.html`
 - Delete: `.github/workflows/static.yml` — duplicate of `pages.yml`
 
-**Repo: `yasirhamza/AndroDR`**
-- Modify: `docs/PRIVACY_POLICY.md` — content update (email fix, active feeds, timeline, bugreport retention language, Data Safety alignment expansion, last-updated date)
-- Modify: `docs/play-store/store-listing.md` — email fix (`privacy@androdr.dev` → `yhamad.dev@gmail.com`)
-- Create: `.github/workflows/notify-privacy-sync.yml` — fires `repository_dispatch` to `androdr-site` on privacy markdown change
+### `yasirhamza/AndroDR` (AndroDR PR)
+- Modify: `cloudflare-worker.js` — fence privacy section, content update
+- Modify: `docs/PRIVACY_POLICY.md` — content refresh, email fix, date bump
+- Modify: `docs/play-store/store-listing.md` — email fix
+- Create: `scripts/requirements.txt` — pinned `markdown` dependency
+- Create: `scripts/render_privacy.py` — canonical renderer (CLI takes markdown path + target html path)
+- Create: `scripts/test_render_privacy.py` — renderer tests
+- Create: `scripts/fixtures/sample_privacy.md` — minimal fixture for tests
+- Create: `.github/workflows/render-privacy-worker.yml` — renders `cloudflare-worker.js` on push
+- Create: `.github/workflows/notify-privacy-sync.yml` — fires `repository_dispatch` to site
 
-**Repo: `yasirhamza/androdr-privacy`**
-- Replace: `index.md` with single-line forwarding pointer
+### `yasirhamza/androdr-privacy` (admin action)
+- Modify: `index.md` → forwarding pointer
 - Archive via `gh repo archive`
 
 ---
 
-## Cutover sequence
-
-Because this is cross-repo and has visible public effects, land changes in this order:
-
-1. Tasks 1–6 land in a single PR against `yasirhamza/androdr-site`. First merge of this PR triggers the render workflow; the workflow will regenerate the privacy HTML from AndroDR's *current* `docs/PRIVACY_POLICY.md` (old content). That is safe — it normalizes the already-live content into the fenced region, no regression.
-2. Tasks 7–9 land in a single PR against `yasirhamza/AndroDR`. Merge fires the `repository_dispatch`; the site re-renders with the updated content; Cloudflare mirror catches up on next pull.
-3. Task 10 (archive mirror repo) runs after both PRs are merged and verified.
-
----
+# Part 1: Site PR
 
 ## Task 1: Fence the privacy section in `androdr-site/index.html`
 
 **Repo:** `yasirhamza/androdr-site`
 **Files:**
-- Modify: `index.html` around the `<section class="privacy" id="privacy">` block
+- Modify: `index.html` (fence markers around existing `<section class="privacy">`)
 
-- [ ] **Step 1: Clone `androdr-site` if not already local**
+- [ ] **Step 1: Clone the site repo and create a branch**
 
-Run:
 ```bash
-cd /tmp && [ -d androdr-site-work ] || gh repo clone yasirhamza/androdr-site androdr-site-work
+cd /tmp && rm -rf androdr-site-work
+gh repo clone yasirhamza/androdr-site androdr-site-work
 cd /tmp/androdr-site-work
 git checkout -b docs/privacy-pipeline
 ```
@@ -62,11 +70,11 @@ git checkout -b docs/privacy-pipeline
 - [ ] **Step 2: Locate the privacy section**
 
 Run: `grep -n 'section class="privacy"' index.html`
-Expected: one match on a line around 219 (`<section class="privacy" id="privacy">`).
+Expected: one line showing `<section class="privacy" id="privacy">`.
 
-- [ ] **Step 3: Wrap with fence comments**
+- [ ] **Step 3: Insert `<!-- ANDRODR:PRIVACY:START -->` before the section and `<!-- ANDRODR:PRIVACY:END -->` after its matching `</section>`**
 
-Edit `index.html`. Replace:
+Use Edit on `index.html`. Replace:
 ```html
   <section class="privacy" id="privacy">
 ```
@@ -76,19 +84,43 @@ with:
   <section class="privacy" id="privacy">
 ```
 
-And replace the matching closing `</section>` (the one on the line immediately before the `<!-- Footer -->` comment or the `<footer>` tag) with:
+Then find the closing `</section>` that matches (the one right before the `<footer>` block) and replace:
+```html
+  </section>
+
+  <hr>
+
+  <!-- Footer -->
+```
+with:
 ```html
   </section>
   <!-- ANDRODR:PRIVACY:END -->
+
+  <hr>
+
+  <!-- Footer -->
 ```
 
-Verify with: `grep -c 'ANDRODR:PRIVACY' index.html`
-Expected: `2`
+(If the exact surrounding context differs, adjust the Edit match; the invariant is exactly one `START` and exactly one `END`, with the `<section>...</section>` block between them and nothing else.)
 
-- [ ] **Step 4: Confirm the fence brackets exactly one privacy section**
+- [ ] **Step 4: Verify fence markers bracket exactly one privacy section**
 
-Run: `python3 -c "import re,sys; html=open('index.html').read(); m=re.search(r'<!-- ANDRODR:PRIVACY:START -->(.*?)<!-- ANDRODR:PRIVACY:END -->', html, re.DOTALL); print('lines:', m.group(1).count(chr(10)) if m else 'NO MATCH')"`
-Expected: `lines: <some number > 150>` (the fenced region is the bulk of the privacy content).
+Run:
+```bash
+grep -c 'ANDRODR:PRIVACY:START' index.html
+grep -c 'ANDRODR:PRIVACY:END' index.html
+python3 -c "
+import re
+html = open('index.html').read()
+m = re.search(r'<!-- ANDRODR:PRIVACY:START -->(.*?)<!-- ANDRODR:PRIVACY:END -->', html, re.DOTALL)
+assert m, 'fence region not found'
+inner = m.group(1)
+assert inner.count('<section class=\"privacy\"') == 1, f'expected 1 section, got {inner.count(\"<section class=\\\"privacy\\\"\")}'
+print('OK: fence region contains exactly one privacy section')
+"
+```
+Expected: each grep prints `1`, Python prints `OK: fence region contains exactly one privacy section`.
 
 - [ ] **Step 5: Commit**
 
@@ -99,40 +131,248 @@ git commit -m "site: fence privacy section for render-privacy workflow"
 
 ---
 
-## Task 2: Create `scripts/requirements.txt` in `androdr-site`
+## Task 2: Create `render-privacy.yml` workflow in `androdr-site`
 
 **Repo:** `yasirhamza/androdr-site`
 **Files:**
-- Create: `scripts/requirements.txt`
+- Create: `.github/workflows/render-privacy.yml`
 
-- [ ] **Step 1: Create the requirements file**
+- [ ] **Step 1: Write the workflow**
+
+Create `.github/workflows/render-privacy.yml` with this content:
+
+```yaml
+name: Render privacy from AndroDR
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/render-privacy.yml'
+      - 'index.html'
+  repository_dispatch:
+    types: [privacy-updated]
+  schedule:
+    # Daily safety net at 05:17 UTC in case a dispatch was missed.
+    - cron: '17 5 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: render-privacy
+  cancel-in-progress: false
+
+jobs:
+  render:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout androdr-site
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Fetch renderer + markdown from AndroDR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p /tmp/androdr
+          for path in docs/PRIVACY_POLICY.md scripts/render_privacy.py scripts/requirements.txt; do
+            out="/tmp/androdr/$(basename "$path")"
+            gh api "repos/yasirhamza/AndroDR/contents/$path" --jq '.content' | base64 -d > "$out"
+            test -s "$out" || { echo "fetch failed: $path"; exit 1; }
+          done
+
+      - name: Capture source SHA for commit message
+        id: src
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          SHA=$(gh api repos/yasirhamza/AndroDR/commits/main --jq '.sha' | cut -c1-7)
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Install renderer dependencies
+        run: python -m pip install -r /tmp/androdr/requirements.txt
+
+      - name: Render privacy into index.html
+        run: python3 /tmp/androdr/render_privacy.py /tmp/androdr/PRIVACY_POLICY.md index.html
+
+      - name: Commit if changed
+        run: |
+          if git diff --quiet -- index.html; then
+            echo "no change — privacy content already in sync"
+            exit 0
+          fi
+          git config user.name 'androdr-site-bot'
+          git config user.email 'yhamad.dev@gmail.com'
+          git add index.html
+          git commit -m "docs(privacy): sync from AndroDR@${{ steps.src.outputs.sha }}"
+          git push
+```
+
+- [ ] **Step 2: Lint the YAML**
+
+Run: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/render-privacy.yml'))"`
+Expected: no output, exit 0.
+
+- [ ] **Step 3: Commit**
 
 ```bash
-mkdir -p scripts
-cat > scripts/requirements.txt <<'EOF'
-markdown==3.6
+git add .github/workflows/render-privacy.yml
+git commit -m "site: render-privacy workflow (fetches renderer + markdown from AndroDR)"
+```
+
+---
+
+## Task 3: Delete duplicate `static.yml`, push, and open the site PR
+
+**Repo:** `yasirhamza/androdr-site`
+
+- [ ] **Step 1: Compare `static.yml` against `pages.yml`**
+
+Run:
+```bash
+cat .github/workflows/pages.yml .github/workflows/static.yml
+```
+
+Both are GitHub Pages deploy workflows. Confirm `static.yml` has no unique step that `pages.yml` lacks. If it does, stop and ask the user before deleting.
+
+- [ ] **Step 2: Delete `static.yml`**
+
+```bash
+git rm .github/workflows/static.yml
+git commit -m "site: remove duplicate static.yml deploy workflow"
+```
+
+- [ ] **Step 3: Push and open PR**
+
+```bash
+git push -u origin docs/privacy-pipeline
+gh pr create --repo yasirhamza/androdr-site \
+  --title "privacy: render from AndroDR markdown via repository_dispatch" \
+  --body "$(cat <<'EOF'
+Part 1 of the privacy publishing pipeline (the other half lands in yasirhamza/AndroDR).
+
+- Fences the existing privacy section with ANDRODR:PRIVACY markers.
+- Adds render-privacy.yml that fetches the renderer + markdown from AndroDR main at run time and renders into index.html. Authenticated GH API fetch is required because the account shadowban blocks anonymous raw.githubusercontent.com.
+- Removes duplicate static.yml in favor of pages.yml.
+
+### Expected first-run failure
+On merge, the push event fires render-privacy.yml. The renderer script does not exist on AndroDR main yet (it lands in the AndroDR-side PR that merges next). The first run will fail with "fetch failed: scripts/render_privacy.py" and that is expected. Normal operation begins once the AndroDR PR merges and the subsequent repository_dispatch triggers a successful render.
+
+Spec: AndroDR/docs/superpowers/specs/2026-04-24-docs-refresh-design.md §5.
 EOF
+)"
+```
+
+- [ ] **Step 4: Merge and confirm expected first-run failure**
+
+After merge, inspect the first workflow run:
+```bash
+gh run list --repo yasirhamza/androdr-site --workflow render-privacy.yml --limit 3
+```
+
+Expected: one failed run with the "fetch failed: scripts/render_privacy.py" message. This is the expected first-run failure — do not treat it as a blocker.
+
+---
+
+# Part 2: AndroDR PR
+
+All remaining tasks happen in the AndroDR repo worktree at `.claude/worktrees/docs-privacy` on branch `docs/privacy-content-update` (already created during plan execution setup).
+
+## Task 4: Fence the privacy section in `cloudflare-worker.js`
+
+**Repo:** `yasirhamza/AndroDR` (worktree `.claude/worktrees/docs-privacy`)
+**Files:**
+- Modify: `cloudflare-worker.js`
+
+- [ ] **Step 1: Change to the worktree**
+
+```bash
+cd /home/yasir/AndroDR/.claude/worktrees/docs-privacy
+git status  # should report clean tree on docs/privacy-content-update
+```
+
+- [ ] **Step 2: Locate the privacy section**
+
+Run: `grep -n '<section class="privacy"' cloudflare-worker.js`
+Expected: one match.
+
+- [ ] **Step 3: Wrap with fence markers**
+
+Use Edit to wrap the `<section class="privacy" id="privacy">...</section>` block with the same `<!-- ANDRODR:PRIVACY:START -->` and `<!-- ANDRODR:PRIVACY:END -->` comments. Note: the HTML is inside a JavaScript template literal, so the comments become literal characters in the response HTML — that's fine; browsers ignore HTML comments.
+
+The final structure inside the template literal must be:
+```
+  <!-- ANDRODR:PRIVACY:START -->
+  <section class="privacy" id="privacy">
+    ...existing content...
+  </section>
+  <!-- ANDRODR:PRIVACY:END -->
+```
+
+- [ ] **Step 4: Verify the fence brackets exactly one privacy section**
+
+Run:
+```bash
+grep -c 'ANDRODR:PRIVACY:START' cloudflare-worker.js
+grep -c 'ANDRODR:PRIVACY:END' cloudflare-worker.js
+python3 -c "
+import re
+txt = open('cloudflare-worker.js').read()
+m = re.search(r'<!-- ANDRODR:PRIVACY:START -->(.*?)<!-- ANDRODR:PRIVACY:END -->', txt, re.DOTALL)
+assert m, 'fence region not found'
+assert m.group(1).count('<section class=\"privacy\"') == 1
+print('OK')
+"
+```
+Expected: two `1`s and `OK`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cloudflare-worker.js
+git commit -m "worker: fence privacy section for render pipeline"
+```
+
+---
+
+## Task 5: Add `scripts/requirements.txt`
+
+**Repo:** `yasirhamza/AndroDR`
+**Files:**
+- Create: `scripts/requirements.txt`
+
+- [ ] **Step 1: Create the file**
+
+Use Write to create `scripts/requirements.txt` with content:
+```
+markdown==3.6
 ```
 
 - [ ] **Step 2: Commit**
 
 ```bash
 git add scripts/requirements.txt
-git commit -m "site: pin markdown dependency for render-privacy script"
+git commit -m "scripts: pin markdown dependency for privacy renderer"
 ```
 
 ---
 
-## Task 3: Write tests for `render_privacy.py` (fail first)
+## Task 6: Write failing tests for `render_privacy.py`
 
-**Repo:** `yasirhamza/androdr-site`
+**Repo:** `yasirhamza/AndroDR`
 **Files:**
 - Create: `scripts/fixtures/sample_privacy.md`
 - Create: `scripts/test_render_privacy.py`
 
-- [ ] **Step 1: Create test fixture**
+- [ ] **Step 1: Create the fixture**
 
-Create `scripts/fixtures/sample_privacy.md`:
+Use Write to create `scripts/fixtures/sample_privacy.md`:
 ```markdown
 # AndroDR Privacy Policy
 
@@ -156,9 +396,9 @@ It scans.
 - Email: yhamad.dev@gmail.com
 ```
 
-- [ ] **Step 2: Write test file**
+- [ ] **Step 2: Create the tests**
 
-Create `scripts/test_render_privacy.py`:
+Use Write to create `scripts/test_render_privacy.py`:
 ```python
 """Tests for render_privacy.py — the markdown-to-HTML fragment renderer."""
 from __future__ import annotations
@@ -182,7 +422,8 @@ def test_render_wraps_in_privacy_section():
 def test_render_produces_h2_for_top_sections():
     html = render_privacy.render(FIXTURE.read_text())
     h2_count = len(re.findall(r"<h2[^>]*>", html))
-    assert h2_count == 3  # Our Philosophy, What AndroDR Does, Contact
+    # Injected "Privacy Policy" h2 + 3 source h2s.
+    assert h2_count == 4
 
 
 def test_render_produces_table_block():
@@ -203,7 +444,6 @@ def test_render_injects_last_updated_into_fragment():
 
 def test_assert_structural_invariants_pass_matching_fixture():
     html = render_privacy.render(FIXTURE.read_text())
-    # Should not raise
     render_privacy.assert_structural_invariants(html, expected_h2=3, expected_tables=1)
 
 
@@ -233,7 +473,7 @@ def test_replace_fenced_region():
     assert "<!-- ANDRODR:PRIVACY:END -->" in result
 
 
-def test_replace_fenced_region_preserves_fences():
+def test_replace_fenced_region_preserves_fences_exactly_once():
     template = "<!-- ANDRODR:PRIVACY:START -->\nOLD\n<!-- ANDRODR:PRIVACY:END -->"
     result = render_privacy.replace_fenced_region(template, "NEW")
     assert result.count("<!-- ANDRODR:PRIVACY:START -->") == 1
@@ -246,51 +486,52 @@ def test_replace_fenced_region_raises_when_fence_missing():
         render_privacy.replace_fenced_region(template, "x")
 ```
 
-- [ ] **Step 3: Run tests and confirm they fail with import error**
+- [ ] **Step 3: Install deps and confirm tests fail with ImportError**
 
-Run:
 ```bash
-cd /tmp/androdr-site-work/scripts
-python3 -m pip install markdown==3.6 pytest -q
-python3 -m pytest test_render_privacy.py -v
+cd /home/yasir/AndroDR/.claude/worktrees/docs-privacy/scripts
+python3 -m pip install --quiet markdown==3.6 pytest
+python3 -m pytest test_render_privacy.py -v 2>&1 | tail -20
 ```
-Expected: all 11 tests fail because `render_privacy` module doesn't exist yet (`ModuleNotFoundError` or `ImportError`).
+Expected: all tests fail with `ModuleNotFoundError: No module named 'render_privacy'` (module doesn't exist yet).
 
 - [ ] **Step 4: Commit failing tests**
 
 ```bash
-cd /tmp/androdr-site-work
+cd /home/yasir/AndroDR/.claude/worktrees/docs-privacy
 git add scripts/fixtures/sample_privacy.md scripts/test_render_privacy.py
-git commit -m "site: tests for privacy render script (red)"
+git commit -m "scripts: tests for privacy renderer (red)"
 ```
 
 ---
 
-## Task 4: Implement `render_privacy.py`
+## Task 7: Implement `render_privacy.py`
 
-**Repo:** `yasirhamza/androdr-site`
+**Repo:** `yasirhamza/AndroDR`
 **Files:**
 - Create: `scripts/render_privacy.py`
 
 - [ ] **Step 1: Write the implementation**
 
-Create `scripts/render_privacy.py`:
+Use Write to create `scripts/render_privacy.py`:
 ```python
-"""Render docs/PRIVACY_POLICY.md (from the AndroDR repo) into an HTML fragment
-for injection into index.html in the androdr-site repo.
+"""Render docs/PRIVACY_POLICY.md into the privacy section of a target HTML file.
 
 Usage:
-    python3 render_privacy.py <markdown-path> <index-html-path>
+    python3 render_privacy.py <markdown-path> <target-html-path>
+
+Targets: cloudflare-worker.js (in this repo) and index.html (in androdr-site).
+Both files have <!-- ANDRODR:PRIVACY:START --> ... <!-- ANDRODR:PRIVACY:END -->
+fence markers; this script replaces the region between them.
 
 The script:
   1. Parses the markdown into an HTML fragment with the 'tables' extension.
   2. Wraps it in <section class="privacy" id="privacy">...</section>
-     so existing CSS in index.html applies unchanged.
+     so existing CSS in both target files applies unchanged.
   3. Asserts structural invariants (expected <h2> and <table> counts); exits
      non-zero if they don't match. Update EXPECTED_H2 / EXPECTED_TABLES in the
      same commit that deliberately changes the privacy structure.
-  4. Replaces the fenced region (<!-- ANDRODR:PRIVACY:START --> ... END -->)
-     in index.html with the new section.
+  4. Replaces the fenced region in the target file.
 """
 from __future__ import annotations
 
@@ -320,12 +561,12 @@ def extract_last_updated(md_text: str) -> str | None:
 def render(md_text: str) -> str:
     """Convert markdown to an HTML fragment wrapped in <section class="privacy">.
 
-    The rendered fragment mirrors the structure the current index.html already
-    uses, so the existing .privacy CSS selectors apply without change. The top
+    The rendered fragment mirrors the structure the current target files use,
+    so the existing .privacy CSS selectors apply without change. The top
     `# AndroDR Privacy Policy` H1 in the markdown is dropped (the H2 "Privacy
     Policy" title lives in the HTML template), and the `_Last updated: ..._`
-    line is rendered as a `<p><em>Last updated: YYYY-MM-DD</em></p>` at the
-    top of the fragment so the date stays visible.
+    line is rendered as `<p><em>Last updated: YYYY-MM-DD</em></p>` at the top
+    of the fragment so the date stays visible.
     """
     last_updated = extract_last_updated(md_text)
     # Strip the H1 and the last-updated line; we'll re-inject the date below.
@@ -341,7 +582,7 @@ def assert_structural_invariants(html: str, expected_h2: int = EXPECTED_H2,
                                  expected_tables: int = EXPECTED_TABLES) -> None:
     """Raise AssertionError if rendered HTML deviates from expected structure."""
     h2_count = len(re.findall(r"<h2[^>]*>", html))
-    # First <h2> is the "Privacy Policy" title we injected; source markdown
+    # First <h2> is the "Privacy Policy" title we inject; source markdown
     # contributes the rest.
     source_h2 = h2_count - 1
     assert source_h2 == expected_h2, (
@@ -375,20 +616,20 @@ def replace_fenced_region(template: str, new_section: str) -> str:
 
 def main(argv: list[str]) -> int:
     if len(argv) != 3:
-        print(f"usage: {argv[0]} <markdown-path> <index-html-path>", file=sys.stderr)
+        print(f"usage: {argv[0]} <markdown-path> <target-html-path>", file=sys.stderr)
         return 2
     md_path = Path(argv[1])
-    html_path = Path(argv[2])
+    target_path = Path(argv[2])
     md_text = md_path.read_text(encoding="utf-8")
     rendered = render(md_text)
     assert_structural_invariants(rendered)
-    template = html_path.read_text(encoding="utf-8")
+    template = target_path.read_text(encoding="utf-8")
     updated = replace_fenced_region(template, rendered)
     if updated == template:
         print("no change")
         return 0
-    html_path.write_text(updated, encoding="utf-8")
-    print(f"updated {html_path}")
+    target_path.write_text(updated, encoding="utf-8")
+    print(f"updated {target_path}")
     return 0
 
 
@@ -396,325 +637,121 @@ if __name__ == "__main__":
     raise SystemExit(main(sys.argv))
 ```
 
-- [ ] **Step 2: Run tests — should now pass**
+- [ ] **Step 2: Run tests — should pass**
 
-Run:
 ```bash
-cd /tmp/androdr-site-work/scripts
-python3 -m pytest test_render_privacy.py -v
+cd /home/yasir/AndroDR/.claude/worktrees/docs-privacy/scripts
+python3 -m pytest test_render_privacy.py -v 2>&1 | tail -20
 ```
 Expected: all 11 tests PASS.
 
-- [ ] **Step 3: Dry-run against real privacy markdown**
+- [ ] **Step 3: Dry-run against `cloudflare-worker.js` to verify end-to-end**
 
-Run:
 ```bash
-cd /tmp/androdr-site-work
-cp /home/yasir/AndroDR/docs/PRIVACY_POLICY.md /tmp/live-privacy.md
-python3 scripts/render_privacy.py /tmp/live-privacy.md index.html
+cd /home/yasir/AndroDR/.claude/worktrees/docs-privacy
+cp cloudflare-worker.js /tmp/worker-before.js
+python3 scripts/render_privacy.py docs/PRIVACY_POLICY.md cloudflare-worker.js
+echo "--- diff summary ---"
+diff <(head -100 /tmp/worker-before.js) <(head -100 cloudflare-worker.js) | head -40
 ```
-Expected: script prints `updated index.html` and exits 0.
+Expected: either `updated cloudflare-worker.js` (current markdown and worker content are different, which is likely because the worker has the old 2026-03-26 date hard-coded) or `no change` (if they happen to match). No assertion failure — the counts should match between markdown and worker.
 
-- [ ] **Step 4: Verify the rendered HTML looks reasonable**
+**If the script reports an AssertionError about h2/table counts:** the markdown or target has drifted structurally from when the counts were locked. Stop and investigate before continuing.
 
-Run:
+- [ ] **Step 4: Revert the preview edit — the AndroDR PR's privacy content update will happen in Task 10, not here**
+
 ```bash
-grep -c '<h3' index.html
-grep -c '<table>' index.html
-grep -c 'yhamad.dev@gmail.com\|privacy@androdr.dev' index.html
-```
-Expected: some `<h3>` count, 3 `<table>` blocks, and `yhamad.dev@gmail.com` present. (Current markdown still has `privacy@androdr.dev` — that gets fixed in Task 7.)
-
-- [ ] **Step 5: Revert the dry-run edit to index.html**
-
-The render in Step 3 modified index.html for preview only. We want the committed state to still have the unmodified fenced region (from Task 1), not pre-applied content. Revert:
-```bash
-git checkout -- index.html
+git checkout -- cloudflare-worker.js
 ```
 
-- [ ] **Step 6: Commit the script**
+- [ ] **Step 5: Commit the script**
 
 ```bash
 git add scripts/render_privacy.py
-git commit -m "site: add render_privacy.py (tests now green)"
+git commit -m "scripts: render_privacy.py canonical markdown-to-HTML renderer (green)"
 ```
 
 ---
 
-## Task 5: Create the `render-privacy.yml` workflow in `androdr-site`
+## Task 8: Add `render-privacy-worker.yml` workflow
 
-**Repo:** `yasirhamza/androdr-site`
+**Repo:** `yasirhamza/AndroDR`
 **Files:**
-- Create: `.github/workflows/render-privacy.yml`
+- Create: `.github/workflows/render-privacy-worker.yml`
 
 - [ ] **Step 1: Write the workflow**
 
-Create `.github/workflows/render-privacy.yml`:
+Use Write to create `.github/workflows/render-privacy-worker.yml`:
 ```yaml
-name: Render privacy from AndroDR
+name: Render privacy into cloudflare-worker.js
 
 on:
   push:
     branches: [main]
     paths:
+      - 'docs/PRIVACY_POLICY.md'
       - 'scripts/render_privacy.py'
-      - 'scripts/requirements.txt'
-      - '.github/workflows/render-privacy.yml'
-  repository_dispatch:
-    types: [privacy-updated]
-  schedule:
-    # Daily safety net in case a repository_dispatch was missed.
-    - cron: '17 5 * * *'
+      - 'cloudflare-worker.js'
+      - '.github/workflows/render-privacy-worker.yml'
   workflow_dispatch:
 
 permissions:
   contents: write
 
 concurrency:
-  group: render-privacy
+  group: render-privacy-worker
   cancel-in-progress: false
 
 jobs:
   render:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout androdr-site
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
 
       - name: Install renderer dependencies
         run: python -m pip install -r scripts/requirements.txt
 
-      - name: Fetch PRIVACY_POLICY.md from AndroDR
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh api repos/yasirhamza/AndroDR/contents/docs/PRIVACY_POLICY.md \
-            --jq '.content' | base64 -d > /tmp/PRIVACY_POLICY.md
-          test -s /tmp/PRIVACY_POLICY.md
-
-      - name: Capture source SHA
-        id: src
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          SHA=$(gh api repos/yasirhamza/AndroDR/commits/main --jq '.sha' | cut -c1-7)
-          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
-
-      - name: Render privacy into index.html
-        run: python3 scripts/render_privacy.py /tmp/PRIVACY_POLICY.md index.html
+      - name: Render privacy into cloudflare-worker.js
+        run: python3 scripts/render_privacy.py docs/PRIVACY_POLICY.md cloudflare-worker.js
 
       - name: Commit if changed
         run: |
-          if git diff --quiet -- index.html; then
-            echo "no change — privacy content already in sync"
+          if git diff --quiet -- cloudflare-worker.js; then
+            echo "no change — worker already in sync"
             exit 0
           fi
-          git config user.name 'androdr-site-bot'
+          git config user.name 'androdr-bot'
           git config user.email 'yhamad.dev@gmail.com'
-          git add index.html
-          git commit -m "docs(privacy): sync from AndroDR@${{ steps.src.outputs.sha }}"
+          git add cloudflare-worker.js
+          git commit -m "docs(privacy): render into cloudflare-worker.js
+
+          Reminder: run 'wrangler deploy' locally to push this change to the
+          Cloudflare Worker. The render workflow only updates the file in the
+          repo; the live Worker deploys from a local checkout."
           git push
 ```
 
-- [ ] **Step 2: Lint the YAML**
+- [ ] **Step 2: Lint YAML**
 
-Run: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/render-privacy.yml'))"`
-Expected: no output, exit 0.
+```bash
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/render-privacy-worker.yml'))"
+```
+Expected: no output.
 
 - [ ] **Step 3: Commit**
 
 ```bash
-git add .github/workflows/render-privacy.yml
-git commit -m "site: render-privacy workflow (push/dispatch/cron/manual triggers)"
+git add .github/workflows/render-privacy-worker.yml
+git commit -m "ci: render-privacy-worker workflow (updates cloudflare-worker.js on push)"
 ```
 
 ---
 
-## Task 6: Delete duplicate `static.yml` workflow, open the site PR
-
-**Repo:** `yasirhamza/androdr-site`
-**Files:**
-- Delete: `.github/workflows/static.yml`
-
-- [ ] **Step 1: Verify `pages.yml` is sufficient for deploy**
-
-Run:
-```bash
-cat .github/workflows/pages.yml
-cat .github/workflows/static.yml
-diff <(grep -v '^#\|^$\|name:' .github/workflows/pages.yml) <(grep -v '^#\|^$\|name:' .github/workflows/static.yml)
-```
-Expected: the two files are near-identical pages-deploy jobs. If there is a unique step in `static.yml`, stop and ask the user before deleting.
-
-- [ ] **Step 2: Delete `static.yml`**
-
-```bash
-git rm .github/workflows/static.yml
-git commit -m "site: remove duplicate static.yml deploy workflow"
-```
-
-- [ ] **Step 3: Push and open PR**
-
-```bash
-git push -u origin docs/privacy-pipeline
-gh pr create --repo yasirhamza/androdr-site \
-  --title "privacy: render from AndroDR markdown via repository_dispatch" \
-  --body "$(cat <<'EOF'
-Establishes single-source-of-truth pipeline for the privacy policy.
-
-- Fences the existing privacy section with ANDRODR:PRIVACY markers
-- Adds scripts/render_privacy.py (with tests) to convert markdown → HTML fragment
-- Adds render-privacy.yml workflow (push / repository_dispatch / daily cron / manual)
-- Removes duplicate static.yml in favor of pages.yml
-
-First merge will trigger a render of the current AndroDR PRIVACY_POLICY.md
-(unchanged content; just normalizes the already-live copy into the fenced
-region). A subsequent AndroDR PR updates the markdown content and fires the
-dispatch.
-
-Spec: https://github.com/yasirhamza/AndroDR/blob/main/docs/superpowers/specs/2026-04-24-docs-refresh-design.md §5
-EOF
-)"
-```
-
-- [ ] **Step 4: Watch the workflow after merge**
-
-After the PR merges, confirm `render-privacy.yml` runs successfully on the push-to-main trigger and produces a `docs(privacy): sync from AndroDR@<sha>` commit (or "no change — privacy content already in sync" if no diff).
-
-```bash
-gh run list --repo yasirhamza/androdr-site --workflow render-privacy.yml --limit 3
-```
-
-Expected: at least one successful run. If it failed, inspect logs with `gh run view --repo yasirhamza/androdr-site <run-id> --log`.
-
----
-
-## Task 7: Update `docs/PRIVACY_POLICY.md` content
-
-**Repo:** `yasirhamza/AndroDR`
-**Files:**
-- Modify: `docs/PRIVACY_POLICY.md`
-
-- [ ] **Step 1: Create branch in AndroDR repo**
-
-```bash
-cd /home/yasir/AndroDR
-git checkout main
-git pull --ff-only
-git checkout -b docs/privacy-content-update
-```
-
-- [ ] **Step 2: Update the `_Last updated:_` line**
-
-Use Edit to change `_Last updated: 2026-03-26_` → `_Last updated: 2026-04-24_`.
-
-- [ ] **Step 3: Replace all `privacy@androdr.dev` with `yhamad.dev@gmail.com`**
-
-Run: `grep -n "privacy@androdr.dev" docs/PRIVACY_POLICY.md`
-Expected: one match on line 197.
-
-Use Edit (replace_all=true) to change `privacy@androdr.dev` → `yhamad.dev@gmail.com`.
-
-- [ ] **Step 4: Update "What AndroDR Does" to mention SIGMA engine + STIX2**
-
-Edit the "What AndroDR Does" section so its last bullet cluster includes:
-- "Uses auditable YAML [SIGMA](https://github.com/SigmaHQ/sigma)-style detection rules — detection logic is not hidden in compiled code"
-- "Imports and exports STIX2-compatible indicators for interoperability with other forensic tools"
-
-- [ ] **Step 5: Extend "Data That Stays On Your Device" table**
-
-Append two rows to the table:
-```
-| Forensic timeline events (e.g., device admin grants) | Displayed in the timeline screen and exportable as part of reports | On-device Room database |
-| Bug report analysis findings | Displayed with scan results; raw bug report file is not retained | On-device Room database |
-```
-
-- [ ] **Step 6: Update "Network Requests" table**
-
-Remove the "Cert hash IOCs (planned)" stub row. Add or update these rows to reflect the current ingesters:
-
-```
-| MalwareBazaar APK hashes + cert hashes | abuse.ch MalwareBazaar public API | Hashes of known malicious APKs and the cert hashes that signed them | 1 API request per refresh |
-| ThreatFox indicators | abuse.ch ThreatFox public API | Command-and-control domain and IP indicators | 1 API request per refresh |
-| Stalkerware cert-hash indicators | AssoEchap/stalkerware-indicators (GitHub) | Cert hashes of known stalkerware signers | 1 HTTP GET |
-```
-
-Keep the existing rows for stalkerware package names, mvt-indicators (but note the dispatcher/cross-dedup wording), and the UAD / Plexus known-app databases.
-
-Append this paragraph below the table:
-> IOC ingesters run in a dispatcher that deduplicates indicators across feeds before writing to the on-device database. Each feed is independently auditable in `app/src/main/java/com/androdr/ioc/feeds/`.
-
-- [ ] **Step 7: Tighten "Bug Report Analysis" section**
-
-Ensure the section explicitly says:
-> AndroDR retains only the analysis *findings* — flagged app names, indicator matches, detected patterns — in the scan result. The original bug report ZIP is not stored on-device after analysis completes.
-
-- [ ] **Step 8: Expand "Google Play Data Safety Alignment"**
-
-Update the bullet list to mirror the declarations in `docs/play-store/18-data-safety-form.md` (read that file first and align the language). At minimum:
-- Data collected — installed apps (on-device), device info (bugreport analysis findings, user-initiated reports only), diagnostic info (app logcat in user-initiated reports only)
-- Data shared — none (explicit user-initiated sharing only)
-- Data encrypted in transit — N/A (no user data transmitted)
-- Data deletion — clear app data / uninstall
-- Optional data collection — none
-
-- [ ] **Step 9: Sanity-check the result**
-
-Run:
-```bash
-grep -c "^## " docs/PRIVACY_POLICY.md
-grep -c "^|" docs/PRIVACY_POLICY.md
-grep -c "privacy@androdr.dev" docs/PRIVACY_POLICY.md
-grep -c "yhamad.dev@gmail.com" docs/PRIVACY_POLICY.md
-```
-Expected: heading count still `18` (no structural break); table row count `≥ 22`; zero matches for `privacy@androdr.dev`; at least one match for `yhamad.dev@gmail.com`.
-
-If the heading count changed, update `EXPECTED_H2` in `androdr-site/scripts/render_privacy.py` within the same cross-repo coordination before merging (raise to user).
-
-- [ ] **Step 10: Commit**
-
-```bash
-git add docs/PRIVACY_POLICY.md
-git commit -m "docs(privacy): refresh content — active feeds, timeline, bugreport retention, correct contact"
-```
-
----
-
-## Task 8: Sweep contact email in `docs/play-store/store-listing.md`
-
-**Repo:** `yasirhamza/AndroDR`
-**Files:**
-- Modify: `docs/play-store/store-listing.md`
-
-- [ ] **Step 1: Locate the bad email**
-
-Run: `grep -n "privacy@androdr.dev" docs/play-store/store-listing.md`
-Expected: one match on line 58.
-
-- [ ] **Step 2: Replace**
-
-Use Edit to change `privacy@androdr.dev` → `yhamad.dev@gmail.com`.
-
-- [ ] **Step 3: Verify no more occurrences anywhere in repo**
-
-Run: `grep -rn "privacy@androdr.dev" . --exclude-dir=.git --exclude-dir=.claude`
-Expected: zero output.
-
-- [ ] **Step 4: Commit**
-
-```bash
-git add docs/play-store/store-listing.md
-git commit -m "docs(play-store): correct contact email in store listing"
-```
-
----
-
-## Task 9: Add `notify-privacy-sync.yml` workflow in AndroDR
+## Task 9: Add `notify-privacy-sync.yml` workflow
 
 **Repo:** `yasirhamza/AndroDR`
 **Files:**
@@ -722,7 +759,7 @@ git commit -m "docs(play-store): correct contact email in store listing"
 
 - [ ] **Step 1: Write the workflow**
 
-Create `.github/workflows/notify-privacy-sync.yml`:
+Use Write to create `.github/workflows/notify-privacy-sync.yml`:
 ```yaml
 name: Notify androdr-site of privacy changes
 
@@ -731,6 +768,8 @@ on:
     branches: [main]
     paths:
       - 'docs/PRIVACY_POLICY.md'
+      - 'scripts/render_privacy.py'
+      - 'scripts/requirements.txt'
 
 permissions:
   contents: read
@@ -743,54 +782,237 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.PRIVACY_SYNC_TOKEN }}
         run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::error::PRIVACY_SYNC_TOKEN secret is not configured. See CONTRIBUTING or the plan for setup steps."
+            exit 1
+          fi
           gh api repos/yasirhamza/androdr-site/dispatches \
             --method POST \
             -f event_type=privacy-updated \
-            -f 'client_payload[source_sha]=${{ github.sha }}'
+            -f "client_payload[source_sha]=${{ github.sha }}"
 ```
 
-- [ ] **Step 2: Flag the token requirement to the user**
+- [ ] **Step 2: Flag token setup to the user**
 
-The default `GITHUB_TOKEN` **cannot** dispatch to another repo. This workflow needs a Personal Access Token (classic, with `repo` scope) or a fine-grained token scoped to `yasirhamza/androdr-site` with `Contents: read` + `Metadata: read` + `Actions: write`. Store it as `PRIVACY_SYNC_TOKEN` in AndroDR repo secrets.
+The default `GITHUB_TOKEN` cannot dispatch to another repo. The PR must be accompanied by a manual secret setup:
 
-Print this instruction so the user (or a follow-up task) handles it:
+1. Create a **fine-grained PAT** scoped to `yasirhamza/androdr-site` with `Contents: read`, `Metadata: read`, `Actions: write` (only these three).
+2. Add it as `PRIVACY_SYNC_TOKEN` in `yasirhamza/AndroDR` repo secrets (Settings → Secrets and variables → Actions → New repository secret).
 
-Run: `echo "MANUAL STEP: create PAT with dispatch scope on androdr-site, add as PRIVACY_SYNC_TOKEN secret in AndroDR repo"`
+Print this note so the user sees it:
 
-- [ ] **Step 3: Lint the YAML**
+```bash
+echo "============================================================"
+echo "MANUAL STEP before merging this PR:"
+echo "  Create a fine-grained PAT scoped to yasirhamza/androdr-site"
+echo "  with Contents: read, Metadata: read, Actions: write."
+echo "  Add it as secret PRIVACY_SYNC_TOKEN in yasirhamza/AndroDR."
+echo "============================================================"
+```
 
-Run: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/notify-privacy-sync.yml'))"`
-Expected: no output, exit 0.
+- [ ] **Step 3: Lint YAML**
+
+```bash
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/notify-privacy-sync.yml'))"
+```
+Expected: no output.
 
 - [ ] **Step 4: Commit**
 
 ```bash
 git add .github/workflows/notify-privacy-sync.yml
-git commit -m "ci: dispatch privacy-updated event to androdr-site on PRIVACY_POLICY change"
+git commit -m "ci: notify androdr-site when privacy content or renderer changes"
 ```
 
-- [ ] **Step 5: Push branch and open AndroDR PR**
+---
+
+## Task 10: Update `docs/PRIVACY_POLICY.md` content
+
+**Repo:** `yasirhamza/AndroDR`
+**Files:**
+- Modify: `docs/PRIVACY_POLICY.md`
+
+- [ ] **Step 1: Read current file (so Write has prior Read on this path)**
 
 ```bash
+wc -l docs/PRIVACY_POLICY.md
+grep -n "Last updated\|privacy@androdr" docs/PRIVACY_POLICY.md
+```
+
+- [ ] **Step 2: Update `_Last updated:_` to `2026-04-24`**
+
+Use Edit: `_Last updated: 2026-03-26_` → `_Last updated: 2026-04-24_`.
+
+- [ ] **Step 3: Replace all occurrences of `privacy@androdr.dev` with `yhamad.dev@gmail.com`**
+
+Use Edit with `replace_all=true` on `privacy@androdr.dev` → `yhamad.dev@gmail.com`.
+
+Verify: `grep -c "privacy@androdr.dev" docs/PRIVACY_POLICY.md` returns `0`.
+
+- [ ] **Step 4: Update "What AndroDR Does" section**
+
+Add these bullets at the end of the existing list (immediately before the `---` divider):
+
+```
+- Evaluates detection rules expressed as auditable YAML — detection logic is not hidden inside compiled code
+- Imports and exports STIX2-compatible indicators for interoperability with other forensic tools
+```
+
+And ensure the DNS monitor bullet reads "**optional** DNS monitor".
+
+- [ ] **Step 5: Extend "Data That Stays On Your Device" table**
+
+Append two rows to the table (before the closing `---`):
+```
+| Forensic timeline events (e.g., device admin grants) | Displayed in the timeline screen; included in exported reports | On-device Room database |
+| Bug report analysis findings | Displayed with scan results; the original bug report ZIP is not retained after analysis | On-device Room database |
+```
+
+- [ ] **Step 6: Update "Network Requests AndroDR Makes" table**
+
+Remove the "Cert hash IOCs (planned)" row. Add or update these rows to reflect the currently-live ingesters:
+
+```
+| MalwareBazaar APK + cert hashes | abuse.ch MalwareBazaar public API | Hashes of known malicious APKs and the cert hashes that signed them | 1 API request per refresh |
+| ThreatFox indicators | abuse.ch ThreatFox public API | Command-and-control domain / IP indicators | 1 API request per refresh |
+| Stalkerware cert-hash indicators | AssoEchap/stalkerware-indicators (GitHub) | Cert hashes of known stalkerware signers | 1 HTTP GET |
+```
+
+Keep existing rows for stalkerware package names, MVT, UAD, and Plexus.
+
+Append this paragraph below the table:
+> All ingesters run inside a dispatcher that deduplicates indicators across feeds before writing to the on-device database. Each feed is independently auditable in `app/src/main/java/com/androdr/ioc/feeds/`.
+
+- [ ] **Step 7: Tighten "Bug Report Analysis" section**
+
+Make sure the section contains this language (add it if missing):
+> AndroDR retains only the analysis findings — flagged app names, indicator matches, detected patterns — in the scan result. The original bug report ZIP is not stored on-device after analysis completes.
+
+- [ ] **Step 8: Expand "Google Play Data Safety Alignment"**
+
+Read `docs/play-store/18-data-safety-form.md` (via Read tool) and align the bullet list in this section so the two files say the same thing. At minimum the bullets should cover:
+
+- Data collected: on-device only — installed app list, device info (in user-initiated reports), diagnostic info (app logcat in user-initiated reports)
+- Data shared: none (only user-initiated sharing)
+- Data encrypted in transit: N/A — no user data is transmitted
+- Data deletion: clear app data or uninstall
+- Optional data collection: none
+
+- [ ] **Step 9: Sanity-check counts**
+
+```bash
+grep -c "^## " docs/PRIVACY_POLICY.md
+grep -c "privacy@androdr.dev" docs/PRIVACY_POLICY.md
+grep -c "yhamad.dev@gmail.com" docs/PRIVACY_POLICY.md
+grep -c "^_Last updated: 2026-04-24_$" docs/PRIVACY_POLICY.md
+```
+
+Expected:
+- `## ` heading count must be exactly `18` (the renderer's EXPECTED_H2). If it differs, update `scripts/render_privacy.py`'s `EXPECTED_H2` in the same commit.
+- `privacy@androdr.dev` → `0`
+- `yhamad.dev@gmail.com` → at least `1`
+- `_Last updated: 2026-04-24_` → `1`
+
+- [ ] **Step 10: Dry-run the renderer against the updated markdown**
+
+```bash
+python3 scripts/render_privacy.py docs/PRIVACY_POLICY.md cloudflare-worker.js
+```
+
+Expected: either `updated cloudflare-worker.js` or `no change`. If AssertionError fires, the heading or table count is off — fix the markdown (or the EXPECTED_* constants with explicit justification) before continuing.
+
+Revert the preview: `git checkout -- cloudflare-worker.js`
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add docs/PRIVACY_POLICY.md
+git commit -m "docs(privacy): refresh — active feeds, timeline, bugreport retention, fix contact"
+```
+
+---
+
+## Task 11: Fix contact email in `docs/play-store/store-listing.md`
+
+**Repo:** `yasirhamza/AndroDR`
+**Files:**
+- Modify: `docs/play-store/store-listing.md`
+
+- [ ] **Step 1: Confirm the bad email is present**
+
+```bash
+grep -n "privacy@androdr.dev" docs/play-store/store-listing.md
+```
+Expected: one match around line 58.
+
+- [ ] **Step 2: Replace**
+
+Use Edit: `privacy@androdr.dev` → `yhamad.dev@gmail.com`.
+
+- [ ] **Step 3: Confirm zero matches remain anywhere in the repo**
+
+```bash
+cd /home/yasir/AndroDR/.claude/worktrees/docs-privacy
+grep -rn "privacy@androdr.dev" . --exclude-dir=.git --exclude-dir=.claude
+```
+Expected: no output. (The `.claude` exclusion prevents matching the plan file which legitimately refers to the old string.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/play-store/store-listing.md
+git commit -m "docs(play-store): correct contact email in store listing"
+```
+
+---
+
+## Task 12: Push branch and open the AndroDR PR
+
+**Repo:** `yasirhamza/AndroDR`
+
+- [ ] **Step 1: Push**
+
+```bash
+cd /home/yasir/AndroDR/.claude/worktrees/docs-privacy
 git push -u origin docs/privacy-content-update
+```
+
+- [ ] **Step 2: Open PR**
+
+```bash
 gh pr create \
-  --title "docs(privacy): refresh policy + wire up site auto-render" \
+  --title "docs(privacy): single-source-of-truth pipeline + content refresh" \
   --body "$(cat <<'EOF'
+Part 2 of the privacy publishing pipeline. Depends on the androdr-site PR (merged first).
+
 ## Summary
-- Refreshes \`docs/PRIVACY_POLICY.md\` content (active feeds including MalwareBazaar APK/cert hashes and ThreatFox, timeline events, bugreport retention language, Data Safety alignment expansion)
-- Fixes hallucinated \`privacy@androdr.dev\` contact (replaced with \`yhamad.dev@gmail.com\`) in the privacy policy and in docs/play-store/store-listing.md
-- Adds notify-privacy-sync.yml workflow that fires \`repository_dispatch\` to androdr-site when the privacy markdown changes, so the public site auto-renders
+- Fences the privacy section in cloudflare-worker.js so the renderer can replace it.
+- Adds scripts/render_privacy.py (the canonical renderer) with tests, fixture, and pinned requirements.
+- Adds .github/workflows/render-privacy-worker.yml — on push when privacy content or renderer changes, re-renders cloudflare-worker.js. Commit message reminds the maintainer to run wrangler deploy.
+- Adds .github/workflows/notify-privacy-sync.yml — fires repository_dispatch to androdr-site so its render workflow runs immediately.
+- Refreshes docs/PRIVACY_POLICY.md content:
+  - Replaces hallucinated contact privacy@androdr.dev with yhamad.dev@gmail.com (same fix in docs/play-store/store-listing.md)
+  - Removes "Cert hash IOCs (planned)" stub; documents active MalwareBazaar APK+cert feed, ThreatFox, and stalkerware cert-hash ingestion
+  - Adds timeline events and bugreport findings to the on-device data table
+  - Adds IOC dispatcher / cross-dedup note
+  - Aligns Google Play Data Safety section with docs/play-store/18-data-safety-form.md
+  - Updates last-updated date to 2026-04-24
 
-Depends on androdr-site PR (https://github.com/yasirhamza/androdr-site/pulls) landing first; once that is in, merging this PR will propagate content to the public site within minutes.
+## Manual setup required before merge
+Create a fine-grained PAT scoped to yasirhamza/androdr-site (Contents: read, Metadata: read, Actions: write) and add it as PRIVACY_SYNC_TOKEN in this repo's Actions secrets. Without it, the notify-privacy-sync workflow will fail.
 
-Closes no issues directly; implements spec §5 (PR A) of docs/superpowers/specs/2026-04-24-docs-refresh-design.md
+## Post-merge manual action
+Run \`wrangler deploy\` from a local checkout to push the updated cloudflare-worker.js to the live Worker at androdr.yasirhamza.workers.dev.
+
+Spec: docs/superpowers/specs/2026-04-24-docs-refresh-design.md §5
 
 ## Test plan
-- [ ] PRIVACY_SYNC_TOKEN secret created in AndroDR repo (PAT with dispatch scope on androdr-site)
-- [ ] CI build check green
-- [ ] After merge, notify-privacy-sync workflow runs successfully
-- [ ] After merge, androdr-site render-privacy workflow fires and produces a \`docs(privacy): sync from AndroDR@<sha>\` commit
-- [ ] Live site (GitHub Pages + Cloudflare mirror) reflects the new content within 5–10 minutes
+- [ ] PRIVACY_SYNC_TOKEN secret exists in repo settings
+- [ ] CI build + lint pass
+- [ ] After merge: render-privacy-worker workflow succeeds and produces a "docs(privacy): render into cloudflare-worker.js" commit
+- [ ] After merge: notify-privacy-sync workflow succeeds and fires dispatch
+- [ ] After merge: androdr-site render-privacy workflow succeeds and updates index.html
+- [ ] After wrangler deploy: live Cloudflare Worker shows Last updated 2026-04-24 and correct contact email
 
 🤖 Generated with [Claude Code](https://claude.com/claude-code)
 EOF
@@ -799,17 +1021,47 @@ EOF
 
 ---
 
-## Task 10: Archive the `androdr-privacy` repo
+## Task 13: Manual `wrangler deploy`
+
+**Maintainer:** Yasir
+**Environment:** local machine with `wrangler` installed and Cloudflare authenticated
+
+- [ ] **Step 1: After the AndroDR PR merges and the worker-render commit lands on main**
+
+```bash
+cd /home/yasir/AndroDR
+git checkout main && git pull --ff-only
+grep "Last updated" cloudflare-worker.js | head -2
+```
+Expected: the `Last updated: 2026-04-24` string appears inside the inline HTML.
+
+- [ ] **Step 2: Deploy**
+
+```bash
+wrangler deploy cloudflare-worker.js
+```
+
+If the Worker is deployed under a different name or script path, use the maintainer's standard `wrangler deploy` invocation.
+
+- [ ] **Step 3: Verify live response**
+
+```bash
+curl -s https://androdr.yasirhamza.workers.dev/ | grep "Last updated\|yhamad.dev\|privacy@androdr" | head -5
+```
+Expected: at least one line containing `Last updated: 2026-04-24`, at least one containing `yhamad.dev@gmail.com`, zero containing `privacy@androdr.dev`.
+
+---
+
+## Task 14: Archive `androdr-privacy`
 
 **Repo:** `yasirhamza/androdr-privacy`
 
-Run after Tasks 1–9 are merged and the pipeline is verified end-to-end.
+Run only after Tasks 1–13 succeed and the pipeline is verified end-to-end. Archiving is semi-destructive — confirm with user before running if in doubt.
 
 - [ ] **Step 1: Replace `index.md` with a forwarding pointer**
 
 ```bash
-cd /tmp
-rm -rf androdr-privacy-archive
+cd /tmp && rm -rf androdr-privacy-archive
 gh repo clone yasirhamza/androdr-privacy androdr-privacy-archive
 cd androdr-privacy-archive
 cat > index.md <<'EOF'
@@ -817,8 +1069,10 @@ cat > index.md <<'EOF'
 
 The canonical AndroDR privacy policy now lives at
 https://github.com/yasirhamza/AndroDR/blob/main/docs/PRIVACY_POLICY.md
-and is rendered publicly at https://yasirhamza.github.io/androdr-site/#privacy
-(mirrored at https://androdr.yasirhamza.workers.dev ).
+
+It is rendered publicly at:
+- https://yasirhamza.github.io/androdr-site/#privacy (GitHub Pages)
+- https://androdr.yasirhamza.workers.dev/#privacy (Cloudflare Worker mirror)
 
 This repository is archived and no longer accepts changes.
 EOF
@@ -829,38 +1083,50 @@ git push
 
 - [ ] **Step 2: Archive the repo**
 
-Run:
 ```bash
 gh repo archive yasirhamza/androdr-privacy --yes
 ```
-Expected: confirmation that the repo is now archived.
 
 - [ ] **Step 3: Verify**
 
-Run: `gh api repos/yasirhamza/androdr-privacy --jq '{archived, updated_at}'`
+```bash
+gh api repos/yasirhamza/androdr-privacy --jq '{archived, updated_at}'
+```
 Expected: `"archived": true`.
 
 ---
 
 ## End-to-end verification
 
-Run after both PRs are merged and Task 10 completes.
+Run after Tasks 1–14 complete. This is the gate between PR A and PR B.
 
-- [ ] **Step 1: Live site reflects content update**
+- [ ] **Step 1: Live site shows fresh content**
 
-Open https://androdr.yasirhamza.workers.dev in a browser. Confirm the `#privacy` section shows `Last updated: 2026-04-24` and the correct contact email `yhamad.dev@gmail.com`. Also confirm the MalwareBazaar row no longer says `(planned)`.
+Open `https://androdr.yasirhamza.workers.dev/#privacy` in a browser. Confirm:
+- `Last updated: 2026-04-24`
+- Contact is `yhamad.dev@gmail.com`
+- MalwareBazaar cert hash row no longer says `(planned)`
 
-- [ ] **Step 2: Cross-repo grep is clean**
+Also open `https://yasirhamza.github.io/androdr-site/#privacy` (may 404 anonymously due to shadowban; use an authenticated GitHub session or check from the workflow logs instead).
 
-Run: `grep -rn "privacy@androdr\.dev" /home/yasir/AndroDR --exclude-dir=.git --exclude-dir=.claude`
-Expected: zero output.
+- [ ] **Step 2: No stale email anywhere**
 
-- [ ] **Step 3: Archive is visible**
+```bash
+cd /home/yasir/AndroDR && git checkout main && git pull --ff-only
+grep -rn "privacy@androdr\.dev" . --exclude-dir=.git --exclude-dir=.claude
+```
+Expected: no output.
 
-Open https://github.com/yasirhamza/androdr-privacy. Confirm the repo shows the "Archived" banner and the `index.md` pointer is visible.
+- [ ] **Step 3: Archive visible**
 
-- [ ] **Step 4: Trigger a trivial propagation test**
+Open `https://github.com/yasirhamza/androdr-privacy`. Confirm the archived banner and the forwarding `index.md`.
 
-Make a whitespace-only commit to `docs/PRIVACY_POLICY.md` on a throwaway branch in AndroDR, merge it, and confirm the site re-renders within ~5 minutes.
+- [ ] **Step 4: Propagation test**
 
-If all four verification steps pass, PR A is complete. Proceed to PR B plan.
+Make a whitespace-only commit to `docs/PRIVACY_POLICY.md` on a throwaway branch, merge it, and confirm within ~5 minutes:
+- `render-privacy-worker.yml` run succeeded and pushed a "docs(privacy): render into cloudflare-worker.js" commit
+- `notify-privacy-sync.yml` run succeeded
+- `androdr-site/render-privacy.yml` run succeeded and pushed a "docs(privacy): sync from AndroDR@<sha>" commit
+- `wrangler deploy` (manual) and re-check the live Worker
+
+If all four steps pass, PR A is complete. Proceed to PR B.

--- a/docs/superpowers/plans/2026-04-24-docs-refresh-pr-b-documentation-sweep.md
+++ b/docs/superpowers/plans/2026-04-24-docs-refresh-pr-b-documentation-sweep.md
@@ -1,0 +1,1094 @@
+# Docs Refresh PR B — Documentation Sweep Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the drift-prone mixed architecture content across README / CONTRIBUTING / CLAUDE.md with a single canonical `docs/ARCHITECTURE.md` reference, rewrite README and CONTRIBUTING to reflect current code (including an AI-assisted rule-authoring path for external contributors), trim CLAUDE.md, delete the stale ROADMAP, and deduplicate the play-store directory.
+
+**Architecture:** Every architecture fact lives in exactly one place. README gives a short, user-first sketch with a pointer out. CONTRIBUTING focuses on how-to-contribute with a pointer out. CLAUDE.md is reduced to AI-agent-only content with a pointer out. `docs/ARCHITECTURE.md` is the one authoritative reference.
+
+**Tech Stack:** Markdown (no code changes). `gh` CLI for issue filing.
+
+**Spec:** `docs/superpowers/specs/2026-04-24-docs-refresh-design.md` §6.
+
+**Prereq:** PR A plan (`2026-04-24-docs-refresh-pr-a-privacy-pipeline.md`) completed and verified end-to-end.
+
+---
+
+## File structure
+
+**Repo: `yasirhamza/AndroDR`**
+- Create: `docs/ARCHITECTURE.md` — canonical architecture reference (~600 lines)
+- Modify: `README.md` — rewrite (~150 lines)
+- Modify: `CONTRIBUTING.md` — rewrite (~300–400 lines)
+- Modify: `CLAUDE.md` — trim project-layout and key-decisions sections to a pointer
+- Delete: `docs/ROADMAP.md` — after extracting its "Architecture Notes" paragraph
+- Delete: `docs/play-store/query-all-packages-declaration.md` (keep `16-…`)
+- Delete: `docs/play-store/vpn-service-declaration.md` (keep `17-…`)
+- Delete: `docs/play-store/data-safety-form.md` (keep `18-…`)
+- Delete: `docs/play-store/content-rating-iarc.md` (keep `19-…`)
+- Delete: `docs/play-store/store-listing.md` (keep `20-…`)
+
+Commit order inside the PR branch is intentional — ARCHITECTURE.md lands first so later commits can reference it.
+
+---
+
+## Task 1: Create branch and capture baseline
+
+**Repo:** `yasirhamza/AndroDR`
+
+- [ ] **Step 1: Ensure PR A has merged and verified**
+
+Check: the PR A plan's end-to-end verification is complete. The AndroDR PR from PR A is merged. If it hasn't, stop and finish PR A first.
+
+Run: `git log --oneline -5 origin/main` — confirm the PR A content commits are in.
+
+- [ ] **Step 2: Create branch**
+
+```bash
+cd /home/yasir/AndroDR
+git checkout main
+git pull --ff-only
+git checkout -b docs/sweep
+```
+
+- [ ] **Step 3: Capture the current package tree to reference while drafting**
+
+Run:
+```bash
+find app/src/main/java/com/androdr -maxdepth 2 -type d | sort > /tmp/androdr-package-tree.txt
+cat /tmp/androdr-package-tree.txt
+```
+Keep this open; Tasks 2–5 and 7 cite it to stay accurate.
+
+---
+
+## Task 2: Draft `docs/ARCHITECTURE.md` chapters 1–3 (overview, principles, module map)
+
+**Repo:** `yasirhamza/AndroDR`
+**Files:**
+- Create: `docs/ARCHITECTURE.md`
+
+- [ ] **Step 1: Write the file header and chapter 1 (Overview)**
+
+Create `docs/ARCHITECTURE.md` starting with:
+```markdown
+# AndroDR Architecture
+
+> This is the canonical architecture reference for AndroDR. For how to contribute, see [CONTRIBUTING.md](../CONTRIBUTING.md). For user-facing guarantees, see [PRIVACY_POLICY.md](PRIVACY_POLICY.md). The README holds only a short sketch that links here.
+
+## 1. Overview
+
+AndroDR is an open-source Android security scanner and endpoint detection tool. It runs entirely on-device — no backend, no accounts, no telemetry — and detects stalkerware, malware, mercenary spyware, sideloaded risk, accessibility/device-admin abuse, DNS command-and-control, and unpatched CVEs. Detection logic is expressed as SIGMA-style YAML rules that are evaluated against telemetry emitted by scanner modules; indicator-of-compromise (IOC) data lives in an external rules repository so updates ship without an app release.
+
+```
+┌────────────────────────┐
+│  Device                │
+└─────────┬──────────────┘
+          │ (packages, flags, DNS, bugreports)
+          ▼
+┌────────────────────────┐      ┌───────────────────────┐
+│  Telemetry emitters    │      │  IOC resolver         │
+│  scanner/, network/    │◄────▶│  ioc/ + ioc/feeds/    │
+└─────────┬──────────────┘      └───────────────────────┘
+          │ structured events
+          ▼
+┌────────────────────────┐
+│  SIGMA rule engine     │
+│  sigma/                │
+└─────────┬──────────────┘
+          │ findings
+          ▼
+┌────────────────────────┐      ┌───────────────────────┐
+│  Data layer  (Room)    │─────▶│  UI  (Compose)        │
+│  data/                 │      │  ui/                  │
+└─────────┬──────────────┘      └───────────────────────┘
+          │
+          ▼
+┌────────────────────────┐
+│  Reports (+STIX2)      │
+│  reporting/            │
+└────────────────────────┘
+```
+
+### Reader's map
+
+- Chapter 2 — the non-negotiables that constrain every module.
+- Chapter 3 — the actual package tree in the app as of the most recent build.
+- Chapter 4 — the end-to-end detection pipeline. **Read this first if you want to understand how everything fits together.**
+- Chapters 5–8 — subsystem deep-dives (data, reporting, DNS VPN, bugreport analysis).
+- Chapter 9 — the external AI rule-authoring pipeline (Claude Code skills in `.claude/`).
+- Chapter 10 — test strategy.
+- Chapter 11 — architecture decisions with the reasoning behind each one.
+```
+
+- [ ] **Step 2: Write chapter 2 (Design principles)**
+
+Append:
+```markdown
+## 2. Design principles
+
+These are non-negotiable. Contributions that contradict them should be rejected or re-scoped.
+
+1. **Detection logic lives in YAML SIGMA rules, not in Kotlin code.** The Kotlin rule engine is the evaluator; rules are the behavior. Adding a new detection is adding a rule file. Consequences: rules are reviewable as data, portable, and updatable without an app release.
+2. **IOC data lives in the external `android-sigma-rules` repository, not bundled in the APK.** Indicator lists (malicious package names, cert hashes, C2 domains, APK hashes) refresh at runtime, so new indicators reach users within hours, not weeks.
+3. **Telemetry emitters are pure and stateless.** Modules in `scanner/` and `network/` produce structured events from device state. They do not decide whether something is a finding — that's the rule engine's job. See issues [#136] (static enforcement) and [#137] (schema-as-contract).
+4. **All processing happens on the device.** No backend, no cloud, no accounts, no analytics SDK. Report sharing is always user-initiated, via the Android share sheet.
+5. **Privacy by design.** Collect only what's needed; persist only what's needed; never transmit user data automatically; disable cloud backup (`android:allowBackup="false"`).
+6. **SIGMA compatibility where practical.** The rule schema deliberately tracks SIGMA semantics so rules can be understood by readers familiar with SIGMA, and so long-run portability to other SIGMA engines stays feasible.
+
+[#136]: https://github.com/yasirhamza/AndroDR/issues/136
+[#137]: https://github.com/yasirhamza/AndroDR/issues/137
+```
+
+- [ ] **Step 3: Write chapter 3 (Module map) against the captured tree**
+
+Reference `/tmp/androdr-package-tree.txt` from Task 1 Step 3. Append:
+```markdown
+## 3. Module map
+
+Current package tree under `app/src/main/java/com/androdr/`:
+
+\`\`\`
+├── data/
+│   ├── db/          Room DAOs + AppDatabase
+│   ├── model/       Domain models (AppRisk, DeviceFlag, DnsEvent, ScanResult, TimelineEvent, BugreportFinding)
+│   └── repo/        ScanRepository, DnsEventRepository, TimelineRepository
+├── di/              Hilt modules
+├── ioc/             Unified IOC resolver, dispatcher, cross-dedup, STIX2 import/export
+│   └── feeds/       Ingesters: stalkerware, MVT, MalwareBazaar, ThreatFox, UAD, Plexus, cert-hash
+├── network/         LocalVpnService (local DNS interception), DNS event capture
+├── reporting/       ReportFormatter, ReportExporter, STIX2 exporter, timeline serializer
+├── scanner/         ScanOrchestrator, AppScanner, DeviceAuditor
+│   └── bugreport/   Bugreport ZIP parser and finding emitter
+├── sigma/           SIGMA rule parser, evaluator, modifier support, schema loader
+├── ui/              Jetpack Compose screens
+│   ├── apps/        Apps screen + ViewModel
+│   ├── bugreport/   Bugreport analysis screen + ViewModel
+│   ├── common/      Shared composables
+│   ├── dashboard/   Dashboard screen + ViewModel
+│   ├── device/      Device audit screen + ViewModel
+│   ├── history/     Scan history + export
+│   ├── network/     DNS monitor screen + ViewModel
+│   ├── permissions/ Permission prompts + rationales
+│   ├── settings/    Settings + About
+│   ├── theme/       Material theme tokens
+│   └── timeline/    Forensic timeline screen + ViewModel
+├── worker/          WorkManager periodic IOC refresh + scan
+├── AndroDRApplication.kt
+└── MainActivity.kt
+\`\`\`
+```
+
+- [ ] **Step 4: Verify the module tree matches reality**
+
+Run:
+```bash
+for dir in data/db data/model data/repo di ioc ioc/feeds network reporting scanner scanner/bugreport sigma \
+           ui/apps ui/bugreport ui/common ui/dashboard ui/device ui/history ui/network ui/permissions ui/settings ui/theme ui/timeline; do
+  test -d "app/src/main/java/com/androdr/$dir" || echo "MISSING: $dir"
+done
+```
+Expected: no output (all directories exist). Any MISSING line is a plan bug — fix the doc before continuing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/ARCHITECTURE.md
+git commit -m "docs(architecture): ch 1-3 overview, principles, module map"
+```
+
+---
+
+## Task 3: Draft `docs/ARCHITECTURE.md` chapter 4 (Detection pipeline)
+
+**Repo:** `yasirhamza/AndroDR`
+**Files:**
+- Modify: `docs/ARCHITECTURE.md`
+
+- [ ] **Step 1: Append chapter 4**
+
+Append:
+```markdown
+## 4. Detection pipeline
+
+This is the end-to-end flow from raw device state to a user-visible finding. Four stages, four clear responsibilities.
+
+### 4.1 Telemetry emitters (`scanner/`, `network/`, `scanner/bugreport/`)
+
+Emitters are pure functions from device state to structured telemetry events. They do **not** know anything about detection rules, severity, or remediation. Their only job is "what is true about the device right now, expressed as typed records."
+
+Current emitters:
+
+- `AppScanner` → produces `AppTelemetry` records for each installed package (package name, signing cert hash, requested permissions, installer source, first-install/last-update time).
+- `DeviceAuditor` → produces `DeviceFlag` records (screen lock presence, USB debugging, bootloader verifiedboot state, security patch level, dev-settings, install-from-unknown sources).
+- `LocalVpnService` → produces `DnsEvent` records (domain, timestamp, querying app UID when attributable).
+- `scanner/bugreport/` → produces `BugreportTelemetry` (parsed dumpsys sections, process names, abnormal wakelocks, base64 blob counts, crash patterns) from a user-provided bug report ZIP.
+
+The purity contract is enforced by convention today and targeted for static-analysis enforcement in [#136].
+
+### 4.2 SIGMA rule engine (`sigma/`)
+
+The rule engine parses YAML rule files from `app/src/main/res/raw/` (bundled rules) and any remote rule feeds configured at runtime. A rule is a declaration of (a) which telemetry type it applies to, (b) field matches with modifiers (`contains`, `startswith`, `endswith`, `regex`, numeric comparisons), (c) a condition combining selections, (d) display metadata (title, severity, category), and (e) remediation guidance shown to the user.
+
+Key files:
+- `SigmaRuleParser.kt` — parses rule YAML against the schema in `third-party/android-sigma-rules/validation/rule-schema.json` (submodule; see `CLAUDE.md` for update flow).
+- `SigmaEvaluator.kt` — evaluates parsed rules against a stream of telemetry events.
+- `SigmaModifier.kt` — implements the modifier algebra (`|contains`, `|startswith`, etc.).
+
+`BundledRulesSchemaCrossCheckTest` in the test suite fails the build if the parser and the schema disagree on which fields or modifiers are valid — the submodule is the authoritative contract.
+
+### 4.3 IOC resolver (`ioc/`, `ioc/feeds/`)
+
+Detection rules reference IOC lists by name (e.g., `ioc:packages:stalkerware`). The IOC resolver answers those lookups. Indicator types currently supported:
+
+| Indicator type | Source examples | Dispatcher owner |
+|---|---|---|
+| Package name | stalkerware-indicators, MVT | PublicRepoIocFeed |
+| Cert hash (signing certificate SHA-256) | stalkerware-indicators, MalwareBazaar | PublicRepoIocFeed + MalwareBazaarFeed |
+| C2 domain | MVT, ThreatFox | PublicRepoIocFeed + ThreatFoxFeed |
+| APK file hash (SHA-256 of APK) | MalwareBazaar | MalwareBazaarApkHashFeed |
+
+The dispatcher (`ioc/IocDispatcher.kt`) performs cross-feed deduplication before writing the indicator to the on-device Room store. This is how the same indicator (e.g., a cert hash appearing in both the stalkerware feed and MalwareBazaar) gets merged into a single resolver entry with attribution preserved. See issue [#143] for the open edge-case around dual-writer collisions.
+
+Cursor state (feed-last-fetched timestamps) and decisions (which indicators were accepted / rejected / deduplicated) are persisted with explicit schemas in the rules repo so the pipeline is debuggable post-hoc.
+
+### 4.4 Findings
+
+When the evaluator finds a match, it produces a `Finding` record carrying:
+- rule id + title (from rule `display:` block)
+- severity + category
+- matched telemetry reference
+- remediation text
+
+Findings are persisted in Room, displayed in the dashboard / apps / device / timeline screens, and included in exported reports. Display metadata lives in the rule, not in Kotlin — adding a new detection doesn't touch UI code.
+
+### 4.5 Example end-to-end walkthrough
+
+1. `AppScanner` enumerates installed packages and emits `AppTelemetry(packageName="com.example.stalker", certHash="abc...", ...)`.
+2. Evaluator loads rule `androdr-001-package-ioc.yml` which has selection `packageName|in:ioc:packages:stalkerware`.
+3. `IocDispatcher` resolves `ioc:packages:stalkerware` → returns a set that includes `com.example.stalker` (ingested from stalkerware-indicators feed on last refresh).
+4. Condition matches. Evaluator produces `Finding(ruleId="androdr-001", severity="critical", ...)`.
+5. Finding is written to `ScanRepository`.
+6. Apps screen observes the repository and displays the finding with remediation.
+7. User exports a report; `ReportExporter` includes the finding with full context.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/ARCHITECTURE.md
+git commit -m "docs(architecture): ch 4 detection pipeline"
+```
+
+---
+
+## Task 4: Draft `docs/ARCHITECTURE.md` chapters 5–8 (subsystems)
+
+**Repo:** `yasirhamza/AndroDR`
+**Files:**
+- Modify: `docs/ARCHITECTURE.md`
+
+- [ ] **Step 1: Append chapter 5 (Data layer)**
+
+Append:
+```markdown
+## 5. Data layer (`data/`)
+
+- **Room database** (`AppDatabase`) stores scan results, DNS events, timeline events, bugreport findings, and IOC cache state. `ScanResult` is serialized via `kotlinx.serialization` so the schema can evolve without DB migrations for every rule change.
+- **Auto-prune** policy keeps scan history retention bounded (configurable; current default: 30 days for DNS events and timeline events).
+- **Cloud backup is disabled** (`android:allowBackup="false"` in manifest) — scan data never reaches Google's backup servers.
+- **STIX2 indicator model** lives in `ioc/stix2/` and is used for both ingesting STIX2 bundles and exporting findings to STIX2-consuming tools.
+```
+
+- [ ] **Step 2: Append chapter 6 (Reporting & export)**
+
+Append:
+```markdown
+## 6. Reporting & export (`reporting/`)
+
+- **`ReportFormatter`** builds a plaintext report from current scan results, DNS events, timeline, and device flags.
+- **`ReportExporter`** is a `@Singleton` that writes the formatted report to `cacheDir/reports/` and captures up to 300 lines of AndroDR's own process log (`logcat --pid` — not system-wide logs). A `FileProvider` configured at `${applicationId}.fileprovider` (paths: `res/xml/file_paths.xml`) serves the file to the Android share sheet.
+- **STIX2 export** writes a STIX2 bundle of findings + observed indicators for forensic tool interop.
+- **Timeline export** serializes the forensic timeline (e.g., device admin grants per #79) into the report.
+- Every export is **user-initiated only** — there is no automatic upload path, by construction.
+```
+
+- [ ] **Step 3: Append chapter 7 (DNS monitor)**
+
+Append:
+```markdown
+## 7. DNS monitor (`network/`)
+
+`LocalVpnService` implements a local VPN that intercepts only DNS queries on-device. It:
+
+- Never routes traffic off-device. The service acts as a local DNS resolver and forwards DNS responses back to the app that issued the query; non-DNS traffic is untouched.
+- Emits `DnsEvent` records into the same evaluator pipeline as other telemetry. A rule that matches domains in the C2 domain IOC list will fire whether the domain came from a scan or from a real-time DNS event.
+- Is strictly optional. The user must accept the Android VPN permission dialog to enable it; there is no way to pre-grant.
+
+### Why DNS-only and not full traffic
+
+Full IP-level filtering / inspection was evaluated and parked. Reasons: (a) TLS SNI inspection introduces trust issues that conflict with the privacy-by-design principle, (b) DNS-level indicator matching covers the overwhelming majority of mobile C2 use cases identified in threat-intel feeds, (c) full filtering materially expands the app's surface area and review burden. The decision is recorded in §11.
+```
+
+- [ ] **Step 4: Append chapter 8 (Bugreport analysis)**
+
+Append:
+```markdown
+## 8. Bugreport analysis (`scanner/bugreport/`)
+
+Android bug reports (`.zip`) contain dumpsys output, process lists, battery stats, and a wealth of forensic signal that doesn't surface through normal runtime APIs. AndroDR accepts a user-provided bugreport and emits findings.
+
+Pipeline stages:
+
+1. **Accept** — user picks a bugreport ZIP via the Android file picker. No auto-capture.
+2. **Parse** — extract relevant dumpsys sections (package, accessibility, device-admin, batterystats wakelocks, process names).
+3. **Emit telemetry** — produce `BugreportTelemetry` records that flow into the same rule evaluator as `AppTelemetry` and `DeviceFlag`. There is no bugreport-specific detection logic in the evaluator.
+4. **Match** — rules with `logsource.service: bugreport` fire on matching telemetry.
+5. **Display findings** — bugreport screen shows what was detected, with pointers into the raw dumpsys for investigation.
+6. **Discard raw** — the original ZIP is not persisted after analysis. Only the structured findings are kept.
+
+Bug reports are among the most sensitive files on an Android device. AndroDR handles them with a strict "your device, your choice" model.
+```
+
+- [ ] **Step 5: Verify Kotlin files referenced in chapters 5–8 still exist**
+
+Run:
+```bash
+find app/src/main/java/com/androdr/reporting -name 'ReportFormatter.kt' -o -name 'ReportExporter.kt'
+find app/src/main/java/com/androdr/network -name 'LocalVpnService.kt'
+find app/src/main/java/com/androdr/scanner/bugreport -type f -name '*.kt' | head -3
+```
+Expected: all the named files exist. If any is missing or renamed, update the doc before committing.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs/ARCHITECTURE.md
+git commit -m "docs(architecture): ch 5-8 data, reporting, DNS, bugreport"
+```
+
+---
+
+## Task 5: Draft `docs/ARCHITECTURE.md` chapters 9–11 (AI pipeline, testing, decisions) + fold ROADMAP notes
+
+**Repo:** `yasirhamza/AndroDR`
+**Files:**
+- Modify: `docs/ARCHITECTURE.md`
+- Read (to extract): `docs/ROADMAP.md` (not yet deleted)
+
+- [ ] **Step 1: Append chapter 9 (AI rule-authoring pipeline)**
+
+Append:
+```markdown
+## 9. AI rule-authoring pipeline
+
+AndroDR uses an AI-assisted pipeline to generate and validate new SIGMA detection rules from threat intelligence sources. The pipeline lives in `.claude/` (Claude Code skills and slash commands) and operates on the external rules repository, not on the app. External contributors do **not** need access to this pipeline to contribute rules — see `CONTRIBUTING.md` for both manual and AI-assisted contribution paths.
+
+### Pipeline stages
+
+1. **Ingest** — feed-specific skills parse upstream threat-intel sources into a normalized `SIR` (Structured Indicator Record) format:
+   - `/update-rules-ingest-abusech` (MalwareBazaar + ThreatFox)
+   - `/update-rules-ingest-stalkerware` (AssoEchap/stalkerware-indicators)
+   - `/update-rules-ingest-mvt` (mvt-project indicators)
+   - `/update-rules-ingest-asb` (Android Security Bulletins)
+   - `/update-rules-ingest-nvd` (NVD/NIST CVE database, Android-filtered)
+   - `/update-rules-ingest-amnesty` (AmnestyTech/investigations)
+   - `/update-rules-ingest-attack` (MITRE ATT&CK Mobile)
+2. **Discover** — `/update-rules-discover` autonomously surfaces threat names from vendor-blog RSS/HTML indices, feeding new SIRs back into ingest.
+3. **Research** — `/update-rules-research-threat` does targeted web research on a named threat to complete its SIR.
+4. **Author** — `/update-rules-author` turns SIRs into candidate SIGMA YAML rules, applying the bundled rule schema and current logsource taxonomy.
+5. **Validate** — `/update-rules-validate` runs a 5-gate validation pipeline (schema, field alignment, modifier compliance, IOC existence, no false-positive on known-good apps).
+6. **Review** — `/update-rules-review` performs an independent LLM review of the AI-authored rules, catching issues like overfitting or missing remediation text.
+7. **Stage and promote** — rules land first in `staging/`, go through Gate-4 harness testing on real telemetry, and get promoted to production when the harness confirms expected behavior.
+
+The orchestrator `/update-rules` runs the full cycle end-to-end.
+
+### Rules repository
+
+All rules and IOC data live in `https://github.com/yasirhamza/android-sigma-rules`, which is vendored into AndroDR as a git submodule at `third-party/android-sigma-rules/`. The submodule pointer is only bumped when the app needs upstream schema changes — adding a rule upstream does not automatically affect the built APK.
+```
+
+- [ ] **Step 2: Append chapter 10 (Test strategy)**
+
+Append:
+```markdown
+## 10. Test strategy
+
+- **Unit tests** (`app/src/test/`) cover parsers, emitters, the rule evaluator, the IOC resolver, report formatting, and serialization. All run via `./gradlew testDebugUnitTest`.
+- **Instrumentation tests** (`app/src/androidTest/`) cover Room DAOs, the DNS VPN service, and file-provider-backed export flows. Run on a connected device or emulator.
+- **`BundledRulesSchemaCrossCheckTest`** asserts the Kotlin `SigmaRuleParser` and the JSON schema in the submodule agree on allowed fields and modifiers. This is the tripwire for schema drift.
+- **Validation gates on rules** (see §9) run on every proposed rule change — AI-generated or hand-authored.
+- **UAT persona testing** via `/uat-test` evaluates AndroDR output from real user perspectives (DV survivor, investigative journalist, IT admin) before material UX changes land.
+- **On-device smoke test** (`scripts/smoke-test.sh`) boots a headless `Medium_Phone_API_36.1` AVD, installs the debug APK, launches the app, and scans logcat for crashes. Required before releasing.
+- **Lint + detekt** (`./gradlew lintDebug detekt`) run on every CI build; warnings are errors in release builds.
+```
+
+- [ ] **Step 3: Read the old ROADMAP "Architecture Notes" paragraph**
+
+Run:
+```bash
+sed -n '/^## Architecture Notes/,$p' docs/ROADMAP.md
+```
+Keep this text open for Step 4.
+
+- [ ] **Step 4: Append chapter 11 (Decisions), absorbing the ROADMAP notes**
+
+Append:
+```markdown
+## 11. Decisions
+
+Short ADR-style entries for load-bearing choices. Each has a one-line claim followed by the reasoning.
+
+### D1. Detection logic in YAML SIGMA rules, not Kotlin code
+
+Rules are reviewable as data, portable, and updatable without app releases. Adding a detection is adding a rule file and an IOC entry, not a code change.
+
+### D2. IOC data lives in an external rules repository, not bundled in the APK
+
+Indicators update faster than app release cadence; DV survivors and journalists benefit from hours-not-weeks indicator turnaround.
+
+### D3. DNS-only VPN scope (full IP filtering parked)
+
+Full IP-level inspection was evaluated and rejected. DNS-level indicator matching covers the majority of observed mobile C2 patterns, and full inspection would require TLS SNI handling that conflicts with privacy-by-design.
+
+### D4. Pure-emitter telemetry/findings contract
+
+Emitters produce typed records; the rule engine is the only decision-maker. This keeps emitters testable, the engine deterministic, and rules the single place detection behavior lives. Static enforcement is open work: [#136]. Machine-readable schema contract: [#137].
+
+### D5. SIGMA compatibility where practical
+
+The rule schema deliberately tracks SIGMA semantics. Some divergences are unavoidable (Android-specific logsource services, display metadata for UI), but modifier semantics, field matching, and condition composition mirror SIGMA.
+
+### D6. No cloud backend
+
+No AndroDR-operated server exists. All processing is on-device. Updates to indicators happen via direct fetches from upstream threat-intel sources, unauthenticated, without transmitting user data. This choice is load-bearing for GDPR/CCPA posture.
+
+### D7. Rule engine capabilities
+
+The rule engine supports field matching with modifiers (`contains`, `startswith`, `endswith`, `regex`, numeric comparisons), IOC lookups (package / cert hash / domain / APK hash), evidence providers (CVE lists with campaign attribution), display metadata (titles, icons, severity, evidence type) embedded in rules, and remote rule feeds from configurable URLs.
+
+### Open architecture work
+
+- Persist all telemetry types to Room for complete forensic export: [#96]
+- Static enforcement of the pure-emitter contract: [#136]
+- Machine-readable telemetry schema contract: [#137]
+- Rule-lineage tooling for the rule author agent: [#139]
+
+[#96]: https://github.com/yasirhamza/AndroDR/issues/96
+[#136]: https://github.com/yasirhamza/AndroDR/issues/136
+[#137]: https://github.com/yasirhamza/AndroDR/issues/137
+[#139]: https://github.com/yasirhamza/AndroDR/issues/139
+[#143]: https://github.com/yasirhamza/AndroDR/issues/143
+```
+
+- [ ] **Step 5: Verify ARCHITECTURE.md has the expected structure**
+
+Run:
+```bash
+grep -c '^## ' docs/ARCHITECTURE.md
+grep -c '^### ' docs/ARCHITECTURE.md
+wc -l docs/ARCHITECTURE.md
+```
+Expected: 11 top-level sections (matching the 11 chapters), ≥20 subsections, ≥500 lines.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs/ARCHITECTURE.md
+git commit -m "docs(architecture): ch 9-11 AI pipeline, tests, decisions (fold ROADMAP notes)"
+```
+
+---
+
+## Task 6: Rewrite `README.md`
+
+**Repo:** `yasirhamza/AndroDR`
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Read the current README so the Write tool has a prior Read on this file, then replace**
+
+Run: `cat README.md | head -1` (or use the Read tool).
+
+Then use Write to replace the file with:
+```markdown
+# AndroDR
+
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
+[![Android](https://img.shields.io/badge/Android-8.0%2B-green.svg)](https://developer.android.com)
+
+Open-source Android security scanner and endpoint detection (EDR). Detects spyware, stalkerware, and malware entirely on-device — no cloud, no accounts, no tracking.
+
+## Who it's for
+
+- **DV survivors** — check if a partner installed monitoring software
+- **Journalists and activists** — detect state-sponsored spyware (Pegasus, Predator, Graphite)
+- **IT security teams** — lightweight device health checks without commercial MDM
+- **Privacy-conscious users** — verify your phone hasn't been compromised
+
+## What it detects
+
+- **Known malware** — package names, signing certificates, and APK file hashes matched against threat intelligence databases
+- **Stalkerware** — commercial surveillance apps (TheTruthSpy, mSpy, FlexiSPY, etc.)
+- **Mercenary spyware** — Pegasus (NSO), Predator (Intellexa), Graphite (Paragon), NoviSpy, ResidentBat
+- **Sideloaded apps** — apps installed from untrusted sources
+- **Surveillance permission combinations** — apps holding camera + microphone + location + contacts access
+- **Accessibility / Device Admin abuse** — apps misusing privileged services for monitoring
+- **Device posture** — screen lock, USB debugging, bootloader state, security patch level
+- **Unpatched CVEs** — checks against the CISA Known Exploited Vulnerabilities catalog
+- **DNS command-and-control** — connections to known malicious domains (optional local VPN monitor)
+- **Spyware file artifacts** — filesystem checks for known spyware remnants
+- **Bug report analysis** — forensic analysis of user-provided Android bug reports (`.zip`)
+- **Forensic timeline** — notable security events over time (e.g., device admin grants)
+
+## How it works
+
+Detection logic is expressed as [SIGMA](https://github.com/SigmaHQ/sigma)-compatible YAML rules evaluated against telemetry emitted by the scanner. Rules are reviewable as data — not hidden in compiled code.
+
+Indicator data (malicious package names, certificate hashes, C2 domains, APK hashes) lives in the external [`android-sigma-rules`](https://github.com/yasirhamza/android-sigma-rules) repository and refreshes at runtime. New indicators reach users within hours, not release cycles.
+
+## Architecture
+
+\`\`\`
+app/src/main/java/com/androdr/
+├── scanner/   Telemetry emitters (apps, device, bugreport)
+├── sigma/     SIGMA rule engine
+├── ioc/       IOC resolver + feed ingesters
+├── data/      Room database + models
+├── reporting/ Reports + STIX2 export + timeline
+├── network/   Local DNS VPN monitor
+└── ui/        Jetpack Compose screens
+\`\`\`
+
+**Key design principles:**
+- Detection logic in YAML rules, not Kotlin code
+- IOC data in the external rules repo, not bundled in the APK
+- All processing on-device — no backend, no accounts, no telemetry
+- Privacy by design — auto-prune, no cloud backup, user-initiated sharing only
+
+See [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) for the full architecture reference.
+
+## Building
+
+```bash
+# Prerequisites: JDK 21, Android SDK (compile SDK 34)
+# No API keys required.
+
+./gradlew assembleDebug        # Build debug APK
+./gradlew testDebugUnitTest    # Run unit tests
+./gradlew lintDebug detekt     # Lint + SAST
+./gradlew installDebug         # Install on device/emulator
+./gradlew bundleRelease        # Build release AAB
+```
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the full development workflow (submodules, smoke test, PR process).
+
+## Download
+
+Latest release: https://github.com/yasirhamza/AndroDR/releases/latest
+
+Mirror (for regions where GitHub downloads are throttled): https://androdr.yasirhamza.workers.dev
+
+## Privacy
+
+All scanning and analysis happens entirely on your device. No data is transmitted to any server. See the [privacy policy](https://androdr.yasirhamza.workers.dev/#privacy).
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for how to add detection rules (manual or AI-assisted), contribute IOC data, report false positives, and set up the development environment.
+
+## License
+
+Apache License 2.0 — see [LICENSE](LICENSE).
+```
+
+- [ ] **Step 2: Verify the README tree matches reality**
+
+Run:
+```bash
+for dir in scanner sigma ioc data reporting network ui; do
+  test -d "app/src/main/java/com/androdr/$dir" || echo "MISSING: $dir"
+done
+```
+Expected: no output. If anything is missing, the README tree is wrong — fix before committing.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md
+git commit -m "docs(readme): rewrite to reflect current code + link to ARCHITECTURE.md"
+```
+
+---
+
+## Task 7: Rewrite `CONTRIBUTING.md`
+
+**Repo:** `yasirhamza/AndroDR`
+**Files:**
+- Modify: `CONTRIBUTING.md`
+
+- [ ] **Step 1: Read the current CONTRIBUTING to preserve anything unique**
+
+Read `CONTRIBUTING.md` end-to-end. Extract:
+- The code-of-conduct wording (preserve verbatim — it's strong and correct).
+- The rule file example structure.
+
+- [ ] **Step 2: Replace `CONTRIBUTING.md` with fresh content**
+
+Use Write to replace the file with:
+```markdown
+# Contributing to AndroDR
+
+Thank you for your interest in contributing. AndroDR protects people in vulnerable situations — domestic violence survivors, journalists under surveillance, activists at risk — from spyware and stalkerware. Every contribution should advance that mission.
+
+## Ways to contribute
+
+- **Detection rules** (SIGMA YAML) — the most impactful contribution, see below
+- **IOC data** — malicious package names, cert hashes, C2 domains
+- **False-positive reports** — rules flagging legitimate apps
+- **Bug reports** — with device details and reproduction steps
+- **Feature ideas** — open a GitHub issue to discuss
+- **Code** — Kotlin app code, or AI-pipeline skill improvements
+
+## Writing detection rules — manual path
+
+Rules live in the companion repository: [yasirhamza/android-sigma-rules](https://github.com/yasirhamza/android-sigma-rules). They are bundled into AndroDR via a git submodule and evaluated on-device.
+
+### Add a new rule
+
+1. Fork and clone `android-sigma-rules`.
+2. Create a YAML file under the appropriate service directory (`app_scanner/`, `device_auditor/`, `dns_monitor/`, `bugreport/`, etc.).
+3. Follow the format below. The authoritative schema is `validation/rule-schema.json` in the same repo.
+4. Add your rule filename to `rules.txt`.
+5. Open a PR with a description of what the rule detects and why it matters.
+
+### Minimal rule example
+
+```yaml
+title: Sample stalkerware package detection
+id: androdr-NNN-sample
+status: experimental
+description: |
+  Detects the presence of <specific stalkerware product> by package name.
+  This product is documented by <source link>.
+author: Your Name
+date: 2026-04-24
+tags:
+  - attack.t1437  # MITRE ATT&CK technique ID
+logsource:
+  product: androdr
+  service: app_scanner
+detection:
+  selection:
+    packageName|in: ioc:packages:stalkerware
+  condition: selection
+level: critical
+display:
+  category: app_risk
+  triggered_title: "<Product> detected"
+  severity_description: "Commercial stalkerware that enables remote monitoring."
+remediation:
+  - "Uninstall the app: Settings → Apps → <Product> → Uninstall."
+  - "If uninstall is blocked by device admin, first revoke admin: Settings → Security → Device admin apps → <Product> → Deactivate, then uninstall."
+  - "If you are at risk, contact a domestic-violence resource before uninstalling — the installer may be notified."
+```
+
+### Logsource services
+
+The `service:` value must match a supported service in `SigmaRuleParser.kt`. Current services include `app_scanner`, `device_auditor`, `dns_monitor`, and `bugreport`. Adding a new service requires a coordinated change in both repos (see `CLAUDE.md` → "Adding a new field or logsource service").
+
+### Local validation
+
+Before opening the PR, run the validation gates locally:
+
+```bash
+cd android-sigma-rules
+./validation/validate.sh your_new_rule.yml
+```
+
+All five gates (schema, field alignment, modifier compliance, IOC existence, no known-good false positives) must pass.
+
+## Writing detection rules — AI-assisted path
+
+Project maintainers use an AI pipeline (Claude Code skills in `.claude/`) to draft and validate rules from threat-intelligence feeds. You are welcome to use AI in your own rule-authoring workflow — the validation gates are the same whether a rule was hand-written or AI-authored, so AI does not skip review.
+
+### Suggested approach
+
+1. Provide the AI with the following context:
+   - The rule schema at `android-sigma-rules/validation/rule-schema.json`
+   - Two or three existing rules in the same service directory as examples
+   - The threat description or threat-intelligence source you are working from
+2. Prompt the AI to produce a candidate rule in the same YAML format, setting `status: experimental` and filling in display and remediation blocks.
+3. Review the output critically. AI drafts often:
+   - Hallucinate field names — compare against the schema
+   - Over-broaden selections — make sure the rule fires only on the intended behavior
+   - Reuse remediation text from examples even when it doesn't fit — rewrite to match the actual threat
+4. Run local validation gates.
+5. Open the PR and mention AI assistance in the description.
+
+For the project's internal pipeline details, see [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) §9. External contributors do not need that pipeline to contribute.
+
+## IOC data contributions
+
+Indicator data lives in `ioc-data/*.yml` in the rules repo:
+
+- `package-names.yml` — known malicious package names
+- `cert-hashes.yml` — malicious signing certificate hashes
+- `c2-domains.yml` — command-and-control domains
+- `malware-hashes.yml` — APK file hashes (SHA-256)
+- `popular-apps.yml` — well-known legitimate apps (reduces false positives)
+
+The AI pipeline's ingester dispatcher writes to these files with cross-feed deduplication. Manual edits are welcome for high-quality, well-sourced additions that the feeds haven't picked up. Include an attribution comment with each entry.
+
+## False-positive reports
+
+If AndroDR flags a legitimate app:
+
+1. Open an issue titled "False positive: <app name>".
+2. Include the package name, the rule id (visible in the app's finding detail), your device model and Android version, and why the app is legitimate (link to the official source, enterprise context, etc.).
+3. If appropriate, open a PR against `ioc-data/popular-apps.yml` adding the app.
+
+## Bug reports
+
+Open an issue with:
+
+- Device model and Android version
+- Steps to reproduce
+- Expected vs. actual behavior
+- Exported scan report if relevant (review it first for anything you don't want to share publicly)
+
+## Development setup
+
+### Prerequisites
+
+- **JDK 21** (`java -version` must report 21.x)
+- **Android SDK** with compile SDK 34 and build-tools. Set `ANDROID_HOME` or point `local.properties` at your SDK.
+- **No API keys or secrets required** — AndroDR compiles and runs fully offline.
+
+### Clone and initialize
+
+```bash
+git clone https://github.com/yasirhamza/AndroDR.git
+cd AndroDR
+git submodule update --init
+```
+
+The submodule at `third-party/android-sigma-rules/` is authoritative for the rule schema; `BundledRulesSchemaCrossCheckTest` fails the build if the parser and schema disagree.
+
+### Build and test
+
+```bash
+./gradlew assembleDebug        # Build debug APK
+./gradlew testDebugUnitTest    # Unit tests
+./gradlew lintDebug detekt     # Lint + SAST
+./gradlew installDebug         # Install on device or emulator
+./gradlew bundleRelease        # Release AAB
+```
+
+### Smoke test (local emulator)
+
+```bash
+./scripts/smoke-test.sh
+```
+
+Boots a headless `Medium_Phone_API_36.1` AVD, installs the debug APK, launches the app, and scans logcat for crashes. Requires `ANDROID_HOME` set.
+
+### On-device testing
+
+1. Enable **Developer Options** and **USB Debugging** on the device.
+2. `adb devices` — confirm the device is listed.
+3. `./gradlew installDebug`.
+4. The DNS VPN feature requires the user to accept the Android VPN permission dialog on first launch — it cannot be pre-granted.
+
+### Submodule update direction
+
+The submodule pointer is pinned. The AI pipeline and upstream contributors can add rules to `android-sigma-rules` without affecting the built APK until the submodule is explicitly bumped:
+
+```bash
+cd third-party/android-sigma-rules && git pull origin main && cd ../..
+git add third-party/android-sigma-rules
+git commit -m "build: bump android-sigma-rules submodule"
+```
+
+Bump when you need upstream schema changes (e.g., a new modifier or logsource service) or when staging rules should be promoted into the built APK.
+
+## PR workflow
+
+- Branch from `main`; name branches `feat/<issue>-<short-name>`, `fix/<topic>`, `docs/<topic>`, `ci/<topic>`, `test/<topic>`.
+- Target `main` in your PR. Do not target `claude/*` branches — those are obsolete mirrors being deleted.
+- Include `Closes #N` in the PR body so merging auto-closes the linked issue.
+- CI must pass — specifically the `build` check.
+- Prefer small, focused PRs over sweeping changes. A PR reviewer should be able to hold the whole diff in their head.
+
+## Architecture principles
+
+See [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) §2 for the non-negotiables and the reasoning behind them.
+
+## Code of conduct
+
+This project serves people in vulnerable situations — domestic violence survivors, journalists under surveillance, activists at risk. All contributions must prioritize user safety and privacy. Contributions that add tracking, analytics, remote telemetry, or other mechanisms that could compromise user privacy will not be accepted regardless of technical merit.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CONTRIBUTING.md
+git commit -m "docs(contributing): rewrite with manual + AI-assisted rule paths, PR workflow, dev setup"
+```
+
+---
+
+## Task 8: Trim `CLAUDE.md`
+
+**Repo:** `yasirhamza/AndroDR`
+**Files:**
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Replace the "Project layout" and "Key architectural decisions" sections with a pointer**
+
+Use Edit to remove the current "## Project layout" section (the stale tree) and the "## Key architectural decisions" section. Replace both with a single block:
+
+```markdown
+## Architecture reference
+
+See [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) for the architecture, module map, and design principles. Keep that document as the single source of truth — do not duplicate its content here.
+```
+
+Everything else in `CLAUDE.md` (build requirements, common commands, development workflow, lint / style, running on physical device, local development, smoke test, submodule guide) stays as-is.
+
+- [ ] **Step 2: Verify no stale tree remains**
+
+Run: `grep -n 'vpn/' CLAUDE.md`
+Expected: zero matches (the old tree referenced `vpn/` which has since been renamed `network/`).
+
+Run: `grep -c '^## ' CLAUDE.md`
+Expected: the total number of sections decreased by 1 from before (two sections merged into one pointer).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs(claude): trim architecture content to pointer at ARCHITECTURE.md"
+```
+
+---
+
+## Task 9: Delete `docs/ROADMAP.md`
+
+**Repo:** `yasirhamza/AndroDR`
+**Files:**
+- Delete: `docs/ROADMAP.md`
+
+- [ ] **Step 1: Confirm ROADMAP "Architecture Notes" content is already in `ARCHITECTURE.md`**
+
+Run:
+```bash
+grep -c 'rule engine supports' docs/ARCHITECTURE.md
+```
+Expected: ≥1 match — the "The rule engine supports ..." paragraph should be folded into §11 D7 per Task 5. If zero, stop and fix Task 5 before deleting.
+
+- [ ] **Step 2: Find inbound links to ROADMAP**
+
+Run:
+```bash
+grep -rn 'docs/ROADMAP\|ROADMAP\.md\b' --include='*.md' --include='*.kt' --include='*.xml' --include='*.yml' --exclude-dir=.git --exclude-dir=.claude .
+```
+
+Expected matches (known, harmless):
+- `docs/detection-rules-catalog.md` — `[ROADMAP #N]` text markers (these are labels, not file links; leave alone per spec §6.5)
+- `notes/apprehend-rename-plan.md` — ignore (user notes, uncommitted)
+- `docs/superpowers/specs/2026-04-24-docs-refresh-design.md` and this plan file — meta-references, leave alone
+
+If there are inbound **link** references (like `[Roadmap](docs/ROADMAP.md)`), fix them to point at the Issues page before deleting.
+
+- [ ] **Step 3: Delete the file**
+
+```bash
+git rm docs/ROADMAP.md
+git commit -m "docs: remove stale ROADMAP.md (GitHub Issues is canonical)"
+```
+
+---
+
+## Task 10: Deduplicate `docs/play-store/`
+
+**Repo:** `yasirhamza/AndroDR`
+
+- [ ] **Step 1: Pairwise compare each numbered vs unnumbered file**
+
+Run each of the following and capture the output:
+
+```bash
+diff -u docs/play-store/query-all-packages-declaration.md  docs/play-store/16-query-all-packages-declaration.md
+diff -u docs/play-store/vpn-service-declaration.md         docs/play-store/17-vpn-permission-declaration.md
+diff -u docs/play-store/data-safety-form.md                docs/play-store/18-data-safety-form.md
+diff -u docs/play-store/content-rating-iarc.md             docs/play-store/19-content-rating-iarc.md
+diff -u docs/play-store/store-listing.md                   docs/play-store/20-store-listing.md
+```
+
+For each pair:
+- If the numbered version is a superset or strictly newer: delete the unnumbered version.
+- If the unnumbered version has unique content: **merge forward** into the numbered version first, then delete the unnumbered one.
+
+- [ ] **Step 2: Perform deletions (only after Step 1 confirms no content loss)**
+
+```bash
+git rm docs/play-store/query-all-packages-declaration.md
+git rm docs/play-store/vpn-service-declaration.md
+git rm docs/play-store/data-safety-form.md
+git rm docs/play-store/content-rating-iarc.md
+git rm docs/play-store/store-listing.md
+```
+
+- [ ] **Step 3: Verify no inbound links to deleted files**
+
+Run:
+```bash
+for f in query-all-packages-declaration vpn-service-declaration data-safety-form content-rating-iarc store-listing; do
+  echo "=== $f ==="
+  grep -rn "play-store/$f" --include='*.md' --exclude-dir=.git . || true
+done
+```
+Expected: zero matches across all five. If any inbound link still points at a deleted file, update it to point at the numbered version.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git commit -m "docs(play-store): remove duplicate unnumbered versions (superseded by 16–20)"
+```
+
+---
+
+## Task 11: File follow-up issue for `detection-rules-catalog.md`
+
+- [ ] **Step 1: Open the issue**
+
+Run:
+```bash
+gh issue create \
+  --title "docs: audit detection-rules-catalog.md against current rule catalog" \
+  --label "documentation,tech-debt" \
+  --body "The file \`docs/detection-rules-catalog.md\` predates the AI rule-authoring pipeline and the post-March 2026 bundled rule additions. It likely describes rules that have since been renamed, split, or superseded.
+
+Scope of this follow-up:
+- Walk \`app/src/main/res/raw/*.yml\` and cross-reference against every section in \`docs/detection-rules-catalog.md\`.
+- For each entry in the catalog: confirm the rule id still exists; confirm description still matches; flag stale entries.
+- Either (a) update the catalog to reflect current rules, or (b) replace it with a generator that builds the catalog from the bundled rule files so drift cannot happen again.
+
+Out of scope for the 2026-04-24 docs refresh (see spec §3 non-goals)."
+```
+
+Expected: output includes the new issue URL; paste it into the PR B description when opening the PR.
+
+---
+
+## Task 12: End-to-end verification before opening PR
+
+- [ ] **Step 1: Link check — no broken internal links**
+
+Run:
+```bash
+python3 - <<'PY'
+import pathlib, re
+root = pathlib.Path('.')
+bad = []
+for md in root.rglob('*.md'):
+    if any(part in md.parts for part in ('.git', '.claude', 'third-party', 'node_modules')):
+        continue
+    text = md.read_text(encoding='utf-8', errors='ignore')
+    for m in re.finditer(r'\]\(([^)]+)\)', text):
+        tgt = m.group(1).split('#', 1)[0]
+        if not tgt or tgt.startswith(('http://', 'https://', 'mailto:')):
+            continue
+        resolved = (md.parent / tgt).resolve()
+        if not resolved.exists():
+            bad.append((str(md), tgt))
+for path, tgt in bad:
+    print(f"BROKEN {path} -> {tgt}")
+print(f"total broken: {len(bad)}")
+PY
+```
+Expected: `total broken: 0`. If any appear, fix them before opening the PR.
+
+- [ ] **Step 2: Grep for stale references**
+
+```bash
+grep -rn 'vpn/' README.md CONTRIBUTING.md CLAUDE.md docs/ARCHITECTURE.md 2>/dev/null || echo "clean"
+grep -rn 'privacy@androdr\.dev' . --exclude-dir=.git --exclude-dir=.claude 2>/dev/null || echo "clean"
+grep -rn 'docs/ROADMAP' --include='*.md' . 2>/dev/null | grep -v 'docs/superpowers/' | grep -v '^Binary' || echo "clean"
+```
+Expected: all three print `clean` (or only meta-references inside `docs/superpowers/specs/`/`plans/`, which are allowed).
+
+- [ ] **Step 3: Local build still passes**
+
+```bash
+./gradlew lintDebug --no-daemon
+```
+Expected: BUILD SUCCESSFUL. Docs changes should not affect lint, but this is the release-gate check so run it.
+
+- [ ] **Step 4: CLAUDE.md is still parseable**
+
+Open a new `claude` session quickly (or `cat CLAUDE.md | head -40`) to make sure the edit didn't leave a broken markdown structure.
+
+Run: `python3 -c "import re, pathlib; t=pathlib.Path('CLAUDE.md').read_text(); hs=re.findall(r'^(#+)\s+', t, flags=re.MULTILINE); print('headings:', len(hs))"`
+Expected: nonzero heading count and no syntax error.
+
+---
+
+## Task 13: Open PR B
+
+- [ ] **Step 1: Push branch**
+
+```bash
+git push -u origin docs/sweep
+```
+
+- [ ] **Step 2: Open PR**
+
+```bash
+gh pr create \
+  --title "docs: documentation sweep (ARCHITECTURE + README + CONTRIBUTING + CLAUDE + cleanups)" \
+  --body "$(cat <<'EOF'
+## Summary
+- Adds canonical \`docs/ARCHITECTURE.md\` (~600 lines, 11 chapters): overview, design principles, accurate module map, detection pipeline, data layer, reporting, DNS monitor, bugreport analysis, AI rule-authoring pipeline, test strategy, decisions.
+- Rewrites \`README.md\` — fresh module tree, new capabilities (bugreport analysis, forensic timeline), short architecture sketch with pointer to ARCHITECTURE.md, Cloudflare mirror note.
+- Rewrites \`CONTRIBUTING.md\` — full dev setup, manual and AI-assisted rule-authoring paths, PR workflow, submodule handling.
+- Trims \`CLAUDE.md\` — removes duplicated architecture content; single pointer to ARCHITECTURE.md.
+- Deletes \`docs/ROADMAP.md\` — GitHub Issues is canonical; useful "Architecture Notes" paragraph folded into ARCHITECTURE.md §11.
+- Deduplicates \`docs/play-store/\` — removes unnumbered duplicates superseded by 16–20 numbered versions.
+
+## Why
+Three drivers: Play Store prep, external audience refresh, internal drift cleanup. Code had moved ahead of docs since March (SIGMA engine, IOC pipeline, bugreport analysis, forensic timeline, AI pipeline).
+
+Spec: \`docs/superpowers/specs/2026-04-24-docs-refresh-design.md\` §6.
+Depends on PR A (privacy pipeline): must merge after PR A is verified end-to-end.
+
+Follow-up issue: <paste URL from Task 11>
+
+## Test plan
+- [ ] CI \`build\` check passes
+- [ ] \`./gradlew lintDebug\` passes locally
+- [ ] No broken internal Markdown links (verified by link-check script)
+- [ ] No stale \`privacy@androdr.dev\`, \`vpn/\` (as package path), or file-link \`docs/ROADMAP.md\` references remain
+- [ ] Fresh Claude Code session loads trimmed CLAUDE.md without parse issues
+- [ ] New \`docs/ARCHITECTURE.md\` module tree matches the actual \`app/src/main/java/com/androdr/\` layout
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Report PR URL to user**
+
+Print the PR URL so the user can review.
+
+---
+
+## Post-merge
+
+After PR B merges:
+
+- [ ] Verify the rendered README on https://github.com/yasirhamza/AndroDR looks right.
+- [ ] Verify the rendered CONTRIBUTING on https://github.com/yasirhamza/AndroDR/blob/main/CONTRIBUTING.md looks right.
+- [ ] Verify `docs/ARCHITECTURE.md` is discoverable via the repo's file tree.
+- [ ] Close any GitHub issues superseded by the new docs (none expected — this was all drift, not feature work).

--- a/docs/superpowers/specs/2026-04-24-docs-refresh-design.md
+++ b/docs/superpowers/specs/2026-04-24-docs-refresh-design.md
@@ -20,7 +20,15 @@ Concrete drift identified during discovery:
 - `CONTRIBUTING.md` has a 4-bullet "Architecture Principles" section that duplicates (and contradicts) content in README.
 - `CLAUDE.md` project-layout section predates the SIGMA engine, IOC pipeline, and bugreport module entirely.
 - `docs/PRIVACY_POLICY.md` is dated 2026-03-26, still describes the MalwareBazaar cert-hash feed as a "stub" (it has been active since commit `8f5b6c9`), omits bugreport analysis as a retained feature, and carries a hallucinated contact email (`privacy@androdr.dev`) that is not owned by the project.
-- The privacy policy exists in **three places** that are already drifting: `docs/PRIVACY_POLICY.md` (2026-03-26 version), `androdr-privacy/index.md` (identical manual mirror), and `androdr-site/index.html` (embedded inline, 2026-04-01 version, with the correct contact email). Same document, three sources, already out of sync.
+- The privacy policy exists in **four places** that are already drifting:
+  1. `docs/PRIVACY_POLICY.md` in AndroDR (2026-03-26 version, hallucinated contact email)
+  2. `androdr-privacy/index.md` (identical manual mirror of #1)
+  3. `androdr-site/index.html` (embedded inline, 2026-04-01 version, correct contact email)
+  4. `cloudflare-worker.js` in AndroDR (inline HTML copy served by the Cloudflare Worker, 2026-03-26 version, hallucinated contact email)
+
+  Source #4 is a full self-contained HTML page returned by the Worker so it serves correctly during the `yasirhamza` account shadowban that would otherwise 404 anonymous visits to the GitHub Pages site.
+
+  The Worker is deployed manually via `wrangler deploy` from a local checkout. There is no Cloudflare CI in this repo. This means the render pipeline can keep the file in the repo fresh automatically, but the maintainer must remember to redeploy the Worker to push the change live.
 - `docs/ROADMAP.md` contradicts the project-wide convention that GitHub Issues are the canonical roadmap; the tables are a stale snapshot.
 - `docs/play-store/` contains duplicate numbered/unnumbered versions of five files (leftover from a rename that didn't clean up).
 - `androdr-site` has two near-identical deploy workflows (`pages.yml` and `static.yml`).
@@ -62,26 +70,19 @@ After this work, each fact lives in exactly one place. Other files reference it.
 
 ## 5. PR A — Privacy publishing pipeline
 
-Cross-repo work. Lands first.
+Cross-repo work. Lands first. The render script is canonical in the AndroDR repo (`scripts/render_privacy.py`) — both render workflows fetch it from there at execution time, so there is only one place the renderer logic can drift.
+
+**Pipeline shape:**
+
+- **Source of truth:** `docs/PRIVACY_POLICY.md` in AndroDR.
+- **Canonical renderer:** `scripts/render_privacy.py` in AndroDR (plus tests and requirements).
+- **Render target 1:** `cloudflare-worker.js` in AndroDR (fenced region replaced by a same-repo workflow on push to main when the privacy markdown changes).
+- **Render target 2:** `androdr-site/index.html` (fenced region replaced by a workflow in the site repo, fired by `repository_dispatch` from AndroDR — the workflow fetches both the markdown and the renderer from AndroDR at run time).
+- **Manual step:** the Worker is deployed by the maintainer via `wrangler deploy`. Workflow commit messages remind them.
 
 ### 5.1 Changes in `AndroDR` repo
 
-1. **`docs/PRIVACY_POLICY.md` content update.** Keep the existing section structure (philosophy → what we do → data → permissions → network → DNS → bugreport → exports → what we don't collect → sharing → retention → transparency → Play Data Safety → children → GDPR/CCPA → contact). Content edits:
-   - Replace all `privacy@androdr.dev` references with `yhamad.dev@gmail.com`.
-   - "What AndroDR Does": mention the SIGMA rule engine briefly; mention STIX2 indicator import/export; clarify DNS monitor remains optional.
-   - "Data That Stays On Your Device" table: add rows for forensic timeline events (persisted per #79) and bugreport analysis findings.
-   - "Network Requests" table: remove the "(planned)" stub; add MalwareBazaar APK hash feed as active; add abuse.ch ThreatFox; update the MVT entry to reflect the IOC dispatcher model; add stalkerware-indicators cert-hash ingestion.
-   - "Bug Report Analysis" section: tighten wording; reinforce that only analysis findings persist (no raw bugreport text).
-   - "Google Play Data Safety Alignment": expand to mirror the declarations in `docs/play-store/18-data-safety-form.md` so the two stay consistent.
-   - Update `_Last updated:_` to the merge date.
-
-2. **Sweep `docs/play-store/store-listing.md`** for `privacy@androdr.dev` and replace with `yhamad.dev@gmail.com` (this PR, not PR B, because it's an email-fix).
-
-3. **New workflow `.github/workflows/notify-privacy-sync.yml`.** Triggers on push to `main` when `docs/PRIVACY_POLICY.md` changes. Fires a `repository_dispatch` to `yasirhamza/androdr-site` with event type `privacy-updated` so the render runs immediately. The daily cron in the site repo is a safety net, not the happy path.
-
-### 5.2 Changes in `androdr-site` repo
-
-4. **Fence the privacy section in `index.html`.** Add HTML comments around the existing `<section class="privacy" id="privacy">` block:
+1. **Fence the privacy section in `cloudflare-worker.js`.** Add HTML comments around the `<section class="privacy" id="privacy">` block in the inline HTML template so the renderer can cleanly replace between them. No content change — just the fence markers.
 
    ```html
    <!-- ANDRODR:PRIVACY:START -->
@@ -91,45 +92,89 @@ Cross-repo work. Lands first.
    <!-- ANDRODR:PRIVACY:END -->
    ```
 
-   No content change to the privacy HTML in this commit — just fence markers so the next commit (the first automated render) can cleanly replace between them.
-
-5. **New `scripts/render_privacy.py`** — small Python script. Responsibilities:
-   - Read `docs/PRIVACY_POLICY.md` content (passed as argument or fetched via API by the workflow).
+2. **New `scripts/render_privacy.py`** — the canonical renderer. Responsibilities:
+   - Read the privacy markdown (passed as argument).
    - Convert Markdown to HTML using the PyPI `markdown` package with the `tables` extension (pin version in `scripts/requirements.txt`).
-   - Wrap output in `<section class="privacy" id="privacy">...</section>` so existing CSS classes apply.
+   - Wrap output in `<section class="privacy" id="privacy">...</section>` so existing CSS classes apply unchanged.
    - Assert structural invariants before writing. Counts are locked in at first run (observed: 18 `<h2>` headings, 3 `<table>` blocks as of 2026-04-24). Script exits non-zero if invariants fail — a content restructure is deliberate and requires updating the assertion counts in the same commit.
-   - Update the `Last updated: YYYY-MM-DD` line inside the rendered section from the markdown's `_Last updated: YYYY-MM-DD_` line.
-   - Output: modified `index.html` with the fenced region replaced.
+   - Inject a `Last updated: YYYY-MM-DD` line inside the rendered section from the markdown's `_Last updated: YYYY-MM-DD_` line.
+   - Replace the fenced region in the target file. Target is passed as a CLI argument so the same script renders both `cloudflare-worker.js` (in this repo) and `androdr-site/index.html` (in the other repo).
 
-6. **New workflow `.github/workflows/render-privacy.yml`.** Triggers:
-   - `push` to main (so edits to the renderer itself take effect)
+3. **New `scripts/test_render_privacy.py`** + **`scripts/fixtures/sample_privacy.md`** + **`scripts/requirements.txt`** — unit tests for the renderer (runnable with `pytest`) and pinned dependency. Covers: section wrapping, h2 count, table rendering, last-updated extraction, structural-invariant assertions, fenced-region replacement.
+
+4. **New workflow `.github/workflows/render-privacy-worker.yml`.** Triggers on push to `main` when `docs/PRIVACY_POLICY.md`, `scripts/render_privacy.py`, or `cloudflare-worker.js` change, plus `workflow_dispatch` for manual runs. Steps:
+   - Checkout.
+   - Install Python + `scripts/requirements.txt`.
+   - Run `scripts/render_privacy.py docs/PRIVACY_POLICY.md cloudflare-worker.js`.
+   - If `cloudflare-worker.js` changed, commit (`docs(privacy): render into cloudflare-worker.js`) with a **reminder in the commit body** that the maintainer must run `wrangler deploy` to push the Worker live.
+
+5. **New workflow `.github/workflows/notify-privacy-sync.yml`.** Triggers on push to `main` when `docs/PRIVACY_POLICY.md` or `scripts/render_privacy.py` changes. Fires a `repository_dispatch` to `yasirhamza/androdr-site` with event type `privacy-updated` so the site render runs immediately. The daily cron in the site repo is a safety net.
+
+6. **`docs/PRIVACY_POLICY.md` content update.** Keep the existing section structure (philosophy → what we do → data → permissions → network → DNS → bugreport → exports → what we don't collect → sharing → retention → transparency → Play Data Safety → children → GDPR/CCPA → contact). Content edits:
+   - Replace all `privacy@androdr.dev` references with `yhamad.dev@gmail.com`.
+   - "What AndroDR Does": mention the SIGMA rule engine briefly; mention STIX2 indicator import/export; clarify DNS monitor remains optional.
+   - "Data That Stays On Your Device" table: add rows for forensic timeline events (persisted per #79) and bugreport analysis findings.
+   - "Network Requests" table: remove the "(planned)" stub; add MalwareBazaar APK hash feed as active; add abuse.ch ThreatFox; update the MVT entry to reflect the IOC dispatcher model; add stalkerware-indicators cert-hash ingestion.
+   - "Bug Report Analysis" section: tighten wording; reinforce that only analysis findings persist (no raw bugreport text).
+   - "Google Play Data Safety Alignment": expand to mirror the declarations in `docs/play-store/18-data-safety-form.md` so the two stay consistent.
+   - Update `_Last updated:_` to the merge date.
+
+7. **Sweep `docs/play-store/store-listing.md`** for `privacy@androdr.dev` → `yhamad.dev@gmail.com` (in this PR, not PR B, because it's an email fix).
+
+### 5.2 Changes in `androdr-site` repo
+
+8. **Fence the privacy section in `index.html`.** Same fence-markers pattern as `cloudflare-worker.js`.
+
+9. **New workflow `.github/workflows/render-privacy.yml`.** Triggers:
+   - `push` to main (on workflow file or fence markers changes — no local script path, see below)
    - `repository_dispatch` with type `privacy-updated` (fires from AndroDR repo)
    - `schedule` daily at a quiet UTC hour (safety net)
    - `workflow_dispatch` (manual trigger for testing)
 
    Steps:
    - Checkout `androdr-site`.
-   - Fetch `docs/PRIVACY_POLICY.md` from `yasirhamza/AndroDR` using `gh api` (authenticated with `GITHUB_TOKEN`, required because the shadowban blocks anonymous raw.githubusercontent.com reads).
-   - Run `scripts/render_privacy.py` → modified `index.html`.
-   - If `index.html` changed, commit (`docs(privacy): sync from AndroDR@<shortsha>`) and push to main. The existing Pages deploy workflow handles publishing.
+   - Install Python.
+   - Fetch `docs/PRIVACY_POLICY.md`, `scripts/render_privacy.py`, and `scripts/requirements.txt` from `yasirhamza/AndroDR` using `gh api` (authenticated with `GITHUB_TOKEN`, required because the shadowban blocks anonymous `raw.githubusercontent.com` reads).
+   - `pip install -r` the fetched requirements.
+   - Run the fetched script: `python3 /tmp/render_privacy.py /tmp/PRIVACY_POLICY.md index.html`.
+   - If `index.html` changed, commit (`docs(privacy): sync from AndroDR@<shortsha>`) and push. The existing Pages deploy workflow handles publishing.
 
-7. **Delete `.github/workflows/static.yml`.** Keep `pages.yml` as the only deploy workflow.
+10. **Delete `.github/workflows/static.yml`.** Keep `pages.yml` as the only deploy workflow.
 
 ### 5.3 Archive `androdr-privacy`
 
-8. Replace `androdr-privacy/index.md` with a one-line forwarding pointer:
+11. Replace `androdr-privacy/index.md` with a one-line forwarding pointer:
 
-   > Moved. See https://github.com/yasirhamza/AndroDR/blob/main/docs/PRIVACY_POLICY.md
+    > Moved. See https://github.com/yasirhamza/AndroDR/blob/main/docs/PRIVACY_POLICY.md
 
-9. `gh repo archive yasirhamza/androdr-privacy --confirm`. Repo remains publicly visible (subject to the shadowban) but is frozen. The URL does not 404.
+12. `gh repo archive yasirhamza/androdr-privacy --yes`. Repo remains publicly visible (subject to the shadowban) but is frozen. The URL does not 404.
 
-### 5.4 Verification (PR A)
+### 5.4 Cutover order
 
-- Run `scripts/render_privacy.py` locally against current `docs/PRIVACY_POLICY.md`, diff output against today's `<section class="privacy">` — expect structural parity.
-- `workflow_dispatch` the render workflow on a branch before merging; inspect the commit it produces.
-- After merge, make a trivial whitespace edit to `docs/PRIVACY_POLICY.md` in a throwaway branch, merge it, and confirm the site commit fires within minutes and Cloudflare-fronted site reflects the change.
-- Grep: zero matches for `privacy@androdr\.dev` anywhere in either repo after merge.
-- API check: `androdr-privacy` is archived.
+The site-repo PR is merged *before* the AndroDR PR so that when AndroDR's content update lands, the dispatch it fires lands on a site repo whose render workflow is already in place.
+
+1. **Site PR** — items 8–10 above. First-run behavior: on merge, the new `render-privacy.yml` workflow fires (push trigger on the workflow file itself). It fetches the renderer from AndroDR main, which does not yet contain `scripts/render_privacy.py` → **the first run fails, as expected**. This is acceptable because the production path is the `repository_dispatch` trigger that fires after the AndroDR PR merges.
+2. **AndroDR PR** — items 1–7 above. On merge, three things fire:
+   - `render-privacy-worker.yml` (in AndroDR) renders `cloudflare-worker.js`. The commit it produces reminds the maintainer to `wrangler deploy`.
+   - `notify-privacy-sync.yml` (in AndroDR) dispatches `privacy-updated` to `androdr-site`.
+   - The site's `render-privacy.yml` receives the dispatch and succeeds (script now exists on AndroDR main), renders `index.html`, and commits.
+3. **Maintainer runs `wrangler deploy`** from local checkout to push the updated Worker live.
+4. **Archive androdr-privacy** per §5.3.
+
+### 5.5 Verification (PR A)
+
+- **Renderer tests green.** `cd scripts && python3 -m pytest test_render_privacy.py` passes.
+- **Local dry-run against real markdown.** Run the renderer against `docs/PRIVACY_POLICY.md` and a copy of `cloudflare-worker.js`; diff the output against today's inline HTML — expect structural parity (same h2/h3 counts, same table row counts).
+- **Same dry-run against `androdr-site/index.html`** — same expectation.
+- **Workflow dry-run.** `workflow_dispatch` each render workflow on its branch before merging; inspect the commit it produces.
+- **End-to-end post-merge.** After both PRs are merged, make a trivial whitespace edit to `docs/PRIVACY_POLICY.md` in a throwaway branch and merge it. Confirm:
+  - `render-privacy-worker.yml` runs successfully and updates `cloudflare-worker.js` in AndroDR.
+  - `notify-privacy-sync.yml` fires the dispatch.
+  - `render-privacy.yml` in `androdr-site` runs successfully and updates `index.html`.
+  - Live `https://yasirhamza.github.io/androdr-site/#privacy` reflects the change within minutes.
+  - Maintainer runs `wrangler deploy`; `https://androdr.yasirhamza.workers.dev/#privacy` reflects the change.
+- **Drift grep.** Zero matches for `privacy@androdr\.dev` anywhere in either repo after merge.
+- **Archive check.** `gh api repos/yasirhamza/androdr-privacy --jq '.archived'` returns `true`.
 
 ---
 
@@ -281,7 +326,8 @@ Split PR B into logical commits so the review diff tells a story:
 |------|-----------|
 | Privacy markdown renderer produces HTML that breaks site styling | Script includes structural assertions (expected `<h2>`/`<h3>`/`<table>` counts); dry-run before merge |
 | Shadowban blocks render workflow's authenticated GH API calls | Workflow uses `GITHUB_TOKEN`; test on branch first |
-| Cloudflare Worker caches stale HTML after site rebuild | Workflow can optionally call Cloudflare purge API; otherwise wait for TTL. Verify manually on first cutover. |
+| Cloudflare Worker caches stale HTML after site rebuild | Worker serves its own inline HTML independently of GH Pages, so site-cache staleness is a non-issue; Worker staleness is handled by the `wrangler deploy` step in §5.4. |
+| Maintainer forgets to `wrangler deploy` after `cloudflare-worker.js` changes | Render-privacy-worker commit message includes an explicit reminder; post-merge verification (§5.5) compares the live Worker response with the repo file. |
 | ARCHITECTURE.md claims something wrong (e.g., wrong module boundary) | Cross-reference every claim against current source while drafting; request code-reviewer pass after draft |
 | ROADMAP deletion breaks an inbound link we missed | Full grep before delete |
 | `androdr-privacy` archive breaks an external backlink | Leave archived, not deleted; forwarding `index.md` stays in place; URL still resolves |

--- a/docs/superpowers/specs/2026-04-24-docs-refresh-design.md
+++ b/docs/superpowers/specs/2026-04-24-docs-refresh-design.md
@@ -1,0 +1,302 @@
+# Documentation Refresh — Design Spec
+
+**Date:** 2026-04-24
+**Status:** Approved (pending spec review)
+**Scope:** Rewrite contributor and user-facing documentation; consolidate the privacy policy into a single source of truth; create a proper architecture document; clean up drift.
+
+---
+
+## 1. Context and motivation
+
+Three drivers push this work simultaneously:
+
+- **Play Store prep.** Privacy policy must be accurate, internally consistent, and aligned with the Data Safety form when submission happens.
+- **External audience.** Journalists, researchers, and potential contributors looking at the public face (site + repo) currently see stale or inconsistent content.
+- **Internal cleanliness.** The code has drifted ahead of the docs since March: the SIGMA rule engine, IOC pipeline, bugreport analysis, forensic timeline, and AI rule-authoring pipeline are all either absent from or misrepresented in README / CONTRIBUTING / CLAUDE.md.
+
+Concrete drift identified during discovery:
+
+- `README.md` module tree lists `vpn/` (the code moved to `network/`) and omits `sigma/`, `ioc/`, `scanner/bugreport/`, `ui/timeline`, `ui/settings`, `ui/permissions`, `di/`.
+- `CONTRIBUTING.md` has a 4-bullet "Architecture Principles" section that duplicates (and contradicts) content in README.
+- `CLAUDE.md` project-layout section predates the SIGMA engine, IOC pipeline, and bugreport module entirely.
+- `docs/PRIVACY_POLICY.md` is dated 2026-03-26, still describes the MalwareBazaar cert-hash feed as a "stub" (it has been active since commit `8f5b6c9`), omits bugreport analysis as a retained feature, and carries a hallucinated contact email (`privacy@androdr.dev`) that is not owned by the project.
+- The privacy policy exists in **three places** that are already drifting: `docs/PRIVACY_POLICY.md` (2026-03-26 version), `androdr-privacy/index.md` (identical manual mirror), and `androdr-site/index.html` (embedded inline, 2026-04-01 version, with the correct contact email). Same document, three sources, already out of sync.
+- `docs/ROADMAP.md` contradicts the project-wide convention that GitHub Issues are the canonical roadmap; the tables are a stale snapshot.
+- `docs/play-store/` contains duplicate numbered/unnumbered versions of five files (leftover from a rename that didn't clean up).
+- `androdr-site` has two near-identical deploy workflows (`pages.yml` and `static.yml`).
+
+---
+
+## 2. Goals
+
+1. Single source of truth for the privacy policy, rendered automatically into the public site.
+2. Accurate, non-duplicated architecture narrative that reflects current code.
+3. Contributor guide that covers real dev setup, PR workflow, and both manual and AI-assisted rule-authoring paths.
+4. Minimum-viable cleanups that remove drift sources without expanding scope.
+5. Correct contact email (`yhamad.dev@gmail.com`) everywhere; removal of the hallucinated `privacy@androdr.dev`.
+
+## 3. Non-goals (scope discipline)
+
+- No Kotlin code changes.
+- No changes to `docs/decisions/`, `docs/research/`, or other `docs/superpowers/` content.
+- No audit of `docs/detection-rules-catalog.md` (file a follow-up issue).
+- No Cloudflare Worker code changes (only verify cache behavior post-cutover).
+- No new documentation files beyond `docs/ARCHITECTURE.md`.
+- No new linting/checking tools or contributor-facing process rules. (The two new workflows in PR A — `notify-privacy-sync.yml` in AndroDR and `render-privacy.yml` in `androdr-site` — are internal plumbing for the privacy single-source-of-truth, not rules contributors have to follow.)
+
+---
+
+## 4. File responsibilities (no duplication)
+
+After this work, each fact lives in exactly one place. Other files reference it.
+
+| File | Audience | Contents | Approx. size |
+|---|---|---|---|
+| `README.md` | Users first, curious devs second | What AndroDR is, who it's for, what it detects, short architecture sketch, download, pointers | ~150 lines |
+| `docs/ARCHITECTURE.md` (new) | Contributors, researchers, reviewers | The canonical architecture reference | ~600 lines |
+| `CONTRIBUTING.md` | Devs about to contribute | Rule authoring (manual + AI-assisted), dev setup, PR workflow, code of conduct | ~300-400 lines |
+| `CLAUDE.md` | AI agents working in the repo | Build commands, workflow conventions, submodule handling, smoke test. Architecture section reduced to a pointer. | current length, minus the architecture sections |
+| `docs/PRIVACY_POLICY.md` | Users, Play Store reviewers | The privacy policy. The single source of truth rendered into the site. | current structure, updated content |
+
+---
+
+## 5. PR A — Privacy publishing pipeline
+
+Cross-repo work. Lands first.
+
+### 5.1 Changes in `AndroDR` repo
+
+1. **`docs/PRIVACY_POLICY.md` content update.** Keep the existing section structure (philosophy → what we do → data → permissions → network → DNS → bugreport → exports → what we don't collect → sharing → retention → transparency → Play Data Safety → children → GDPR/CCPA → contact). Content edits:
+   - Replace all `privacy@androdr.dev` references with `yhamad.dev@gmail.com`.
+   - "What AndroDR Does": mention the SIGMA rule engine briefly; mention STIX2 indicator import/export; clarify DNS monitor remains optional.
+   - "Data That Stays On Your Device" table: add rows for forensic timeline events (persisted per #79) and bugreport analysis findings.
+   - "Network Requests" table: remove the "(planned)" stub; add MalwareBazaar APK hash feed as active; add abuse.ch ThreatFox; update the MVT entry to reflect the IOC dispatcher model; add stalkerware-indicators cert-hash ingestion.
+   - "Bug Report Analysis" section: tighten wording; reinforce that only analysis findings persist (no raw bugreport text).
+   - "Google Play Data Safety Alignment": expand to mirror the declarations in `docs/play-store/18-data-safety-form.md` so the two stay consistent.
+   - Update `_Last updated:_` to the merge date.
+
+2. **Sweep `docs/play-store/store-listing.md`** for `privacy@androdr.dev` and replace with `yhamad.dev@gmail.com` (this PR, not PR B, because it's an email-fix).
+
+3. **New workflow `.github/workflows/notify-privacy-sync.yml`.** Triggers on push to `main` when `docs/PRIVACY_POLICY.md` changes. Fires a `repository_dispatch` to `yasirhamza/androdr-site` with event type `privacy-updated` so the render runs immediately. The daily cron in the site repo is a safety net, not the happy path.
+
+### 5.2 Changes in `androdr-site` repo
+
+4. **Fence the privacy section in `index.html`.** Add HTML comments around the existing `<section class="privacy" id="privacy">` block:
+
+   ```html
+   <!-- ANDRODR:PRIVACY:START -->
+   <section class="privacy" id="privacy">
+     ...existing content...
+   </section>
+   <!-- ANDRODR:PRIVACY:END -->
+   ```
+
+   No content change to the privacy HTML in this commit — just fence markers so the next commit (the first automated render) can cleanly replace between them.
+
+5. **New `scripts/render_privacy.py`** — small Python script. Responsibilities:
+   - Read `docs/PRIVACY_POLICY.md` content (passed as argument or fetched via API by the workflow).
+   - Convert Markdown to HTML using the PyPI `markdown` package with the `tables` extension (pin version in `scripts/requirements.txt`).
+   - Wrap output in `<section class="privacy" id="privacy">...</section>` so existing CSS classes apply.
+   - Assert structural invariants before writing. Counts are locked in at first run (observed: 18 `<h2>` headings, 3 `<table>` blocks as of 2026-04-24). Script exits non-zero if invariants fail — a content restructure is deliberate and requires updating the assertion counts in the same commit.
+   - Update the `Last updated: YYYY-MM-DD` line inside the rendered section from the markdown's `_Last updated: YYYY-MM-DD_` line.
+   - Output: modified `index.html` with the fenced region replaced.
+
+6. **New workflow `.github/workflows/render-privacy.yml`.** Triggers:
+   - `push` to main (so edits to the renderer itself take effect)
+   - `repository_dispatch` with type `privacy-updated` (fires from AndroDR repo)
+   - `schedule` daily at a quiet UTC hour (safety net)
+   - `workflow_dispatch` (manual trigger for testing)
+
+   Steps:
+   - Checkout `androdr-site`.
+   - Fetch `docs/PRIVACY_POLICY.md` from `yasirhamza/AndroDR` using `gh api` (authenticated with `GITHUB_TOKEN`, required because the shadowban blocks anonymous raw.githubusercontent.com reads).
+   - Run `scripts/render_privacy.py` → modified `index.html`.
+   - If `index.html` changed, commit (`docs(privacy): sync from AndroDR@<shortsha>`) and push to main. The existing Pages deploy workflow handles publishing.
+
+7. **Delete `.github/workflows/static.yml`.** Keep `pages.yml` as the only deploy workflow.
+
+### 5.3 Archive `androdr-privacy`
+
+8. Replace `androdr-privacy/index.md` with a one-line forwarding pointer:
+
+   > Moved. See https://github.com/yasirhamza/AndroDR/blob/main/docs/PRIVACY_POLICY.md
+
+9. `gh repo archive yasirhamza/androdr-privacy --confirm`. Repo remains publicly visible (subject to the shadowban) but is frozen. The URL does not 404.
+
+### 5.4 Verification (PR A)
+
+- Run `scripts/render_privacy.py` locally against current `docs/PRIVACY_POLICY.md`, diff output against today's `<section class="privacy">` — expect structural parity.
+- `workflow_dispatch` the render workflow on a branch before merging; inspect the commit it produces.
+- After merge, make a trivial whitespace edit to `docs/PRIVACY_POLICY.md` in a throwaway branch, merge it, and confirm the site commit fires within minutes and Cloudflare-fronted site reflects the change.
+- Grep: zero matches for `privacy@androdr\.dev` anywhere in either repo after merge.
+- API check: `androdr-privacy` is archived.
+
+---
+
+## 6. PR B — Documentation sweep
+
+In-repo prose edits. Lands after PR A is verified.
+
+### 6.1 `docs/ARCHITECTURE.md` (new) — ~600 lines
+
+Chapter outline:
+
+1. **Overview (~50 lines).** One-paragraph description of AndroDR, single block diagram (ASCII) showing the major layers (device → telemetry emitters → rule engine + IOC resolver → findings → persistence → UI/reports), reader's map ("this document covers X; CONTRIBUTING covers how-to; PRIVACY_POLICY covers user-facing guarantees").
+
+2. **Design principles (~40 lines).** Non-negotiables with one-line rationales:
+   - Detection logic in YAML SIGMA rules, not Kotlin code.
+   - IOC data lives in the external rules repo, not bundled in the APK.
+   - Pure-emitter telemetry/findings contract (forward-reference #136, #137).
+   - All processing on-device — no backend, no telemetry, no accounts.
+   - Privacy-by-design: minimum collection, retention boundaries, no cloud backup.
+   - SIGMA compatibility where practical.
+
+3. **Module map (~80 lines).** Accurate tree matching today's code:
+   `data/`, `di/`, `ioc/`, `ioc/feeds/`, `network/`, `reporting/`, `scanner/`, `scanner/bugreport/`, `sigma/`, `ui/apps`, `ui/bugreport`, `ui/common`, `ui/dashboard`, `ui/device`, `ui/history`, `ui/network`, `ui/permissions`, `ui/settings`, `ui/theme`, `ui/timeline`. One-liner per package.
+
+4. **Detection pipeline (~120 lines) — the centerpiece.** End-to-end flow from raw device state to a user-visible finding:
+   - **Telemetry emitters** (`scanner/*`, `network/*`): pure functions producing structured telemetry events (AppTelemetry, DeviceFlag, DnsEvent, BugreportTelemetry). Why pure: the rule engine is the only place detection logic runs; emitters are trivially testable.
+   - **SIGMA rule engine** (`sigma/*`): parser (`SigmaRuleParser`), evaluator, modifier support, schema cross-check test. Field alignment with the `android-sigma-rules` submodule.
+   - **IOC resolver** (`ioc/*`): feeds, dispatcher with cross-dedup, cursor/decisions schemas, four IOC types (package name, cert hash, C2 domain, APK file hash), resolution lifecycle.
+   - **Findings**: Room persistence, serialization contract, display metadata from rules, remediation text.
+   - ASCII flow diagram showing all four lanes.
+
+5. **Data layer (~50 lines).** Room schema, what's persisted vs. transient, auto-prune policy, STIX2 indicator model.
+
+6. **Reporting & export (~40 lines).** `ReportFormatter`, `ReportExporter`, FileProvider, timeline, STIX2 export, user-initiated share flow.
+
+7. **DNS monitor (~40 lines).** `LocalVpnService`, local-only DNS interception, why DNS-only (link to the parked IP-filtering decision), how DNS events flow into the rule engine like any other telemetry.
+
+8. **Bugreport analysis (~60 lines).** Pipeline stages (parse → extract → match → emit findings), what's parsed (dumpsys sections, processes, wakelocks), what's discarded (original bugreport never persisted), how findings reuse the same rule-engine pathway.
+
+9. **AI rule-authoring pipeline (~80 lines).** What lives in `.claude/`: the ingester skills (`/update-rules-ingest-*`), discover agent (`/update-rules-discover`), author agent (`/update-rules-author`), validator (`/update-rules-validate` — the 5-gate pipeline), reviewer (`/update-rules-review`), orchestrator (`/update-rules`). Rule lifecycle: threat intel feed → candidate SIR → draft rule → validation gates → staging → promotion. Link to the rules repo. CONTRIBUTING's AI section points here for depth.
+
+10. **Test strategy (~40 lines).** Unit tests, integration tests, `BundledRulesSchemaCrossCheckTest`, validation gates on rules, UAT persona testing (`/uat-test`), on-device smoke test (`scripts/smoke-test.sh`).
+
+11. **Decisions (~60 lines).** ADR-style short entries: rule engine in YAML, IOC data external, DNS-only VPN scope, pure-emitter contract, SIGMA compatibility, no cloud backend. Absorbs the useful "Architecture Notes" paragraph from the old ROADMAP.md. Forward-references open arch issues (#96, #136, #137) without pretending they're done.
+
+### 6.2 `README.md` rewrite — ~150 lines
+
+Sections:
+1. Title + badges (License, Android 8.0+).
+2. Tagline (keep current wording).
+3. Who it's for (DV survivors / journalists / IT security / privacy-conscious — keep current wording, it's good).
+4. What it detects — refreshed bullets:
+   - Known malware (package, cert, APK hash)
+   - Stalkerware
+   - Mercenary spyware (Pegasus, Predator, Graphite, NoviSpy, ResidentBat)
+   - Sideloaded apps from untrusted sources
+   - Surveillance permission combinations
+   - Accessibility / Device Admin abuse
+   - Device posture (screen lock, USB debug, bootloader, patch level)
+   - Unpatched CVEs (CISA KEV catalog)
+   - DNS C2 (optional local VPN monitor)
+   - Spyware file artifacts
+   - **Bugreport analysis** (new — forensic analysis of `.zip` bugreports)
+   - **Forensic timeline** (new — device admin grants, etc., per #79)
+5. How it works — tighten current 2-paragraph version, same thrust.
+6. Architecture (brief) — short fresh tree + 4 principle bullets, link out to `docs/ARCHITECTURE.md`.
+7. Building — the six gradle commands; anything beyond moves to CONTRIBUTING.
+8. Download — releases link + Cloudflare mirror note.
+9. Privacy — one line pointing to the rendered public site.
+10. Contributing — one line pointing to `CONTRIBUTING.md`.
+11. License — one line.
+
+### 6.3 `CONTRIBUTING.md` rewrite — ~300-400 lines
+
+Sections:
+1. Intro — short; why the project matters; users include DV survivors, journalists, activists. Safety-first ethos.
+2. Ways to contribute — taxonomy of contribution types.
+3. **Writing detection rules — manual path.**
+   - Real rules repo URL.
+   - Minimal example rule (refreshed to current schema — includes `display` + `remediation` blocks).
+   - Field reference: summary + pointer to `validation/rule-schema.json` in the submodule as authoritative spec.
+   - Logsource conventions (services + products taxonomy per #108).
+   - Registering in `rules.txt`.
+   - Local validation steps.
+4. **Writing detection rules — AI-assisted path.**
+   - "We use AI to author rules in our own workflow. You're welcome to, too."
+   - The schema + existing rules are the context any LLM needs.
+   - A short copy-pasteable prompt pattern (not overspecified).
+   - All rules — AI-written or hand-written — go through the same validation gates; AI does not skip review.
+   - For the internal pipeline details (not needed to contribute), pointer to `docs/ARCHITECTURE.md` §9.
+5. IOC data contributions — `ioc-data/{package-names,cert-hashes,c2-domains,malware-hashes,popular-apps}.yml`, dedup / cross-write ownership rules.
+6. False-positive reports — template, triage process.
+7. Bug reports — template, what to include.
+8. Development setup — JDK 21, Android SDK (compile SDK 34), `local.properties`, clone + `git submodule update --init`, Android Studio vs command-line flow.
+9. Build & test — gradle commands, lint, detekt, smoke test (`scripts/smoke-test.sh`, AVD `Medium_Phone_API_36.1`), on-device testing, submodule update direction (AI pipeline → AndroDR is pinned).
+10. PR workflow — branch naming, target `main`, `Closes #N` keyword, CI `build` check must pass, small focused PRs.
+11. Architecture principles — one-line pointer to `docs/ARCHITECTURE.md` (no duplication).
+12. Code of conduct — keep current strong wording on user safety; no tracking contributions accepted.
+
+### 6.4 `CLAUDE.md` trim
+
+- **Keep:** build requirements, common commands, development workflow, lint/style, running on physical device, local development (SDK setup, smoke test, submodule handling — Claude Code agents actually use these).
+- **Replace** the "Project layout" tree and "Key architectural decisions" section with a single line:
+  > See [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) for architecture, module map, and design principles.
+
+### 6.5 `docs/ROADMAP.md` — delete
+
+- Extract the useful "Architecture Notes" paragraph at the tail into `docs/ARCHITECTURE.md` §11 (Decisions) and §4 (rule engine capabilities) as appropriate.
+- Delete `docs/ROADMAP.md` entirely.
+- Fix any inbound links. Known references:
+  - `docs/detection-rules-catalog.md` has six `[ROADMAP #N]` text markers — **leave alone** (they're historical context, issue numbers still resolve).
+- No other inbound links found as of 2026-04-24.
+
+### 6.6 `docs/play-store/` dedupe
+
+Pairwise compare numbered vs unnumbered versions, merge forward if unnumbered has unique content, then delete the unnumbered copies:
+- `query-all-packages-declaration.md` (keep `16-…`)
+- `vpn-service-declaration.md` (keep `17-…`)
+- `data-safety-form.md` (keep `18-…`)
+- `content-rating-iarc.md` (keep `19-…`)
+- `store-listing.md` (keep `20-…`)
+
+Keep: `manage-external-storage-declaration.md`, all media files, all numbered files.
+
+### 6.7 Commit structure for PR B
+
+Split PR B into logical commits so the review diff tells a story:
+1. `docs(architecture): add docs/ARCHITECTURE.md`
+2. `docs(readme): rewrite README to reflect current code + link to ARCHITECTURE`
+3. `docs(contributing): rewrite CONTRIBUTING with manual + AI rule authoring paths`
+4. `docs(claude): trim CLAUDE.md architecture section to pointer`
+5. `docs: delete stale docs/ROADMAP.md`
+6. `docs(play-store): deduplicate numbered and unnumbered filename variants`
+
+### 6.8 Verification (PR B)
+
+- Link check: grep for internal Markdown links after ROADMAP deletion and play-store dedupe; confirm no broken links.
+- Every architecture claim in README/CONTRIBUTING/ARCHITECTURE verified against current source tree (not against today's stale docs). Spot-check: module map, SIGMA engine description, IOC pipeline narrative, bugreport analysis stages.
+- CLAUDE.md still renders cleanly in a new Claude Code session (no syntax issues).
+- `git diff` each play-store pair before deletion; confirm no unique content lost.
+- `./gradlew lintDebug` passes.
+- Open a follow-up issue: "Audit `docs/detection-rules-catalog.md` for drift from current rule catalog."
+
+---
+
+## 7. Risks and mitigations
+
+| Risk | Mitigation |
+|------|-----------|
+| Privacy markdown renderer produces HTML that breaks site styling | Script includes structural assertions (expected `<h2>`/`<h3>`/`<table>` counts); dry-run before merge |
+| Shadowban blocks render workflow's authenticated GH API calls | Workflow uses `GITHUB_TOKEN`; test on branch first |
+| Cloudflare Worker caches stale HTML after site rebuild | Workflow can optionally call Cloudflare purge API; otherwise wait for TTL. Verify manually on first cutover. |
+| ARCHITECTURE.md claims something wrong (e.g., wrong module boundary) | Cross-reference every claim against current source while drafting; request code-reviewer pass after draft |
+| ROADMAP deletion breaks an inbound link we missed | Full grep before delete |
+| `androdr-privacy` archive breaks an external backlink | Leave archived, not deleted; forwarding `index.md` stays in place; URL still resolves |
+| Bad privacy email still appears after sweep | Post-change grep returns zero matches for `privacy@androdr\.dev` |
+| play-store dedupe silently drops content unique to unnumbered file | Pairwise `diff` of each pair; manual merge-forward before delete |
+| PR B is too large to review | Six focused commits (§6.7) so reviewer can walk the history |
+
+## 8. Cutover order
+
+1. Open and land **PR A**. Verify privacy pipeline end-to-end (edit markdown → site commit fires → Cloudflare serves fresh).
+2. Only after PR A is verified, open **PR B**. Any privacy content tweaks that surface during PR B work flow through the now-working pipeline.
+3. After PR B merges: confirm CI `build` is green; open the follow-up issue for `detection-rules-catalog.md` audit.
+
+## 9. Open questions / follow-ups
+
+- **Cloudflare cache purge:** whether to add a `cloudflare/purge` step to the render workflow is deferred. If the Worker's TTL is short enough the daily cron + manual verification is sufficient; if stale content sticks for more than a few hours after a merge, add the purge step in a follow-up.
+- **detection-rules-catalog.md audit:** out of scope here; follow-up issue filed at end of PR B.
+- **Spec/plan split for PR B:** the writing-plans skill will turn this spec into a concrete step plan. Expectation is PR A gets its own plan; PR B gets its own plan; the AI can sequence them.


### PR DESCRIPTION
## Summary
- Adds `docs/superpowers/specs/2026-04-24-docs-refresh-design.md` — design spec for a two-PR documentation overhaul
- PR A: privacy publishing pipeline. Single markdown source of truth in `docs/PRIVACY_POLICY.md`; `androdr-site` renders it into `index.html` at build time via `repository_dispatch`; `androdr-privacy` mirror archived; hallucinated `privacy@androdr.dev` contact replaced with the correct `yhamad.dev@gmail.com` everywhere
- PR B: documentation sweep. New `docs/ARCHITECTURE.md` as the canonical architecture reference (~600 lines, 11 chapters). README + CONTRIBUTING rewritten to current reality, including a new AI-assisted rule-authoring path for external contributors. CLAUDE.md trimmed so architecture lives in one place. `docs/ROADMAP.md` deleted (GH issues are canonical). `docs/play-store/` deduplicated.

## Why now
Play Store prep + external audience + internal drift — all three. Site, privacy mirror, and repo docs are already three out of sync. Code has moved ahead of docs since March (SIGMA engine, IOC pipeline, bugreport analysis, timeline, AI pipeline).

## What this PR does not do
No Kotlin code changes, no Cloudflare Worker code changes, no `detection-rules-catalog.md` audit (follow-up issue), no new contributor-facing process rules.

## Test plan
- [ ] User reads `docs/superpowers/specs/2026-04-24-docs-refresh-design.md` and approves or requests changes
- [ ] After spec approval, the writing-plans skill turns the spec into concrete implementation plans (PR A plan, PR B plan)
- [ ] PRs A and B land in order; spec sections §5.4 and §6.8 define their verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)