### PR TITLE
fix(bugreport): surface success/error states on completion (#148)

### DIFF
--- a/app/src/main/java/com/androdr/ui/bugreport/BugReportScreen.kt
+++ b/app/src/main/java/com/androdr/ui/bugreport/BugReportScreen.kt
@@ -56,7 +56,9 @@ import com.androdr.R
 import com.androdr.ui.common.FindingCard
 
 @Suppress("LongMethod") // Bug report screen combines file-picker launch, progress state,
-// empty-state, findings list, and export; splitting would require threading state through extra wrappers.
+// empty-state, completion confirmation, error card, findings list, timeline, and export.
+// Splitting into child composables would require threading 5+ state flows through wrappers;
+// keeping inline trades length for state-flow locality.
 @Composable
 fun BugReportScreen(
     viewModel: BugReportViewModel = hiltViewModel()
@@ -64,6 +66,8 @@ fun BugReportScreen(
     val findings by viewModel.findings.collectAsStateWithLifecycle()
     val timeline by viewModel.timeline.collectAsStateWithLifecycle()
     val isAnalyzing by viewModel.isAnalyzing.collectAsStateWithLifecycle()
+    val analysisFinished by viewModel.analysisFinished.collectAsStateWithLifecycle()
+    val errorMessage by viewModel.errorMessage.collectAsStateWithLifecycle()
     val exporting by viewModel.exporting.collectAsStateWithLifecycle()
     val shareUri by viewModel.shareUri.collectAsStateWithLifecycle()
 
@@ -203,8 +207,8 @@ fun BugReportScreen(
                 }
             }
 
-            // Empty state before any analysis
-            if (!isAnalyzing && !hasResults) {
+            // Pre-analysis empty state (initial, no analysis attempted yet)
+            if (!isAnalyzing && !analysisFinished) {
                 item {
                     Box(
                         modifier = Modifier
@@ -237,7 +241,131 @@ fun BugReportScreen(
                 }
             }
 
-            // Analysis results
+            // Error card — analysis threw an unhandled exception
+            if (!isAnalyzing && analysisFinished && errorMessage != null) {
+                item {
+                    Card(
+                        modifier = Modifier.fillMaxWidth(),
+                        colors = CardDefaults.cardColors(
+                            containerColor = MaterialTheme.colorScheme.errorContainer
+                        )
+                    ) {
+                        Row(
+                            modifier = Modifier.padding(16.dp),
+                            horizontalArrangement = Arrangement.spacedBy(12.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Icon(
+                                imageVector = Icons.Filled.Error,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.onErrorContainer
+                            )
+                            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                                Text(
+                                    text = stringResource(R.string.bugreport_error_title),
+                                    style = MaterialTheme.typography.titleSmall,
+                                    fontWeight = FontWeight.SemiBold,
+                                    color = MaterialTheme.colorScheme.onErrorContainer
+                                )
+                                Text(
+                                    text = stringResource(
+                                        R.string.bugreport_error_hint,
+                                        errorMessage ?: ""
+                                    ),
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onErrorContainer,
+                                    maxLines = 6,
+                                    overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Completion confirmation card — analysis succeeded but yielded no triggered findings.
+            // Without this card the screen would revert to the idle empty-state and the user
+            // could not distinguish success-with-no-signals from "spinner crashed silently".
+            if (!isAnalyzing && analysisFinished && errorMessage == null && !hasResults) {
+                item {
+                    Card(
+                        modifier = Modifier.fillMaxWidth(),
+                        colors = CardDefaults.cardColors(
+                            containerColor = MaterialTheme.colorScheme.surfaceContainerHighest
+                        )
+                    ) {
+                        Row(
+                            modifier = Modifier.padding(16.dp),
+                            horizontalArrangement = Arrangement.spacedBy(12.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Icon(
+                                imageVector = Icons.Filled.Info,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.primary
+                            )
+                            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                                Text(
+                                    text = stringResource(R.string.bugreport_complete_clean_title),
+                                    style = MaterialTheme.typography.titleSmall,
+                                    fontWeight = FontWeight.SemiBold,
+                                    color = MaterialTheme.colorScheme.onSurface
+                                )
+                                Text(
+                                    text = if (timeline.isNotEmpty()) {
+                                        stringResource(
+                                            R.string.bugreport_complete_timeline_only,
+                                            timeline.size
+                                        )
+                                    } else {
+                                        stringResource(R.string.bugreport_complete_clean_hint)
+                                    },
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
+                        }
+                    }
+                }
+
+                // Timeline-only result: still show the timeline + an export button so
+                // the user can capture forensic events that didn't trip a SIGMA rule.
+                if (timeline.isNotEmpty()) {
+                    item {
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.End,
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            OutlinedButton(
+                                onClick = { viewModel.exportReport() },
+                                enabled = !exporting
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Filled.Share,
+                                    contentDescription = stringResource(R.string.report_export_cd),
+                                    modifier = Modifier.size(18.dp)
+                                )
+                                Spacer(modifier = Modifier.width(6.dp))
+                                Text(stringResource(R.string.report_export_label))
+                            }
+                        }
+                    }
+                    item {
+                        Text(
+                            text = stringResource(R.string.bugreport_timeline_count, timeline.size),
+                            style = MaterialTheme.typography.titleSmall,
+                            fontWeight = FontWeight.SemiBold,
+                            color = MaterialTheme.colorScheme.primary
+                        )
+                    }
+                    items(timeline.sortedBy { it.timestamp }) { event ->
+                        TimelineEventCard(event = event)
+                    }
+                }
+            }
+
+            // Analysis results — at least one triggered SIGMA finding
             if (!isAnalyzing && hasResults) {
                 // Export button
                 item {

--- a/app/src/main/java/com/androdr/ui/bugreport/BugReportViewModel.kt
+++ b/app/src/main/java/com/androdr/ui/bugreport/BugReportViewModel.kt
@@ -39,6 +39,16 @@ class BugReportViewModel @Inject constructor(
     private val _isAnalyzing = MutableStateFlow(false)
     val isAnalyzing: StateFlow<Boolean> = _isAnalyzing.asStateFlow()
 
+    /** True once an analysis has finished (success OR failure, NOT cancellation).
+     *  Used to render a completion confirmation distinct from the pre-analysis
+     *  idle state — the bug in #148 was that the UI couldn't tell those apart. */
+    private val _analysisFinished = MutableStateFlow(false)
+    val analysisFinished: StateFlow<Boolean> = _analysisFinished.asStateFlow()
+
+    /** Non-null when the most recent analysis threw an unrecoverable error. */
+    private val _errorMessage = MutableStateFlow<String?>(null)
+    val errorMessage: StateFlow<String?> = _errorMessage.asStateFlow()
+
     /** Emits a [Uri] when a report is ready to share; null when idle or after consumption. */
     private val _shareUri = MutableStateFlow<Uri?>(null)
     val shareUri: StateFlow<Uri?> = _shareUri.asStateFlow()
@@ -83,12 +93,28 @@ class BugReportViewModel @Inject constructor(
     fun analyzeUri(uri: Uri) {
         viewModelScope.launch {
             _isAnalyzing.value = true
+            _analysisFinished.value = false
+            _errorMessage.value = null
             _findings.value = emptyList()
             _timeline.value = emptyList()
             try {
                 val result = orchestrator.analyzeBugReport(uri)
                 _findings.value = result.findings
                 _timeline.value = result.timeline
+                _analysisFinished.value = true
+            } catch (e: kotlinx.coroutines.CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                val raw = e.message ?: e::class.simpleName ?: "Unknown error"
+                // Cap to keep zip/IO exception messages (which often embed
+                // long content:// URIs and stack-frame-like strings) from
+                // overflowing the error card on small screens.
+                _errorMessage.value = if (raw.length > MAX_ERROR_MESSAGE_LEN) {
+                    raw.take(MAX_ERROR_MESSAGE_LEN) + "…"
+                } else {
+                    raw
+                }
+                _analysisFinished.value = true
             } finally {
                 _isAnalyzing.value = false
             }
@@ -140,5 +166,9 @@ class BugReportViewModel @Inject constructor(
     /** Call after the share intent has been launched to reset the URI state. */
     fun onShareConsumed() {
         _shareUri.value = null
+    }
+
+    private companion object {
+        const val MAX_ERROR_MESSAGE_LEN = 280
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -82,6 +82,12 @@
     <string name="bugreport_analyzing">Analyzing system diagnostic\u2026</string>
     <string name="bugreport_empty_state">No analysis yet</string>
     <string name="bugreport_empty_hint">Select a system diagnostic .zip file to scan for threats</string>
+    <string name="bugreport_complete_clean_title">Scan complete — no security signals detected</string>
+    <string name="bugreport_complete_clean_hint">Your system diagnostic was analyzed against AndroDR\'s detection rules and no triggered findings were produced.</string>
+    <!-- PluralsCandidate: compact completion summary; matches bugreport_finding_count style -->
+    <string name="bugreport_complete_timeline_only" tools:ignore="PluralsCandidate">Scan complete — %1$d timeline event(s), no triggered findings</string>
+    <string name="bugreport_error_title">Analysis failed</string>
+    <string name="bugreport_error_hint">Reason: %1$s</string>
     <string name="dashboard_bugreport_title">Deep Device Scan</string>
     <string name="dashboard_bugreport_hint">Analyze a system diagnostic for hidden threats</string>
 


### PR DESCRIPTION
## Summary

Fixes #148 — bug-report analysis on Samsung Galaxy Z Fold 2 (and any device producing zero triggered findings) showed spinner appear → spinner disappear → no feedback. The screen reverted to the idle "Select Diagnostic File" empty-state, indistinguishable from "no analysis ever attempted".

**Root cause:** `BugReportScreen` gated the results section on `hasResults = findings.isNotEmpty()`. A clean device produces an empty findings list (the expected outcome, not an error), so the screen rolled back to the pre-analysis empty-state — same strings, same hint, no signal that anything happened. The bug also hid timeline-only results because timeline rendering lived inside the `hasResults` branch.

**Fix:** add `analysisFinished` and `errorMessage` state flows on `BugReportViewModel`; render five mutually-exclusive UI states:

| State condition | UI |
|---|---|
| `!isAnalyzing && !analysisFinished` | Pre-analysis hint (unchanged) |
| `isAnalyzing` | Spinner (unchanged) |
| `!isAnalyzing && analysisFinished && errorMessage != null` | **NEW** error card |
| `!isAnalyzing && analysisFinished && errorMessage == null && !hasResults` | **NEW** clean-confirmation card (+ timeline + export if timeline non-empty) |
| `!isAnalyzing && hasResults` | Findings list (unchanged) |

## Two-reviewer cycle

**Spec reviewer (general-purpose):** PASS on all 7 requirements — all five render branches mutually exclusive, cancellation does NOT flip `analysisFinished`, state resets at the start of each `analyzeUri()`.

**Harsh quality reviewer (code-reviewer agent):** NO BLOCKERS — APPROVE FOR MERGE with MINOR feedback. Triage:

| Finding | Disposition |
|---|---|
| 🟡 Error message could overflow / leak PII | **Accepted** — cap to 280 chars at ViewModel; `maxLines=6` + ellipsis on Text |
| 🟡 Translation pipeline may strip format-only string | **Accepted** — wrap `bugreport_error_hint` as `"Reason: %1\$s"` |
| 🟡 `hasCompleted` naming ambiguous | **Accepted** — renamed to `analysisFinished` |
| 🟡 `LongMethod` suppression comment stale | **Accepted** — updated to reflect expanded state machine |
| 🟡 Reorder state writes to avoid one-frame inconsistency | **Rejected** — proposed alt (drop `finally`, set `_isAnalyzing=false` in try) would break cancellation; current order is correct because all post-completion branches guard on `!isAnalyzing` |
| 🟡 Double-tap race in `analyzeUri` | **Rejected** — reviewer notes "currently unreachable via UI" (file picker disabled while analyzing); over-engineering for this scope |
| 🟡 Process death loses `analysisFinished` state | **Deferred** — separate follow-up; `SavedStateHandle` plumbing is out of scope |
| 🟡 `exportReport()` has no error handling | **Deferred** — pre-existing; not introduced by this PR |
| 🟢 No ViewModel test coverage | **Acknowledged** — `BugReportViewModel` has no existing tests; introducing the first pattern (fake `ScanOrchestrator` + coroutine test scaffolding) is scope-creep for a UI bug fix |

## Test plan

- [x] \`./gradlew assembleDebug\` BUILD SUCCESSFUL
- [x] \`./gradlew testDebugUnitTest\` BUILD SUCCESSFUL (no new tests; existing 9 Gate-4 fixture tests + 30+ other unit tests pass)
- [x] \`./gradlew lintDebug\` BUILD SUCCESSFUL
- [ ] **Manual on-device:** install debug APK on a phone; from Dashboard tap "Deep Device Scan"; feed a real \`bugreport-*.zip\` from a clean device → verify the clean-confirmation card appears with timeline-count text and the Export button works
- [ ] **Manual on-device error path:** feed a corrupted/non-zip file → verify the error card appears with a non-empty "Reason:" message
- [ ] CI \`build\` check passes

Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)