### PR TITLE
feat(rules): add androdr-052 — LANDFALL spyware CVE detection

### DIFF
--- a/app/src/main/res/raw/sigma_androdr_052_landfall_cves.yml
+++ b/app/src/main/res/raw/sigma_androdr_052_landfall_cves.yml
@@ -1,0 +1,39 @@
+title: CVE exploited by LANDFALL spyware
+id: androdr-052
+status: experimental
+description: >
+    Device has unpatched CVEs known to be exploited by LANDFALL,
+    a commercial-grade Android spyware family active since at least
+    July 2024 against Samsung Galaxy S22/S23/S24, Z Fold4, and Z
+    Flip4 users in Iraq, Iran, Turkey, and Morocco. Delivered via
+    a malformed DNG image over WhatsApp.
+author: AndroDR (AI-generated)
+date: 2026/05/03
+references:
+    - https://unit42.paloaltonetworks.com/landfall-is-new-commercial-grade-android-spyware/
+    - https://thehackernews.com/2025/11/samsung-zero-click-flaw-exploited-to.html
+    - https://securityaffairs.com/184331/security/landfall-spyware-exploited-samsung-zero-day-cve-2025-21042-in-middle-east-attacks.html
+tags:
+    - attack.t1404
+    - attack.t1664
+    - campaign.landfall
+logsource:
+    product: androdr
+    service: device_auditor
+detection:
+    selection:
+        unpatched_cve_id|contains:
+            - "CVE-2025-21042"
+            - "CVE-2025-21043"
+    condition: selection
+display:
+    category: device_posture
+    icon: shield_alert
+    triggered_title: "{count} CVEs linked to LANDFALL"
+    safe_title: "No LANDFALL-linked CVEs"
+    evidence_type: cve_list
+    summary_template: "LANDFALL spyware exploits {count} unpatched CVEs on this device"
+level: medium
+category: device_posture
+remediation:
+    - "Go to Settings > Software Update > Download and Install immediately. Also check Play Store > Settings > About > Google Play system update. These Samsung libimagecodec.quram.so vulnerabilities are exploited by LANDFALL spyware via malformed DNG images sent over WhatsApp."

--- a/app/src/test/resources/gate4-fixtures/landfall-cves.yml
+++ b/app/src/test/resources/gate4-fixtures/landfall-cves.yml
@@ -1,0 +1,15 @@
+# Fixture for androdr-052: CVEs exploited by LANDFALL spyware
+rule_file: sigma_androdr_052_landfall_cves.yml
+service: device_auditor
+
+true_positives:
+  - unpatched_cve_id: "CVE-2025-21042"
+  - unpatched_cve_id: "CVE-2025-21043"
+  - unpatched_cve_id: "CVE-2025-21042,CVE-2025-21043"
+  - unpatched_cve_id: "CVE-2024-99999,CVE-2025-21042"
+
+true_negatives:
+  - unpatched_cve_id: "CVE-2024-21042"
+  - unpatched_cve_id: ""
+  - unpatched_cve_id: "CVE-2025-99999"
+  - unpatched_cve_id: "CVE-2024-99999,CVE-2025-99998"


### PR DESCRIPTION
## Summary

Adds **androdr-052**, detecting Samsung devices with CVEs known to be exploited by **LANDFALL** commercial-grade Android spyware (CVE-2025-21042 + CVE-2025-21043, Samsung `libimagecodec.quram.so`, zero-click via WhatsApp DNG image, disclosed by Palo Alto Unit42 in November 2025).

Fifth rule in the per-spyware-CVE family (peers 048 Pegasus, 049 Predator, 050 Graphite, 051 Cellebrite). Same shape, same level, same logsource. Adds `attack.t1664` (Exploitation for Initial Access - Mobile) on top of `attack.t1404` to model the zero-click DNG delivery vector — peers only tag `t1404`.

## Why now

- LANDFALL is a *current*, *named*, commercial-grade Android spyware family with a documented victim profile (Iraq, Iran, Turkey, Morocco journalists/dissidents) and active exploitation pre-disclosure (since at least July 2024).
- Matches the existing rule-family model exactly — zero net-new schema/code.
- CVE-2025-21042 patched in Samsung SMR-APR-2025; CVE-2025-21043 patched in SMR-SEP-2025. Users on stock Samsung Android in those regimes who delay updates remain exposed.

## 5-gate validation

| Gate | Result | Notes |
|---|---|---|
| 1. Schema | ✅ | \`validate-rule.py\` exit 0 |
| 2. IOC verification | ✅ | Both CVEs publicly attributed to LANDFALL via Unit42, The Hacker News, SecurityAffairs |
| 3. Dedup | ✅ | ID \`androdr-052\` free; CVE sets disjoint from peers 048-051 |
| 4. Dry-run fixture | ✅ | 4 TPs (each CVE singly + comma-separated + mixed-context) + 4 TNs |
| 5. LLM self-review | ✅ | \`pass_with_notes\`, FP risk \`low\` |

## Two-reviewer cycle

**Spec reviewer (general-purpose):** PASS — all 8 explicit requirements met, structural consistency with family confirmed.

**Harsh quality reviewer (code-reviewer agent):** 1 BLOCKER + 3 MAJORs raised; verified independently:

- 🔴 ~~\`attack.t1664\` invalid~~ — **rejected**: T1664 *is* valid ATT&CK Mobile (\"Exploitation for Initial Access\"), confirmed via mitre.org/techniques/T1664/.
- 🟠 Comma-vs-space wire format in fixture — **accepted**: \`DeviceTelemetry.kt:24\` joins CVEs with \`\",\"\`. Fixture updated to use comma-separated; added a mixed-context TP (LANDFALL CVE adjacent to unrelated CVE) which reflects production wire shape.
- 🟠 ~~Missing \`report_safe_state: true\`~~ — **rejected for this PR**: empirically breaks the Gate 4 harness (it counts safe-state findings as positives, making all TNs fail). Cellebrite (the only Gate-4-tested peer) deliberately omits the flag. This is a latent harness issue affecting peers 048/050 retroactively; separate work.
- 🟠 ~~Add lowercase TN to document case sensitivity~~ — **rejected**: \`|contains\` is case-insensitive in \`SigmaRuleEvaluator.kt:212-213\` (both sides lowercased). No limitation to document.

Minor suggestions (drop derivative refs, drop library jargon, add SMR refs, severity rationale comment) deferred — none affect detection correctness.

## Test plan

- [x] \`python3 third-party/android-sigma-rules/validation/validate-rule.py app/src/main/res/raw/sigma_androdr_052_landfall_cves.yml\` returns PASS
- [x] \`./gradlew testDebugUnitTest --tests \"com.androdr.sigma.GateFourFixtureTest\" --rerun-tasks\` BUILD SUCCESSFUL with \`fixture passes gate 4[landfall-cves]\` 0.003s pass
- [x] \`./gradlew lintDebug\` BUILD SUCCESSFUL
- [ ] On-device sanity: on a Samsung running affected Android image patch level, verify the finding renders correctly on the dashboard
- [ ] CI \`build\` check passes

## References

- Unit42, *LANDFALL is a new commercial-grade Android spyware*: https://unit42.paloaltonetworks.com/landfall-is-new-commercial-grade-android-spyware/
- The Hacker News, *Samsung Zero-Click Flaw Exploited*: https://thehackernews.com/2025/11/samsung-zero-click-flaw-exploited-to.html
- SecurityAffairs, *LANDFALL spyware exploited Samsung zero-day CVE-2025-21042*: https://securityaffairs.com/184331/security/landfall-spyware-exploited-samsung-zero-day-cve-2025-21042-in-middle-east-attacks.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)