### PR TITLE
fix(settings): read versionName/versionCode from PackageManager at runtime

### DIFF
--- a/app/src/debug/java/com/androdr/debug/ScanBroadcastReceiver.kt
+++ b/app/src/debug/java/com/androdr/debug/ScanBroadcastReceiver.kt
@@ -12,6 +12,7 @@ import com.androdr.reporting.ReportFormatter
 import com.androdr.scanner.ScanOrchestrator
 import com.androdr.sigma.SigmaRuleEngine
 import com.androdr.sigma.SigmaRuleFeed
+import com.androdr.util.appVersion
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -45,7 +46,10 @@ class ScanBroadcastReceiver : BroadcastReceiver() {
                     val scan = scanOrchestrator.runFullScan()
                     val dns = dnsEventDao.getRecentSnapshot()
                     val inventory = scanOrchestrator.lastAppTelemetry
-                    val report = ReportFormatter.formatScanReport(scan, dns, emptyList(), inventory)
+                    val report = ReportFormatter.formatScanReport(
+                        scan, dns, emptyList(), inventory,
+                        versionName = context.appVersion().name
+                    )
                     val outDir = context.getExternalFilesDir(null) ?: return@launch
                     File(outDir, "androdr_last_report.txt").writeText(report)
                     Log.i(TAG, "Scan complete, report written to ${outDir.absolutePath}")

--- a/app/src/main/java/com/androdr/reporting/ReportExporter.kt
+++ b/app/src/main/java/com/androdr/reporting/ReportExporter.kt
@@ -8,6 +8,7 @@ import com.androdr.data.db.DnsEventDao
 import com.androdr.data.model.ScanResult
 import com.androdr.scanner.AppScanner
 import com.androdr.scanner.ScanOrchestrator
+import com.androdr.util.appVersion
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -71,6 +72,7 @@ class ReportExporter @Inject constructor(
             accessibilityTelemetry = accessibilityTelemetry,
             receiverTelemetry = receiverTelemetry,
             appOpsTelemetry = appOpsTelemetry,
+            versionName = context.appVersion().name,
         )
 
         val reportsDir = File(context.cacheDir, "reports").apply { mkdirs() }

--- a/app/src/main/java/com/androdr/reporting/ReportFormatter.kt
+++ b/app/src/main/java/com/androdr/reporting/ReportFormatter.kt
@@ -38,6 +38,7 @@ object ReportFormatter {
         accessibilityTelemetry: List<AccessibilityTelemetry> = emptyList(),
         receiverTelemetry: List<ReceiverTelemetry> = emptyList(),
         appOpsTelemetry: List<AppOpsTelemetry> = emptyList(),
+        versionName: String,
     ): String = buildString {
         val includeFindings = mode != ExportMode.TELEMETRY_ONLY
         val includeTelemetry = mode != ExportMode.FINDINGS_ONLY
@@ -49,7 +50,7 @@ object ReportFormatter {
         appendLine(RULE)
         appendLine("  AndroDR Security Report")
         appendLine("  Format    : v${ReportExporter.EXPORT_FORMAT_VERSION} (mode=${mode.name})")
-        appendLine("  Version   : ${com.androdr.BuildConfig.VERSION_NAME}")
+        appendLine("  Version   : $versionName")
         appendLine("  Generated : $generated")
         appendLine("  Scan time : $scanDate")
         appendLine("  Android   : ${Build.VERSION.RELEASE} (API ${Build.VERSION.SDK_INT})")

--- a/app/src/main/java/com/androdr/reporting/TimelineExporter.kt
+++ b/app/src/main/java/com/androdr/reporting/TimelineExporter.kt
@@ -21,11 +21,12 @@ object TimelineExporter {
     fun formatPlaintext(
         events: List<ForensicTimelineEvent>,
         displayNames: Map<String, String> = emptyMap(),
-        ruleGuidance: Map<String, String> = emptyMap()
+        ruleGuidance: Map<String, String> = emptyMap(),
+        versionName: String
     ): String = buildString {
         appendLine(RULE)
         appendLine("  AndroDR Forensic Timeline")
-        appendLine("  Version: ${com.androdr.BuildConfig.VERSION_NAME}")
+        appendLine("  Version: $versionName")
         appendLine("  Generated: ${SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.US).format(Date())}")
         appendLine("  Android: ${Build.VERSION.RELEASE} (API ${Build.VERSION.SDK_INT})")
         appendLine("  Device: ${Build.MANUFACTURER} ${Build.MODEL}")

--- a/app/src/main/java/com/androdr/reporting/TimelineFormatter.kt
+++ b/app/src/main/java/com/androdr/reporting/TimelineFormatter.kt
@@ -23,13 +23,14 @@ object TimelineFormatter {
         timeline: List<TimelineEvent>,
         findings: List<Finding>,
         hashByPkg: Map<String, String> = emptyMap(),
-        displayNames: Map<String, String> = emptyMap()
+        displayNames: Map<String, String> = emptyMap(),
+        versionName: String
     ): String = buildString {
         val generated = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.US).format(Date())
 
         appendLine(RULE)
         appendLine("  AndroDR Bug Report Analysis Timeline")
-        appendLine("  Version   : ${com.androdr.BuildConfig.VERSION_NAME}")
+        appendLine("  Version   : $versionName")
         appendLine("  Generated : $generated")
         appendLine("  Android   : ${Build.VERSION.RELEASE} (API ${Build.VERSION.SDK_INT})")
         appendLine("  Device    : ${Build.MANUFACTURER} ${Build.MODEL}")

--- a/app/src/main/java/com/androdr/ui/bugreport/BugReportViewModel.kt
+++ b/app/src/main/java/com/androdr/ui/bugreport/BugReportViewModel.kt
@@ -9,6 +9,7 @@ import com.androdr.data.model.TimelineEvent
 import com.androdr.reporting.TimelineFormatter
 import com.androdr.scanner.ScanOrchestrator
 import com.androdr.sigma.Finding
+import com.androdr.util.appVersion
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
@@ -115,7 +116,8 @@ class BugReportViewModel @Inject constructor(
                     _timeline.value,
                     _findings.value,
                     hashByPkg,
-                    displayNames
+                    displayNames,
+                    versionName = appContext.appVersion().name
                 )
                 _shareUri.value = withContext(Dispatchers.IO) {
                     val reportsDir = File(appContext.cacheDir, "reports").apply { mkdirs() }

--- a/app/src/main/java/com/androdr/ui/history/HistoryViewModel.kt
+++ b/app/src/main/java/com/androdr/ui/history/HistoryViewModel.kt
@@ -1,5 +1,6 @@
 package com.androdr.ui.history
 
+import android.content.Context
 import android.net.Uri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -10,7 +11,9 @@ import com.androdr.reporting.ExportMode
 import com.androdr.reporting.ReportExporter
 import com.androdr.reporting.ReportFormatter
 import com.androdr.scanner.ScanOrchestrator
+import com.androdr.util.appVersion
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -25,7 +28,8 @@ class HistoryViewModel @Inject constructor(
     private val repository: ScanRepository,
     private val orchestrator: ScanOrchestrator,
     private val reportExporter: ReportExporter,
-    private val dnsEventDao: DnsEventDao
+    private val dnsEventDao: DnsEventDao,
+    @ApplicationContext private val appContext: Context
 ) : ViewModel() {
 
     /** Full scan history, newest first. */
@@ -77,7 +81,8 @@ class HistoryViewModel @Inject constructor(
             val dnsEvents = dnsEventDao.getRecentSnapshot()
             val inventory = orchestrator.lastAppTelemetry
             _sheetReportText.value = ReportFormatter.formatScanReport(
-                scan, dnsEvents, emptyList(), inventory
+                scan, dnsEvents, emptyList(), inventory,
+                versionName = appContext.appVersion().name
             )
         }
     }

--- a/app/src/main/java/com/androdr/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/androdr/ui/settings/SettingsScreen.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.androdr.util.appVersion
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -255,21 +256,18 @@ fun SettingsScreen(viewModel: SettingsViewModel = hiltViewModel()) {
                     containerColor = MaterialTheme.colorScheme.surfaceContainer
                 )
             ) {
+                val appVersion = remember(context) { context.appVersion() }
                 Column(
                     modifier = Modifier.padding(16.dp),
                     verticalArrangement = Arrangement.spacedBy(6.dp)
                 ) {
                     StatRow(
                         label = "Version",
-                        value = com.androdr.BuildConfig.VERSION_NAME
+                        value = appVersion.name
                     )
                     StatRow(
                         label = "Build",
-                        value = com.androdr.BuildConfig.VERSION_CODE.toString()
-                    )
-                    StatRow(
-                        label = "What's New",
-                        value = com.androdr.BuildConfig.RELEASE_NOTE
+                        value = appVersion.code.toString()
                     )
                     StatRow(
                         label = "Android",

--- a/app/src/main/java/com/androdr/ui/timeline/TimelineViewModel.kt
+++ b/app/src/main/java/com/androdr/ui/timeline/TimelineViewModel.kt
@@ -10,6 +10,7 @@ import com.androdr.data.model.ForensicTimelineEvent
 import com.androdr.data.repo.ScanRepository
 import com.androdr.reporting.TimelineExporter
 import com.androdr.sigma.Finding
+import com.androdr.util.appVersion
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
@@ -331,14 +332,21 @@ class TimelineViewModel @Inject constructor(
     fun generateReport() {
         viewModelScope.launch {
             val allEvents = withContext(Dispatchers.IO) { dao.getAllForExport() }
+            val versionName = appContext.appVersion().name
             _reportText.value = withContext(Dispatchers.Default) {
-                TimelineExporter.formatPlaintext(allEvents, buildDisplayNames(allEvents), buildRuleGuidance())
+                TimelineExporter.formatPlaintext(
+                    allEvents, buildDisplayNames(allEvents), buildRuleGuidance(),
+                    versionName = versionName
+                )
             }
         }
     }
 
     fun exportPlaintext() = export("txt") {
-        TimelineExporter.formatPlaintext(it, buildDisplayNames(it), buildRuleGuidance())
+        TimelineExporter.formatPlaintext(
+            it, buildDisplayNames(it), buildRuleGuidance(),
+            versionName = appContext.appVersion().name
+        )
     }
     fun exportCsv() = export("csv") { TimelineExporter.formatCsv(it) }
 

--- a/app/src/main/java/com/androdr/util/AppVersion.kt
+++ b/app/src/main/java/com/androdr/util/AppVersion.kt
@@ -1,0 +1,23 @@
+package com.androdr.util
+
+import android.content.Context
+import android.content.pm.PackageManager
+import androidx.core.content.pm.PackageInfoCompat
+
+data class AppVersion(val name: String, val code: Long)
+
+/**
+ * Reads versionName and longVersionCode from the installed APK's manifest at runtime.
+ * Avoids BuildConfig: Kotlin inlines `BuildConfig.VERSION_NAME`/`VERSION_CODE` as
+ * compile-time constants, and the Gradle build cache can serve those constants stale
+ * when surrounding source files don't change but the build metadata does.
+ */
+fun Context.appVersion(): AppVersion = try {
+    val info = packageManager.getPackageInfo(packageName, 0)
+    AppVersion(
+        name = info.versionName.orEmpty(),
+        code = PackageInfoCompat.getLongVersionCode(info),
+    )
+} catch (_: PackageManager.NameNotFoundException) {
+    AppVersion(name = "", code = 0L)
+}

--- a/app/src/test/java/com/androdr/reporting/ReportFormatterTest.kt
+++ b/app/src/test/java/com/androdr/reporting/ReportFormatterTest.kt
@@ -56,7 +56,7 @@ class ReportFormatterTest {
 
     @Test
     fun `verdict shows no threats when clean`() {
-        val text = ReportFormatter.formatScanReport(cleanScan, emptyList(), emptyList())
+        val text = ReportFormatter.formatScanReport(cleanScan, emptyList(), emptyList(), versionName = "test")
         assertTrue(text.contains("No threats detected"))
         assertTrue(text.contains("SUMMARY:"))
         assertTrue(text.contains("Flagged: 0"))
@@ -65,7 +65,7 @@ class ReportFormatterTest {
     @Test
     fun `verdict shows device settings when only device issues`() {
         val scan = buildScan(deviceFlags = listOf(deviceFinding))
-        val text = ReportFormatter.formatScanReport(scan, emptyList(), emptyList())
+        val text = ReportFormatter.formatScanReport(scan, emptyList(), emptyList(), versionName = "test")
         assertTrue(text.contains("device setting(s) need attention"))
         assertTrue(text.contains("Device posture: USB Debugging Enabled"))
     }
@@ -73,7 +73,7 @@ class ReportFormatterTest {
     @Test
     fun `action guidance from rule guidance field for malware`() {
         val scan = buildScan(appRisks = listOf(malwareFinding), knownMalwareCount = 1)
-        val text = ReportFormatter.formatScanReport(scan, emptyList(), emptyList())
+        val text = ReportFormatter.formatScanReport(scan, emptyList(), emptyList(), versionName = "test")
         assertTrue(text.contains("ACTION REQUIRED:"))
         assertTrue("Guidance from rule", text.contains("UNINSTALL IMMEDIATELY"))
     }
@@ -81,7 +81,7 @@ class ReportFormatterTest {
     @Test
     fun `action guidance from rule guidance field for sideloads`() {
         val scan = buildScan(appRisks = listOf(sideloadFinding), riskySideloadCount = 1)
-        val text = ReportFormatter.formatScanReport(scan, emptyList(), emptyList())
+        val text = ReportFormatter.formatScanReport(scan, emptyList(), emptyList(), versionName = "test")
         assertTrue("Guidance from rule", text.contains("REVIEW -- sideloaded app"))
     }
 
@@ -90,7 +90,8 @@ class ReportFormatterTest {
         val scan = buildScan(appRisks = listOf(sideloadFinding))
         val names = mapOf("com.unknown.app" to "Mystery App")
         val text = ReportFormatter.formatScanReport(
-            scan, emptyList(), emptyList(), displayNames = names
+            scan, emptyList(), emptyList(), displayNames = names,
+            versionName = "test"
         )
         assertTrue("Display name should appear", text.contains("Mystery App"))
     }
@@ -102,7 +103,7 @@ class ReportFormatterTest {
             knownMalwareCount = 1,
             riskySideloadCount = 1
         )
-        val text = ReportFormatter.formatScanReport(scan, emptyList(), emptyList())
+        val text = ReportFormatter.formatScanReport(scan, emptyList(), emptyList(), versionName = "test")
         assertTrue(text.contains("UNINSTALL IMMEDIATELY"))
         assertTrue(text.contains("REVIEW -- sideloaded app"))
     }
@@ -115,14 +116,14 @@ class ReportFormatterTest {
             knownMalwareCount = 1,
             riskySideloadCount = 1
         )
-        val text = ReportFormatter.formatScanReport(scan, emptyList(), emptyList())
+        val text = ReportFormatter.formatScanReport(scan, emptyList(), emptyList(), versionName = "test")
         val nonAscii = text.filter { it.code > 127 }
         assertTrue("Non-ASCII characters found: $nonAscii", nonAscii.isEmpty())
     }
 
     @Test
     fun `no action block when scan is clean`() {
-        val text = ReportFormatter.formatScanReport(cleanScan, emptyList(), emptyList())
+        val text = ReportFormatter.formatScanReport(cleanScan, emptyList(), emptyList(), versionName = "test")
         assertFalse(text.contains("ACTION REQUIRED:"))
     }
 
@@ -137,7 +138,7 @@ class ReportFormatterTest {
     fun `BOTH mode contains both section markers`() {
         val text = ReportFormatter.formatScanReport(
             richScan(), emptyList(), listOf("log line"),
-            mode = ExportMode.BOTH
+            mode = ExportMode.BOTH, versionName = "test"
         )
         assertTrue(text.contains("FINDINGS SECTION"))
         assertTrue(text.contains("TELEMETRY SECTION"))
@@ -149,7 +150,7 @@ class ReportFormatterTest {
     fun `TELEMETRY_ONLY writes only telemetry section`() {
         val text = ReportFormatter.formatScanReport(
             richScan(), emptyList(), listOf("log line"),
-            mode = ExportMode.TELEMETRY_ONLY
+            mode = ExportMode.TELEMETRY_ONLY, versionName = "test"
         )
         assertTrue(text.contains("TELEMETRY SECTION"))
         assertTrue(text.contains("DNS ACTIVITY"))
@@ -163,7 +164,7 @@ class ReportFormatterTest {
     fun `FINDINGS_ONLY writes only findings section`() {
         val text = ReportFormatter.formatScanReport(
             richScan(), emptyList(), listOf("log line"),
-            mode = ExportMode.FINDINGS_ONLY
+            mode = ExportMode.FINDINGS_ONLY, versionName = "test"
         )
         assertTrue(text.contains("FINDINGS SECTION"))
         assertTrue(text.contains("DEVICE CHECKS"))
@@ -175,7 +176,7 @@ class ReportFormatterTest {
 
     @Test
     fun `format version line is present`() {
-        val text = ReportFormatter.formatScanReport(cleanScan, emptyList(), emptyList())
+        val text = ReportFormatter.formatScanReport(cleanScan, emptyList(), emptyList(), versionName = "test")
         assertTrue(text.contains("Format    : v${ReportExporter.EXPORT_FORMAT_VERSION}"))
     }
 }

--- a/app/src/test/java/com/androdr/reporting/TimelineExporterTest.kt
+++ b/app/src/test/java/com/androdr/reporting/TimelineExporterTest.kt
@@ -26,7 +26,7 @@ class TimelineExporterTest {
 
     @Test
     fun `plaintext export contains header and events`() {
-        val text = TimelineExporter.formatPlaintext(events)
+        val text = TimelineExporter.formatPlaintext(events, versionName = "test")
         assertTrue(text.contains("AndroDR Forensic Timeline"))
         assertTrue(text.contains("IOC: com.evil.spy"))
         assertTrue(text.contains("com.evil.spy used CAMERA"))
@@ -141,7 +141,7 @@ class TimelineExporterTest {
 
     @Test
     fun `empty events produce valid output`() {
-        val text = TimelineExporter.formatPlaintext(emptyList())
+        val text = TimelineExporter.formatPlaintext(emptyList(), versionName = "test")
         assertTrue(text.contains("No timeline events"))
         val csv = TimelineExporter.formatCsv(emptyList())
         assertTrue(csv.lines().first().contains("timestamp"))
@@ -157,14 +157,14 @@ class TimelineExporterTest {
             )
         )
         val names = mapOf("com.whatsapp" to "WhatsApp")
-        val text = TimelineExporter.formatPlaintext(eventsNoName, names)
+        val text = TimelineExporter.formatPlaintext(eventsNoName, names, versionName = "test")
         assertTrue("Should resolve display name", text.contains("App: WhatsApp (com.whatsapp)"))
     }
 
     @Test
     fun `assessment driven by rule guidance`() {
         val guidance = mapOf("androdr-001" to "UNINSTALL IMMEDIATELY -- known malware")
-        val text = TimelineExporter.formatPlaintext(events, ruleGuidance = guidance)
+        val text = TimelineExporter.formatPlaintext(events, ruleGuidance = guidance, versionName = "test")
         assertTrue("Should have assessment", text.contains("ASSESSMENT:"))
         assertTrue("Rule guidance drives critical assessment",
             text.contains("CRITICAL ACTIVITY DETECTED"))
@@ -176,7 +176,7 @@ class TimelineExporterTest {
         // guidance, assessment falls through to NO CONCERNS. Phase B will
         // reintroduce finding-driven REVIEW/CRITICAL assessments via the
         // Finding-row variant.
-        val text = TimelineExporter.formatPlaintext(events)
+        val text = TimelineExporter.formatPlaintext(events, versionName = "test")
         assertTrue(text.contains("ASSESSMENT:"))
     }
 
@@ -189,13 +189,13 @@ class TimelineExporterTest {
                 packageName = "com.test"
             )
         )
-        val text = TimelineExporter.formatPlaintext(infoEvents)
+        val text = TimelineExporter.formatPlaintext(infoEvents, versionName = "test")
         assertTrue(text.contains("NO CONCERNS"))
     }
 
     @Test
     fun `output is ASCII only`() {
-        val text = TimelineExporter.formatPlaintext(events)
+        val text = TimelineExporter.formatPlaintext(events, versionName = "test")
         val nonAscii = text.filter { it.code > 127 }
         assertTrue("Non-ASCII characters found: $nonAscii", nonAscii.isEmpty())
     }

--- a/app/src/test/java/com/androdr/reporting/TimelineFormatterTest.kt
+++ b/app/src/test/java/com/androdr/reporting/TimelineFormatterTest.kt
@@ -30,7 +30,7 @@ class TimelineFormatterTest {
     @Test
     fun `verdict shows CLEAN when no triggered findings`() {
         val text = TimelineFormatter.formatTimeline(
-            emptyList(), emptyList()
+            emptyList(), emptyList(), versionName = "test"
         )
         assertTrue(text.contains("ANALYSIS VERDICT: CLEAN"))
     }
@@ -38,7 +38,7 @@ class TimelineFormatterTest {
     @Test
     fun `verdict shows CRITICAL THREATS when critical findings present`() {
         val text = TimelineFormatter.formatTimeline(
-            emptyList(), listOf(criticalFinding)
+            emptyList(), listOf(criticalFinding), versionName = "test"
         )
         assertTrue(text.contains("ANALYSIS VERDICT: CRITICAL THREATS DETECTED"))
         assertTrue(text.contains("1 critical"))
@@ -47,7 +47,7 @@ class TimelineFormatterTest {
     @Test
     fun `verdict shows ISSUES FOUND for medium findings`() {
         val text = TimelineFormatter.formatTimeline(
-            emptyList(), listOf(mediumFinding)
+            emptyList(), listOf(mediumFinding), versionName = "test"
         )
         assertTrue(text.contains("ANALYSIS VERDICT: ISSUES FOUND"))
         assertTrue(text.contains("1 medium"))
@@ -58,7 +58,7 @@ class TimelineFormatterTest {
         val names = mapOf("com.test.app" to "Test App")
         val text = TimelineFormatter.formatTimeline(
             emptyList(), listOf(mediumFinding),
-            displayNames = names
+            displayNames = names, versionName = "test"
         )
         assertTrue("Display name should appear", text.contains("Test App (com.test.app)"))
     }
@@ -69,7 +69,7 @@ class TimelineFormatterTest {
         val names = mapOf("com.whatsapp" to "WhatsApp")
         val text = TimelineFormatter.formatTimeline(
             emptyList(), emptyList(),
-            hashByPkg = hashes, displayNames = names
+            hashByPkg = hashes, displayNames = names, versionName = "test"
         )
         assertTrue("Display name in inventory", text.contains("WhatsApp"))
         assertTrue("Package name in inventory", text.contains("Package: com.whatsapp"))
@@ -80,7 +80,8 @@ class TimelineFormatterTest {
         val text = TimelineFormatter.formatTimeline(
             emptyList(),
             listOf(criticalFinding, mediumFinding),
-            mapOf("com.test" to "hash123")
+            mapOf("com.test" to "hash123"),
+            versionName = "test"
         )
         val nonAscii = text.filter { it.code > 127 }
         assertTrue("Non-ASCII characters found: $nonAscii", nonAscii.isEmpty())


### PR DESCRIPTION
## Summary

- Settings → About card and exported report headers were showing stale `versionName`/`versionCode` because Kotlin inlines `BuildConfig.VERSION_NAME`/`VERSION_CODE` as compile-time constants and Gradle's build cache served cached `.class` files for Kotlin sources whose own bytes hadn't changed.
- Switch the About card and the three report formatters (`ReportFormatter`, `TimelineExporter`, `TimelineFormatter`) to read `versionName` + `longVersionCode` from `PackageManager.getPackageInfo(...)` at runtime — the manifest pipeline is independent of `BuildConfig`, so it's immune to the build-cache failure mode.
- The "What's New" StatRow is dropped per the issue spec.

## Implementation notes

- New `Context.appVersion()` extension in `util/AppVersion.kt` using `PackageInfoCompat.getLongVersionCode()` (handles the API 28 long-vs-int split — minSdk = 26).
- Settings About card uses `remember(context) { context.appVersion() }` so the PackageManager IPC happens once per composition lifetime.
- The three pure-formatter `object`s gained a required `versionName: String` parameter (no default) rather than reaching into BuildConfig themselves. Keeps them I/O-free and unit-testable without a device. Required (not optional) so a future caller cannot forget the version and silently render a blank `Version :` line — the same class of bug this PR fixes.
- Real callers — `ReportExporter`, `HistoryViewModel`, `TimelineViewModel`, `BugReportViewModel`, debug `ScanBroadcastReceiver` — pass `context.appVersion().name`. `HistoryViewModel` gained an `@ApplicationContext` injection.
- Test call sites updated to pass `versionName = "test"`.

Closes #158

## Test plan

- [ ] CI green (`./gradlew assembleDebug`, `testDebugUnitTest`, `lintDebug`).
- [ ] On-device verification: install fresh debug APK, open Settings → About; the displayed Version/Build match `adb shell dumpsys package com.androdr.debug | grep -E "versionName|versionCode"`.
- [ ] Export a scan report and a forensic timeline; both headers carry the same version string.
- [ ] After `./gradlew clean assembleDebug` (no extra flags) and reinstall, the About screen shows the new version. Repeat to confirm the build cache no longer serves stale values.

## Out of scope

- `BuildConfig.RELEASE_NOTE` is still defined in `app/build.gradle.kts` (~25 lines of git-log + regex stripping) but is no longer referenced from any Kotlin source. Removing the gradle-side machinery is harmless follow-up cleanup, not part of this bug fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)