### PR TITLE
docs(privacy): disclose runtime rule fetches + decoupling story

### DIFF
--- a/cloudflare-worker.js
+++ b/cloudflare-worker.js
@@ -257,6 +257,24 @@ export default {
 <td>Cert hashes of known stalkerware signers</td>
 <td>1 HTTP GET</td>
 </tr>
+<tr>
+<td>SIGMA detection rules</td>
+<td>android-sigma-rules/rules (GitHub)</td>
+<td>Rule manifest (<code>rules.txt</code>), SHA-256 integrity manifest (<code>rules.sha256</code>), then one GET per rule YAML file listed in the manifest. Each downloaded rule is integrity-checked against the manifest before being loaded.</td>
+<td>2 manifests + 1 per rule</td>
+</tr>
+<tr>
+<td>Centralized IOC data</td>
+<td>android-sigma-rules/rules (GitHub)</td>
+<td>Package names, C2 domains, signing-cert hashes, APK hashes, and known-good app lists from the repo's <code>ioc-data/</code> directory</td>
+<td>5 HTTP GETs</td>
+</tr>
+<tr>
+<td><strong>Optional:</strong> custom rule URLs</td>
+<td>URLs you configure in Settings → Custom Rule Sources</td>
+<td>Same SIGMA-rule-feed format as above. Disabled by default; only fetched if you add a URL.</td>
+<td>Same as above per configured URL</td>
+</tr>
 </tbody>
 </table>
 <p>All requests are unauthenticated public HTTP GET requests. No API keys, no authentication tokens, no cookies, and no tracking headers are sent. You can verify this in the source code at <code>app/src/main/java/com/androdr/ioc/feeds/</code>.</p>
@@ -331,6 +349,13 @@ export default {
 <li><strong>Data storage:</strong> <code>app/src/main/java/com/androdr/data/</code></li>
 </ul>
 <p>If you find a privacy concern in the code, open an issue or contact us directly.</p>
+<h3>Detection rules live in a separate, public repository</h3>
+<p>What the app looks for is not hidden inside compiled Kotlin. AndroDR's detection rules are authored as human-readable YAML in an independent public repository — <a href="https://github.com/android-sigma-rules/rules">github.com/android-sigma-rules/rules</a> — and bundled into the app at build time via a pinned git submodule. The rule schema (<code>validation/rule-schema.json</code>) is published alongside the rules. This decoupling has two privacy consequences:</p>
+<ul>
+<li><strong>You can read every rule before installing.</strong> Each rule names the indicator (package name, signing-cert hash, DNS domain, permission combination, etc.), the threat it models, and the public source it was derived from. No detection exists only inside the binary.</li>
+<li><strong>Rule changes are reviewable independently of the app.</strong> New detections land in the rules repo through a public 5-gate validation pipeline (schema check, build, IOC sanity, semantic deduplication, and an independent review pass). You can audit the diff between any two rule-bundle versions without disassembling the APK.</li>
+</ul>
+<p>The threat-intelligence feeds AndroDR ingests at runtime are listed in the "Network Requests" section above. The rules that decide what those indicators <em>mean</em> live in the rules repo. Both are public; neither is part of the compiled app's hidden state. Advanced users can also configure additional rule sources in Settings; those URLs are fetched in the same way as the default repo and are listed in the Network Requests table above.</p>
 <hr />
 <h2>Google Play Data Safety Alignment</h2>
 <p>For Google Play's Data Safety section, AndroDR declares:</p>

--- a/docs/PRIVACY_POLICY.md
+++ b/docs/PRIVACY_POLICY.md
@@ -70,6 +70,9 @@ AndroDR fetches publicly available threat intelligence feeds to keep its detecti
 | MalwareBazaar APK + cert hashes | abuse.ch MalwareBazaar public API | Hashes of known malicious APKs and the cert hashes that signed them | 1 API request per refresh |
 | ThreatFox indicators | abuse.ch ThreatFox public API | Command-and-control domain / IP indicators | 1 API request per refresh |
 | Stalkerware cert-hash indicators | AssoEchap/stalkerware-indicators (GitHub) | Cert hashes of known stalkerware signers | 1 HTTP GET |
+| SIGMA detection rules | android-sigma-rules/rules (GitHub) | Rule manifest (`rules.txt`), SHA-256 integrity manifest (`rules.sha256`), then one GET per rule YAML file listed in the manifest. Each downloaded rule is integrity-checked against the manifest before being loaded. | 2 manifests + 1 per rule |
+| Centralized IOC data | android-sigma-rules/rules (GitHub) | Package names, C2 domains, signing-cert hashes, APK hashes, and known-good app lists from the repo's `ioc-data/` directory | 5 HTTP GETs |
+| **Optional:** custom rule URLs | URLs you configure in Settings → Custom Rule Sources | Same SIGMA-rule-feed format as above. Disabled by default; only fetched if you add a URL. | Same as above per configured URL |
 
 All requests are unauthenticated public HTTP GET requests. No API keys, no authentication tokens, no cookies, and no tracking headers are sent. You can verify this in the source code at `app/src/main/java/com/androdr/ioc/feeds/`.
 
@@ -160,6 +163,15 @@ AndroDR's source code is publicly available. Every detection heuristic, every ne
 - **Data storage:** `app/src/main/java/com/androdr/data/`
 
 If you find a privacy concern in the code, open an issue or contact us directly.
+
+### Detection rules live in a separate, public repository
+
+What the app looks for is not hidden inside compiled Kotlin. AndroDR's detection rules are authored as human-readable YAML in an independent public repository — [github.com/android-sigma-rules/rules](https://github.com/android-sigma-rules/rules) — and bundled into the app at build time via a pinned git submodule. The rule schema (`validation/rule-schema.json`) is published alongside the rules. This decoupling has two privacy consequences:
+
+- **You can read every rule before installing.** Each rule names the indicator (package name, signing-cert hash, DNS domain, permission combination, etc.), the threat it models, and the public source it was derived from. No detection exists only inside the binary.
+- **Rule changes are reviewable independently of the app.** New detections land in the rules repo through a public 5-gate validation pipeline (schema check, build, IOC sanity, semantic deduplication, and an independent review pass). You can audit the diff between any two rule-bundle versions without disassembling the APK.
+
+The threat-intelligence feeds AndroDR ingests at runtime are listed in the "Network Requests" section above. The rules that decide what those indicators *mean* live in the rules repo. Both are public; neither is part of the compiled app's hidden state. Advanced users can also configure additional rule sources in Settings; those URLs are fetched in the same way as the default repo and are listed in the Network Requests table above.
 
 ---
 


### PR DESCRIPTION
## Summary

The privacy page had two real gaps surfaced while discussing AndroDR's positioning vs. consumer adblockers:

1. **Three runtime egress paths missing from the Network Requests table:**
   - SIGMA rule manifest + per-rule YAML downloads (`SigmaRuleFeed.kt`)
   - Centralized IOC YAMLs from `android-sigma-rules/rules/ioc-data/` (`PublicRepoIocFeed.kt`)
   - User-configured custom rule URLs (Settings → Custom Rule Sources)
2. **The "Open Source Transparency" section didn't articulate that detection logic lives in an independent public repo**, decoupled from the compiled app — a core trust property for the high-risk-user audience.

Both are now disclosed:

- Three new rows in the Network Requests table (one of them flagged as Optional, since custom rule URLs are off by default).
- A new `### Detection rules live in a separate, public repository` subsection under Open Source Transparency that explains the YAML-rules-as-data approach, the public 5-gate validation pipeline, and the `validation/rule-schema.json` contract.
- One added sentence pointing users to the custom-URL toggle in Settings and back to the Network Requests table.

`cloudflare-worker.js` re-rendered via `scripts/render_privacy.py` so the PR-time sync check (#167) passes.

## Test plan

- [ ] CI: `Check privacy sync` workflow passes (worker is in sync with markdown).
- [ ] Renderer is idempotent — running `python3 scripts/render_privacy.py docs/PRIVACY_POLICY.md cloudflare-worker.js` a second time prints `no change`.
- [ ] No top-level `## ` sections were added or removed (renderer's `EXPECTED_H2 = 18` invariant unchanged).
- [ ] No new tables added (renderer's `EXPECTED_TABLES = 3` invariant unchanged — only rows added to the existing Network Requests table).
- [ ] Visual check: render `docs/PRIVACY_POLICY.md` (e.g., on the github.io page after merge) and confirm the new rows appear above the closing paragraph and the new subsection appears between the audit links and the "Google Play Data Safety Alignment" section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)