### PR TITLE
docs(#168): spec for data-broker SDK scanner extension

### DIFF
--- a/docs/superpowers/plans/2026-05-17-data-broker-sdk-scanner-plan.md
+++ b/docs/superpowers/plans/2026-05-17-data-broker-sdk-scanner-plan.md
@@ -128,12 +128,13 @@ This task adds the pure-function extractor only. Wiring into `collectTelemetry()
 
 - [ ] **Step 1: Write the failing test for the happy path**
 
-Open `app/src/test/java/com/androdr/scanner/AppScannerTelemetryTest.kt`. Append after the existing tests:
+Open `app/src/test/java/com/androdr/scanner/AppScannerTelemetryTest.kt`.
+
+**Imports:** `android.content.pm.ServiceInfo` (line 8) and `android.content.pm.ActivityInfo` (line 9) are ALREADY imported in this file — do not add them a second time. Only `android.content.pm.ProviderInfo` is genuinely new; add that single line at the file top in the existing import block (after the other `android.content.pm.*` imports), NOT inline next to the test methods (Kotlin requires imports at the top of the file).
+
+**Test methods:** append the three test methods below at the bottom of the class body, alongside the existing `@Test` methods. (The `import` line goes at the top; only the `@Test` blocks below go at the bottom.)
 
 ```kotlin
-import android.content.pm.ProviderInfo
-import android.content.pm.ActivityInfo
-import android.content.pm.ServiceInfo
 
 @Test
 fun `extractComponentClassNames returns deduped sorted class names from all four component kinds`() {
@@ -205,7 +206,7 @@ Expected: compile error — `extractComponentClassNames` does not exist on `AppS
 
 - [ ] **Step 3: Add the function to `AppScanner.kt`**
 
-Open `app/src/main/java/com/androdr/scanner/AppScanner.kt`. Add this `internal` function inside the class (just below `collectTelemetry()` is the natural spot):
+Open `app/src/main/java/com/androdr/scanner/AppScanner.kt`. Place this `internal` function **after `buildTelemetryForPackage()`** (and before any APK-hash helpers) so the two SDK-signal extractors live next to each other and don't split the existing `collectTelemetry` → `buildTelemetryForPackage` pair:
 
 ```kotlin
 /**
@@ -485,7 +486,14 @@ Open `app/src/main/java/com/androdr/data/model/AppTelemetry.kt`. The constructor
 
 - [ ] **Step 4: Add the two keys to `toFieldMap()`**
 
-`AppTelemetry.toFieldMap()` (at line 39) is what `LogsourceTaxonomyCrossCheckTest` inspects — adding constructor fields alone won't make the cross-check happy because the test compares `toFieldMap().keys` against the taxonomy YAML. Append the two new entries at the end of the map (after `"last_update_time" to lastUpdateTime`):
+`AppTelemetry.toFieldMap()` (at line 39) is what `LogsourceTaxonomyCrossCheckTest` inspects — adding constructor fields alone won't make the cross-check happy because the test compares `toFieldMap().keys` against the taxonomy YAML. Append the two new entries at the end of the map.
+
+The existing `mapOf(...)` body ends at line 59 with `"last_update_time" to lastUpdateTime` and NO trailing comma (line 60 is the closing `)`). To insert the new entries, you must:
+
+1. **Add a trailing comma** to the existing `"last_update_time" to lastUpdateTime` line.
+2. **Append two new lines** below it.
+
+Result (lines 58-62 region after edit):
 
 ```kotlin
     fun toFieldMap(): Map<String, Any?> = mapOf(
@@ -500,20 +508,24 @@ Open `app/src/main/java/com/androdr/data/model/AppTelemetry.kt`. The constructor
 
 The snake_case map keys must match the taxonomy YAML byte-for-byte; the cross-check does NOT do case conversion. `LogsourceTaxonomyCrossCheckTest.kt` itself does NOT need to be modified — its `memberFunctionFieldMaps()` constructs `AppTelemetry(...)` with named args and the two new fields take their `emptyList()` defaults without breaking the call.
 
-- [ ] **Step 5: Wire the extractors into `collectTelemetry()`**
+- [ ] **Step 5: Wire the extractors into `buildTelemetryForPackage()`**
 
-In `AppScanner.kt`, find the body of `collectTelemetry()` where each `AppTelemetry(...)` is constructed. Just before constructing the `AppTelemetry`, compute:
+Despite the function name suggesting otherwise, `AppTelemetry(...)` is NOT constructed in `collectTelemetry()` — `collectTelemetry()` (line 96) fans out to `buildTelemetryForPackage()` (line 147), which is where the single `AppTelemetry(...)` constructor call lives (currently around line 250, `return AppTelemetry(...)`).
+
+In `buildTelemetryForPackage`, an `applicationInfo` is already null-checked into the local `appInfo` (line 153: `val appInfo = pkg.applicationInfo ?: return null`). Reuse that — don't re-dereference `pkg.applicationInfo`, which would re-introduce the nullability the function already handled. The `PackageInfo` parameter is named `pkg` in this function.
+
+Just before `return AppTelemetry(...)`, compute:
 
 ```kotlin
-val embeddedComponentClasses = extractComponentClassNames(packageInfo)
-val embeddedNativeLibs = extractNativeLibFileNames(packageInfo.applicationInfo)
+val embeddedComponentClasses = extractComponentClassNames(pkg)
+val embeddedNativeLibs = extractNativeLibFileNames(appInfo)
 ```
 
-Then pass them to the constructor:
+Then pass them as the last two named arguments to the constructor:
 
 ```kotlin
-AppTelemetry(
-    // ... existing args ...
+return AppTelemetry(
+    // ... all existing named args, unchanged ...
     source = TelemetrySource.RUNTIME,
     embeddedComponentClasses = embeddedComponentClasses,
     embeddedNativeLibs = embeddedNativeLibs,

--- a/docs/superpowers/plans/2026-05-17-data-broker-sdk-scanner-plan.md
+++ b/docs/superpowers/plans/2026-05-17-data-broker-sdk-scanner-plan.md
@@ -1,0 +1,704 @@
+# Data-Broker SDK Scanner — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend `AppScanner` to emit two new list-typed telemetry fields — `embeddedComponentClasses` and `embeddedNativeLibs` — so subsequent rule packs can fingerprint ad-broker SDKs that ship embedded inside otherwise-mainstream apps.
+
+**Architecture:** Two pure-function extractors added as `internal` members of `AppScanner`. Manifest extractor reads `.name` from `PackageInfo.services|receivers|activities|providers`. Native-libs extractor opens the APK via `applicationInfo.publicSourceDir` as a `ZipFile` and lists `lib/*/*.so` entries. Output is appended to `AppTelemetry` (Approach A, per spec). Schema parity enforced by `BundledRulesSchemaCrossCheckTest` after coordinated submodule taxonomy update.
+
+**Tech Stack:** Kotlin, AndroidX, Hilt, JUnit4, mockk, `java.util.zip.ZipFile`, `java.util.zip.ZipOutputStream` (test fixture building).
+
+**Spec:** `docs/superpowers/specs/2026-05-17-data-broker-sdk-scanner-design.md`
+
+**Issue:** [#168](https://github.com/yasirhamza/AndroDR/issues/168)
+
+---
+
+## PR boundary 1: Submodule (`android-sigma-rules`)
+
+This work happens in `/home/yasir/AndroDR/third-party/android-sigma-rules/`. Open the PR in the `android-sigma-rules/rules` repo, admin-merge there, then come back to AndroDR for the rest.
+
+### Task 1: Add taxonomy fields to logsource-taxonomy.yml
+
+**Files:**
+- Modify: `third-party/android-sigma-rules/validation/logsource-taxonomy.yml` (under `app_scanner.fields`)
+
+- [ ] **Step 1: Create the submodule branch**
+
+```bash
+cd third-party/android-sigma-rules
+git checkout main
+git pull --ff-only origin main
+git checkout -b feat/168-embedded-sdk-fields
+```
+
+- [ ] **Step 2: Insert the two new field entries**
+
+Open `validation/logsource-taxonomy.yml`. Find the `app_scanner.fields:` block. After the existing `last_update_time` entry, add:
+
+```yaml
+      embedded_component_class: { type: list, description: "Class names from manifest services/receivers/activities/providers; deduplicated; capped per app. Used by embedded-SDK fingerprinting rules (AndroDR #168)." }
+      embedded_native_lib: { type: list, description: "Filenames of lib/*/*.so entries inside the APK, ABI prefix stripped; deduplicated; capped per app. Used by embedded-SDK fingerprinting rules (AndroDR #168)." }
+```
+
+Match the existing inline-flow style on every neighbouring entry. Do **not** add a multi-line yaml block — the existing entries are all single-line.
+
+- [ ] **Step 3: Run the validator's self-test**
+
+```bash
+cd /home/yasir/AndroDR/third-party/android-sigma-rules
+python3 -m pytest validation/test_validate_ioc_complementarity.py -v
+```
+
+Expected: all tests still pass. (None reference these new fields, but this confirms the YAML still parses.)
+
+- [ ] **Step 4: Commit + push**
+
+```bash
+git add validation/logsource-taxonomy.yml
+git commit -m "feat(taxonomy): add embedded_component_class + embedded_native_lib to app_scanner (AndroDR #168)"
+git push -u origin feat/168-embedded-sdk-fields
+```
+
+- [ ] **Step 5: Open submodule PR + admin-merge**
+
+```bash
+gh pr create --base main --head feat/168-embedded-sdk-fields \
+  --title "feat(taxonomy): add embedded-SDK fields to app_scanner (AndroDR #168)" \
+  --body "Adds embedded_component_class + embedded_native_lib under app_scanner.fields, both list-typed. Used by AndroDR #168 scanner extension (parent: docs/superpowers/specs/2026-05-17-data-broker-sdk-scanner-design.md in AndroDR repo). No rule-side consumers in this submodule yet; rules land in AndroDR-side PRs after the scanner ships."
+gh pr merge --admin --squash --delete-branch
+```
+
+Capture the merged commit SHA — you will need it for the submodule pointer bump in Task 2:
+
+```bash
+git fetch origin main
+git rev-parse origin/main
+```
+
+---
+
+## PR boundary 2: AndroDR
+
+Back in `/home/yasir/AndroDR`. Single PR; tasks 2-7 belong here.
+
+### Task 2: Bump submodule pointer + create AndroDR feature branch
+
+**Files:**
+- Modify: `third-party/android-sigma-rules` (gitlink only)
+
+- [ ] **Step 1: Branch off main**
+
+```bash
+cd /home/yasir/AndroDR
+git checkout main
+git pull --ff-only origin main
+git checkout -b feat/168-app-scanner-embedded-sdk-signals
+```
+
+- [ ] **Step 2: Bump the submodule pointer to the freshly-merged taxonomy commit**
+
+```bash
+cd third-party/android-sigma-rules
+git fetch origin main
+git checkout main
+git pull --ff-only origin main
+cd ../..
+```
+
+- [ ] **Step 3: Stage + commit the pointer bump**
+
+```bash
+git add third-party/android-sigma-rules
+git -c commit.gpgsign=false commit -m "chore(submodule): bump android-sigma-rules for embedded-SDK fields (#168)"
+```
+
+(Drop the `gpgsign=false` if the project doesn't require it — match what prior `chore(submodule):` commits used; see `git log --grep "chore(submodule)"`.)
+
+### Task 3: Add `extractComponentClassNames` (TDD)
+
+**Files:**
+- Test: `app/src/test/java/com/androdr/scanner/AppScannerTelemetryTest.kt` (modify — append tests + helpers)
+- Modify: `app/src/main/java/com/androdr/scanner/AppScanner.kt` (add function)
+
+This task adds the pure-function extractor only. Wiring into `collectTelemetry()` happens in Task 5.
+
+- [ ] **Step 1: Write the failing test for the happy path**
+
+Open `app/src/test/java/com/androdr/scanner/AppScannerTelemetryTest.kt`. Append after the existing tests:
+
+```kotlin
+import android.content.pm.ProviderInfo
+import android.content.pm.ActivityInfo
+import android.content.pm.ServiceInfo
+
+@Test
+fun `extractComponentClassNames returns deduped sorted class names from all four component kinds`() {
+    val pkgInfo = PackageInfo().apply {
+        services = arrayOf(
+            ServiceInfo().apply { name = "com.outlogic.collector.GeoSyncService" },
+            ServiceInfo().apply { name = "com.example.legit.NormalService" }
+        )
+        receivers = arrayOf(
+            ActivityInfo().apply { name = "com.outlogic.collector.WakeReceiver" }
+        )
+        activities = arrayOf(
+            ActivityInfo().apply { name = "com.example.legit.MainActivity" },
+            ActivityInfo().apply { name = "com.example.legit.MainActivity" } // dup
+        )
+        providers = arrayOf(
+            ProviderInfo().apply { name = "com.example.legit.SettingsProvider" }
+        )
+    }
+
+    val result = scanner.extractComponentClassNames(pkgInfo)
+
+    assertEquals(
+        listOf(
+            "com.example.legit.MainActivity",
+            "com.example.legit.NormalService",
+            "com.example.legit.SettingsProvider",
+            "com.outlogic.collector.GeoSyncService",
+            "com.outlogic.collector.WakeReceiver"
+        ),
+        result
+    )
+}
+
+@Test
+fun `extractComponentClassNames returns emptyList when all four arrays are null`() {
+    val pkgInfo = PackageInfo().apply {
+        services = null
+        receivers = null
+        activities = null
+        providers = null
+    }
+    assertEquals(emptyList<String>(), scanner.extractComponentClassNames(pkgInfo))
+}
+
+@Test
+fun `extractComponentClassNames truncates to MAX_COMPONENTS_PER_APP`() {
+    val many = (1..2000).map { ActivityInfo().apply { name = "com.example.A$it" } }.toTypedArray()
+    val pkgInfo = PackageInfo().apply { activities = many; services = null; receivers = null; providers = null }
+    val result = scanner.extractComponentClassNames(pkgInfo)
+    assertEquals(1024, result.size)
+}
+```
+
+(`scanner` is the existing `AppScanner` instance built in this file's `@Before`. If that name differs in the actual `@Before`, match the existing field name — search the file for `lateinit var.*AppScanner` to confirm.)
+
+- [ ] **Step 2: Run the failing test**
+
+```bash
+export JAVA_HOME=/home/yasir/Applications/jdk-21
+./gradlew testDebugUnitTest --tests "com.androdr.scanner.AppScannerTelemetryTest"
+```
+
+Expected: compile error — `extractComponentClassNames` does not exist on `AppScanner`.
+
+- [ ] **Step 3: Add the function to `AppScanner.kt`**
+
+Open `app/src/main/java/com/androdr/scanner/AppScanner.kt`. Add this `internal` function inside the class (just below `collectTelemetry()` is the natural spot):
+
+```kotlin
+/**
+ * Returns deduped, sorted class names from a PackageInfo's services,
+ * receivers, activities, and providers arrays. Used downstream by SIGMA
+ * rules that fingerprint embedded SDKs by class-name prefix. See
+ * spec `docs/superpowers/specs/2026-05-17-data-broker-sdk-scanner-design.md`.
+ *
+ * Output is capped at [MAX_COMPONENTS_PER_APP] to bound memory against
+ * pathological/malicious manifests. Stable sort produces consistent
+ * diffs in scan history.
+ */
+internal fun extractComponentClassNames(packageInfo: PackageInfo): List<String> {
+    val out = LinkedHashSet<String>()
+    packageInfo.services?.forEach { it.name?.takeIf { n -> n.isNotBlank() }?.let { n -> out.add(n) } }
+    packageInfo.receivers?.forEach { it.name?.takeIf { n -> n.isNotBlank() }?.let { n -> out.add(n) } }
+    packageInfo.activities?.forEach { it.name?.takeIf { n -> n.isNotBlank() }?.let { n -> out.add(n) } }
+    packageInfo.providers?.forEach { it.name?.takeIf { n -> n.isNotBlank() }?.let { n -> out.add(n) } }
+    return out.asSequence().take(MAX_COMPONENTS_PER_APP).sorted().toList()
+}
+```
+
+Add the cap constant to the `companion object` (find the existing one in `AppScanner.kt` — there is one for `TAG` etc.):
+
+```kotlin
+companion object {
+    // existing entries unchanged
+    private const val MAX_COMPONENTS_PER_APP = 1024
+    private const val MAX_NATIVE_LIBS_PER_APP = 256
+}
+```
+
+(Add both constants together — Task 4 will use `MAX_NATIVE_LIBS_PER_APP`.)
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+./gradlew testDebugUnitTest --tests "com.androdr.scanner.AppScannerTelemetryTest.extractComponentClassNames*"
+```
+
+Expected: all three new test cases pass; no other tests break.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/java/com/androdr/scanner/AppScanner.kt \
+        app/src/test/java/com/androdr/scanner/AppScannerTelemetryTest.kt
+git -c commit.gpgsign=false commit -m "feat(scanner): extract manifest component class names (#168)"
+```
+
+### Task 4: Add `extractNativeLibFileNames` (TDD)
+
+**Files:**
+- Test: `app/src/test/java/com/androdr/scanner/AppScannerTelemetryTest.kt` (append tests)
+- Modify: `app/src/main/java/com/androdr/scanner/AppScanner.kt` (add function)
+
+The test builds a synthetic ZIP at runtime via `ZipOutputStream` — no binary fixture checked in.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `AppScannerTelemetryTest.kt`:
+
+```kotlin
+import java.io.File
+import java.io.FileOutputStream
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+import org.junit.rules.TemporaryFolder
+import org.junit.Rule
+
+// ... if @Rule already declared elsewhere in the class, don't redeclare; just reuse
+@get:Rule
+val tempFolder = TemporaryFolder()
+
+private fun buildSyntheticApk(name: String, entries: List<String>): File {
+    val file = tempFolder.newFile(name)
+    ZipOutputStream(FileOutputStream(file)).use { zip ->
+        for (entry in entries) {
+            zip.putNextEntry(ZipEntry(entry))
+            zip.write(byteArrayOf(0)) // placeholder body so the entry is well-formed
+            zip.closeEntry()
+        }
+    }
+    return file
+}
+
+@Test
+fun `extractNativeLibFileNames returns deduped leaf filenames across ABIs`() {
+    val apk = buildSyntheticApk("test.apk", listOf(
+        "AndroidManifest.xml",
+        "classes.dex",
+        "lib/arm64-v8a/libxmode.so",
+        "lib/arm64-v8a/libcollector.so",
+        "lib/x86_64/libxmode.so",                 // dup of arm64-v8a leaf
+        "lib/armeabi-v7a/libcollector.so",        // dup of arm64-v8a leaf
+        "lib/arm64-v8a/libunique.so",
+        "res/values/strings.xml"
+    ))
+    val appInfo = ApplicationInfo().apply { publicSourceDir = apk.absolutePath }
+
+    val result = scanner.extractNativeLibFileNames(appInfo)
+
+    assertEquals(listOf("libcollector.so", "libunique.so", "libxmode.so"), result)
+}
+
+@Test
+fun `extractNativeLibFileNames returns emptyList for a non-existent path`() {
+    val appInfo = ApplicationInfo().apply { publicSourceDir = "/does/not/exist.apk" }
+    assertEquals(emptyList<String>(), scanner.extractNativeLibFileNames(appInfo))
+}
+
+@Test
+fun `extractNativeLibFileNames returns emptyList for a corrupt zip`() {
+    val bogus = tempFolder.newFile("bogus.apk")
+    bogus.writeText("not a zip file")
+    val appInfo = ApplicationInfo().apply { publicSourceDir = bogus.absolutePath }
+    assertEquals(emptyList<String>(), scanner.extractNativeLibFileNames(appInfo))
+}
+
+@Test
+fun `extractNativeLibFileNames truncates to MAX_NATIVE_LIBS_PER_APP`() {
+    val entries = (1..400).map { "lib/arm64-v8a/lib$it.so" }
+    val apk = buildSyntheticApk("big.apk", entries)
+    val appInfo = ApplicationInfo().apply { publicSourceDir = apk.absolutePath }
+    val result = scanner.extractNativeLibFileNames(appInfo)
+    assertEquals(256, result.size)
+}
+```
+
+- [ ] **Step 2: Run the failing tests**
+
+```bash
+./gradlew testDebugUnitTest --tests "com.androdr.scanner.AppScannerTelemetryTest.extractNativeLibFileNames*"
+```
+
+Expected: compile error — `extractNativeLibFileNames` not found.
+
+- [ ] **Step 3: Add the function to `AppScanner.kt`**
+
+Add an import: `import java.util.zip.ZipFile`. Then add this `internal` function next to `extractComponentClassNames`:
+
+```kotlin
+/**
+ * Returns deduped, sorted leaf filenames of native libraries embedded
+ * in the APK at [applicationInfo.publicSourceDir]. ABI prefix is stripped
+ * so `lib/arm64-v8a/libxmode.so` and `lib/x86_64/libxmode.so` collapse
+ * to a single `libxmode.so` entry. Output is capped at
+ * [MAX_NATIVE_LIBS_PER_APP]. Failures (unreadable APK, corrupt zip) are
+ * logged and produce an empty list — never thrown — so one bad APK
+ * cannot abort the whole scan.
+ */
+@Suppress("TooGenericExceptionCaught", "SwallowedException")
+internal fun extractNativeLibFileNames(applicationInfo: ApplicationInfo): List<String> {
+    val path = applicationInfo.publicSourceDir ?: return emptyList()
+    val out = LinkedHashSet<String>()
+    try {
+        ZipFile(path).use { zip ->
+            val entries = zip.entries()
+            while (entries.hasMoreElements()) {
+                val name = entries.nextElement().name
+                if (name.startsWith("lib/") && name.endsWith(".so")) {
+                    val leaf = name.substringAfterLast('/')
+                    if (leaf.isNotBlank()) out.add(leaf)
+                }
+            }
+        }
+    } catch (e: Exception) {
+        Log.w(TAG, "extractNativeLibFileNames failed for $path: ${e.message}")
+        return emptyList()
+    }
+    return out.asSequence().take(MAX_NATIVE_LIBS_PER_APP).sorted().toList()
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+./gradlew testDebugUnitTest --tests "com.androdr.scanner.AppScannerTelemetryTest.extractNativeLibFileNames*"
+```
+
+Expected: all four new test cases pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/java/com/androdr/scanner/AppScanner.kt \
+        app/src/test/java/com/androdr/scanner/AppScannerTelemetryTest.kt
+git -c commit.gpgsign=false commit -m "feat(scanner): extract embedded native lib filenames (#168)"
+```
+
+### Task 5: Add fields to `AppTelemetry` and wire extractors into `collectTelemetry()`
+
+**Files:**
+- Modify: `app/src/main/java/com/androdr/data/model/AppTelemetry.kt`
+- Modify: `app/src/main/java/com/androdr/scanner/AppScanner.kt` (`collectTelemetry()`)
+- Test: `app/src/test/java/com/androdr/scanner/AppScannerTelemetryTest.kt` (integration test on the full pipeline)
+
+- [ ] **Step 1: Write the failing integration test**
+
+Append to `AppScannerTelemetryTest.kt`:
+
+```kotlin
+@Test
+fun `collectTelemetry populates embeddedComponentClasses and embeddedNativeLibs`() = runTest {
+    // Use the existing test scaffolding to install a stub package via
+    // the same `packageManager` mockk that other tests in this file
+    // already program. The pattern is: every { packageManager.getInstalledPackages(any()) }
+    // returns a list including a PackageInfo whose services/receivers/etc
+    // and applicationInfo.publicSourceDir are set to the synthetic APK from buildSyntheticApk.
+    //
+    // If unsure how the existing `@Before` builds the mock, copy the
+    // pattern from `collectTelemetry returns expected metadata for an installed app`
+    // (or the closest equivalent already in this file).
+
+    val apk = buildSyntheticApk("integration.apk", listOf("lib/arm64-v8a/libxmode.so"))
+    val pkgInfo = PackageInfo().apply {
+        packageName = "com.example.broker"
+        applicationInfo = ApplicationInfo().apply {
+            publicSourceDir = apk.absolutePath
+            sourceDir = apk.absolutePath
+        }
+        services = arrayOf(ServiceInfo().apply { name = "com.outlogic.GeoCollectorService" })
+        receivers = null
+        activities = arrayOf(ActivityInfo().apply { name = "com.example.broker.MainActivity" })
+        providers = null
+    }
+    every { packageManager.getInstalledPackages(any<Int>()) } returns listOf(pkgInfo)
+
+    val telemetry = scanner.collectTelemetry()
+
+    val entry = telemetry.single { it.packageName == "com.example.broker" }
+    assertEquals(
+        listOf("com.example.broker.MainActivity", "com.outlogic.GeoCollectorService"),
+        entry.embeddedComponentClasses
+    )
+    assertEquals(listOf("libxmode.so"), entry.embeddedNativeLibs)
+}
+```
+
+If `every { packageManager.getInstalledPackages(...) }` isn't already set up in this file, match the existing pattern from `AppScannerTelemetryTest` (search the file for `getInstalledPackages` to see how other tests stub it).
+
+- [ ] **Step 2: Run the failing test**
+
+```bash
+./gradlew testDebugUnitTest --tests "com.androdr.scanner.AppScannerTelemetryTest.collectTelemetry populates embeddedComponentClasses*"
+```
+
+Expected: compile error — `embeddedComponentClasses` and `embeddedNativeLibs` don't exist on `AppTelemetry` yet.
+
+- [ ] **Step 3: Add the two fields to `AppTelemetry`**
+
+Open `app/src/main/java/com/androdr/data/model/AppTelemetry.kt`. Find the data class declaration. Add these two fields **at the end** of the constructor parameter list, both with `= emptyList()` defaults so no existing call sites need updating:
+
+```kotlin
+// ... existing fields ...
+val firstInstallTime: Long = 0L,
+val lastUpdateTime: Long = 0L,
+val source: TelemetrySource,
+// NEW (#168):
+val embeddedComponentClasses: List<String> = emptyList(),
+val embeddedNativeLibs: List<String> = emptyList(),
+```
+
+If the data class has a trailing field or different shape, the principle is: append, never insert; default to `emptyList()`; no behavior change for callers that don't pass them.
+
+- [ ] **Step 4: Wire the extractors into `collectTelemetry()`**
+
+In `AppScanner.kt`, find the body of `collectTelemetry()` where each `AppTelemetry(...)` is constructed. Just before constructing the `AppTelemetry`, compute:
+
+```kotlin
+val embeddedComponentClasses = extractComponentClassNames(packageInfo)
+val embeddedNativeLibs = extractNativeLibFileNames(packageInfo.applicationInfo)
+```
+
+Then pass them to the constructor:
+
+```kotlin
+AppTelemetry(
+    // ... existing args ...
+    source = TelemetrySource.RUNTIME,
+    embeddedComponentClasses = embeddedComponentClasses,
+    embeddedNativeLibs = embeddedNativeLibs,
+)
+```
+
+- [ ] **Step 5: Run the integration test**
+
+```bash
+./gradlew testDebugUnitTest --tests "com.androdr.scanner.AppScannerTelemetryTest.collectTelemetry populates embeddedComponentClasses*"
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Run the entire AppScannerTelemetryTest to check nothing else broke**
+
+```bash
+./gradlew testDebugUnitTest --tests "com.androdr.scanner.AppScannerTelemetryTest"
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/src/main/java/com/androdr/data/model/AppTelemetry.kt \
+        app/src/main/java/com/androdr/scanner/AppScanner.kt \
+        app/src/test/java/com/androdr/scanner/AppScannerTelemetryTest.kt
+git -c commit.gpgsign=false commit -m "feat(scanner): wire embedded-SDK signals into AppTelemetry (#168)"
+```
+
+### Task 6: Schema cross-check + lint + full unit test sweep
+
+**Files:** (none modified; this is a verification gate)
+
+- [ ] **Step 1: Run the schema cross-check test**
+
+```bash
+./gradlew testDebugUnitTest --tests "com.androdr.sigma.BundledRulesSchemaCrossCheckTest"
+```
+
+Expected: PASS. The two new YAML fields (in the bumped submodule) now have matching Kotlin properties on `AppTelemetry`.
+
+If it fails with "field X declared in YAML but not in Kotlin": you misnamed a field — YAML uses `embedded_component_class` / `embedded_native_lib` (snake_case), Kotlin uses `embeddedComponentClasses` / `embeddedNativeLibs` (camelCase). The cross-check converts between cases; if it complains, the case-conversion expects exactly that mapping.
+
+If it fails with "field Y declared in Kotlin but not in YAML": submodule pointer wasn't bumped, or the submodule PR didn't include both fields. Fix and re-run.
+
+- [ ] **Step 2: Run lint**
+
+```bash
+./gradlew lintDebug
+```
+
+Expected: BUILD SUCCESSFUL. The new code uses only existing project imports and patterns; no new lint baseline should be needed.
+
+- [ ] **Step 3: Run the full unit test suite to catch unrelated regressions**
+
+```bash
+./gradlew testDebugUnitTest
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 4: Build the debug APK**
+
+```bash
+./gradlew assembleDebug
+```
+
+Expected: BUILD SUCCESSFUL. APK at `app/build/outputs/apk/debug/app-debug.apk`.
+
+### Task 7: On-device sanity check
+
+**Files:** (none modified; on-device verification)
+
+- [ ] **Step 1: Install the new APK on the test phone**
+
+```bash
+ADB=/home/yasir/Android/Sdk/platform-tools/adb
+$ADB devices    # confirm device is listed as "device", not "unauthorized"
+$ADB install -r app/build/outputs/apk/debug/app-debug.apk
+```
+
+Expected: `Success`.
+
+- [ ] **Step 2: Add a one-time debug log so on-device verification is possible**
+
+In `AppScanner.collectTelemetry()`, after building the full `List<AppTelemetry>`, add a debug-only summary log (the spec promises this in the acceptance criteria):
+
+```kotlin
+val telemetryList = installed.map { /* ... existing construction ... */ }
+Log.d(TAG, "collectTelemetry: ${telemetryList.size} apps, " +
+    "${telemetryList.count { it.embeddedComponentClasses.isNotEmpty() }} with components, " +
+    "${telemetryList.count { it.embeddedNativeLibs.isNotEmpty() }} with native libs")
+return@withContext telemetryList
+```
+
+Place this immediately before the existing return statement of `collectTelemetry()`. The exact return shape may vary — match what's already there.
+
+- [ ] **Step 3: Rebuild and reinstall**
+
+```bash
+./gradlew assembleDebug
+$ADB install -r app/build/outputs/apk/debug/app-debug.apk
+```
+
+- [ ] **Step 4: Launch the app + trigger a scan**
+
+```bash
+$ADB shell am start -W -n com.androdr.debug/com.androdr.MainActivity
+```
+
+Then in the device UI: Dashboard → "Run Scan". Wait for completion (a few seconds on a low-app-count test phone).
+
+- [ ] **Step 5: Confirm the debug log fires with non-zero counts**
+
+```bash
+$ADB logcat -d -s AppScanner:D | tail -20
+```
+
+Expected: a line of the form `collectTelemetry: N apps, M with components, K with native libs`. `M` should be roughly equal to `N` (every app has at least a launcher activity), and `K` should be at least 1 (Google Play Services / Chrome / similar will have native libs).
+
+If `M == 0`: the wiring in Task 5 didn't take effect; double-check the field is passed to the AppTelemetry constructor.
+If `K == 0` on a phone with Google Play Services installed: the ZIP iteration is broken or `applicationInfo.publicSourceDir` is empty; add a transient `Log.d` at the top of `extractNativeLibFileNames` to confirm the path and re-run.
+
+- [ ] **Step 6: Commit the debug log**
+
+```bash
+git add app/src/main/java/com/androdr/scanner/AppScanner.kt
+git -c commit.gpgsign=false commit -m "chore(scanner): one-time debug log of embedded-SDK signal counts (#168)"
+```
+
+### Task 8: Two-reviewer cycle + PR
+
+**Files:** (none modified; review + PR ceremony)
+
+- [ ] **Step 1: Dispatch both reviewers in parallel via the Agent tool**
+
+Use the `Agent` tool to launch **two background agents** with non-overlapping mandates. Use these exact prompt templates (truncate file paths if your wrapper requires it):
+
+**Spec compliance reviewer** (subagent_type: `general-purpose`):
+
+> You are the Spec Compliance Reviewer. Personality: strict, literal. Verify the implementation matches `docs/superpowers/specs/2026-05-17-data-broker-sdk-scanner-design.md` line-by-line. For each acceptance criterion in the spec, point to a file:line where it's implemented. End with VERDICT: PASS or FAIL. Files: `app/src/main/java/com/androdr/data/model/AppTelemetry.kt`, `app/src/main/java/com/androdr/scanner/AppScanner.kt`, `app/src/test/java/com/androdr/scanner/AppScannerTelemetryTest.kt`. Submodule taxonomy change is in `third-party/android-sigma-rules/validation/logsource-taxonomy.yml`.
+
+**Harsh quality reviewer** (subagent_type: `git-pr-workflows:code-reviewer`):
+
+> You are the Harsh Code Quality Reviewer. Personality: skeptical, no participation trophies. Find bugs, footguns, missed edge cases, lifecycle issues. Same files as the spec reviewer. Specifically check: (1) does `extractNativeLibFileNames` correctly handle the AAB / split-APK case where `applicationInfo.splitPublicSourceDirs` carries additional .so files? (2) does `extractComponentClassNames` correctly handle null elements within the services/receivers/activities/providers arrays (mocking permits this; real Android sometimes does too)? (3) does the cap truncation happen BEFORE or AFTER sorting — and which is correct? (4) does the new debug log leak PII? (5) what happens if the same APK is opened concurrently from two threads — is `ZipFile.use` safe? Output: severity-tagged bullet list ending in NO BLOCKERS — APPROVE FOR MERGE or DO NOT APPROVE.
+
+- [ ] **Step 2: Wait for both reviewer notifications**
+
+Don't poll; the harness notifies you when each completes.
+
+- [ ] **Step 3: Triage findings + fix accepted ones**
+
+For each BLOCKER/MAJOR: either accept (fix it in the code, commit with a message like `fix(scanner): <issue> per harsh review (#168)`) or reject with documented reasoning to be cited in the PR body. Mirror the pattern from PR #177's review-triage table.
+
+- [ ] **Step 4: Push the branch**
+
+```bash
+git push -u origin feat/168-app-scanner-embedded-sdk-signals
+```
+
+- [ ] **Step 5: Open the AndroDR PR**
+
+```bash
+gh pr create --base main --head feat/168-app-scanner-embedded-sdk-signals \
+  --title "feat(scanner): emit embedded-SDK signals for AppTelemetry (#168)" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Implements the scanner extension specified in docs/superpowers/specs/2026-05-17-data-broker-sdk-scanner-design.md. Adds two list-typed fields to AppTelemetry — embeddedComponentClasses and embeddedNativeLibs — and the corresponding extraction logic in AppScanner. Prereq for issue #168 (data-broker SDK detection rule pack); rule packs follow in separate PRs.
+
+## What changed
+
+- Submodule bumped: logsource-taxonomy.yml now declares embedded_component_class + embedded_native_lib under app_scanner.fields.
+- AppTelemetry: two new list fields, both default emptyList() so no caller breaks.
+- AppScanner: two new internal extractors (extractComponentClassNames, extractNativeLibFileNames) called from collectTelemetry().
+- Tests: per-extractor unit tests plus a wiring integration test.
+- A one-time debug log in collectTelemetry() reports per-scan counts so on-device verification doesn't need a Room round-trip.
+
+## Two-reviewer cycle
+- Spec reviewer verdict + evidence
+- Harsh reviewer findings + triage table
+
+## Test plan
+- ./gradlew testDebugUnitTest — all tests pass (count: ___)
+- ./gradlew lintDebug — BUILD SUCCESSFUL
+- ./gradlew assembleDebug — BUILD SUCCESSFUL
+- adb install on Z Fold 2 (R3CR300WRRH) — Success; logcat shows non-zero component/native-lib counts
+
+Closes nothing yet — issue #168 stays open. This is the first of several PRs.
+
+Refs #168
+EOF
+)"
+```
+
+- [ ] **Step 6: Admin-merge (GHA is out of budget per CLAUDE.md memory)**
+
+```bash
+gh pr merge --admin --squash --delete-branch
+```
+
+- [ ] **Step 7: Sync local main**
+
+```bash
+git checkout main
+git pull --ff-only origin main
+git log --oneline -3
+```
+
+Expected: the squash-merge commit at HEAD, with the matching `feat(scanner)` subject.
+
+---
+
+## Done criteria
+
+- Submodule PR merged with the two new taxonomy entries.
+- AndroDR PR merged with the AppTelemetry + AppScanner changes.
+- `BundledRulesSchemaCrossCheckTest` passes.
+- On-device debug log confirms non-zero embedded-component and native-lib counts.
+- Two-reviewer cycle completed with all BLOCKERs and MAJORs resolved or documented as rejected.
+
+After this lands, the next session can brainstorm the **SIR research** sub-spec (which broker SDKs to fingerprint, what evidence per SDK), then move on to authoring the `installed_app` rule pack that consumes these new fields.

--- a/docs/superpowers/plans/2026-05-17-data-broker-sdk-scanner-plan.md
+++ b/docs/superpowers/plans/2026-05-17-data-broker-sdk-scanner-plan.md
@@ -421,7 +421,7 @@ git -c commit.gpgsign=false commit -m "feat(scanner): extract embedded native li
 
 - [ ] **Step 1: Write the failing integration test**
 
-Append to `AppScannerTelemetryTest.kt`. The existing mock fixture in this file already programs `every { packageManager.getInstalledPackages(any<Int>()) }` — the new test reuses that mockk wiring by overriding the return value just for this case.
+Append to `AppScannerTelemetryTest.kt`. The existing file already has an `installPackages(vararg packages: PackageInfo)` helper at line 91 that programs the mockk `pm` (PackageManager mock, declared at line 28 as `private lateinit var pm: PackageManager`) with `every { pm.getInstalledPackages(any<Int>()) } returns ...`. Use that helper — do NOT reach into `pm` directly and do NOT use a different mock name (the variable is `pm`, not `packageManager`).
 
 ```kotlin
 @Test
@@ -445,7 +445,7 @@ fun `collectTelemetry populates embeddedComponentClasses and embeddedNativeLibs`
         )
         providers = null
     }
-    every { packageManager.getInstalledPackages(any<Int>()) } returns listOf(pkgInfo)
+    installPackages(pkgInfo)
 
     val telemetry = scanner.collectTelemetry()
 
@@ -521,12 +521,11 @@ val embeddedComponentClasses = extractComponentClassNames(pkg)
 val embeddedNativeLibs = extractNativeLibFileNames(appInfo)
 ```
 
-Then pass them as the last two named arguments to the constructor:
+Then pass them as the last two named arguments to the constructor. The existing call at AppScanner.kt:250 has `source = TelemetrySource.LIVE_SCAN` at line 271 — leave that and every other existing named arg untouched; only add the two new lines:
 
 ```kotlin
 return AppTelemetry(
-    // ... all existing named args, unchanged ...
-    source = TelemetrySource.RUNTIME,
+    // ... all existing named args, unchanged — including source = TelemetrySource.LIVE_SCAN ...
     embeddedComponentClasses = embeddedComponentClasses,
     embeddedNativeLibs = embeddedNativeLibs,
 )

--- a/docs/superpowers/plans/2026-05-17-data-broker-sdk-scanner-plan.md
+++ b/docs/superpowers/plans/2026-05-17-data-broker-sdk-scanner-plan.md
@@ -4,7 +4,7 @@
 
 **Goal:** Extend `AppScanner` to emit two new list-typed telemetry fields — `embeddedComponentClasses` and `embeddedNativeLibs` — so subsequent rule packs can fingerprint ad-broker SDKs that ship embedded inside otherwise-mainstream apps.
 
-**Architecture:** Two pure-function extractors added as `internal` members of `AppScanner`. Manifest extractor reads `.name` from `PackageInfo.services|receivers|activities|providers`. Native-libs extractor opens the APK via `applicationInfo.publicSourceDir` as a `ZipFile` and lists `lib/*/*.so` entries. Output is appended to `AppTelemetry` (Approach A, per spec). Schema parity enforced by `BundledRulesSchemaCrossCheckTest` after coordinated submodule taxonomy update.
+**Architecture:** Two pure-function extractors added as `internal` members of `AppScanner`. Manifest extractor reads `.name` from `PackageInfo.services|receivers|activities|providers`. Native-libs extractor opens the APK via `applicationInfo.publicSourceDir` as a `ZipFile` and lists `lib/*/*.so` entries. Output is appended to `AppTelemetry` (Approach A, per spec). Schema parity enforced by `LogsourceTaxonomyCrossCheckTest` after coordinated submodule taxonomy update.
 
 **Tech Stack:** Kotlin, AndroidX, Hilt, JUnit4, mockk, `java.util.zip.ZipFile`, `java.util.zip.ZipOutputStream` (test fixture building).
 
@@ -25,11 +25,12 @@ This work happens in `/home/yasir/AndroDR/third-party/android-sigma-rules/`. Ope
 
 - [ ] **Step 1: Create the submodule branch**
 
+The submodule is pinned by AndroDR to a specific commit, so the local `main` branch may be behind `origin/main`. Fetch then branch off `origin/main` directly — avoids `--ff-only` failure if local main is stale.
+
 ```bash
 cd third-party/android-sigma-rules
-git checkout main
-git pull --ff-only origin main
-git checkout -b feat/168-embedded-sdk-fields
+git fetch origin main
+git checkout -b feat/168-embedded-sdk-fields origin/main
 ```
 
 - [ ] **Step 2: Insert the two new field entries**
@@ -63,11 +64,13 @@ git push -u origin feat/168-embedded-sdk-fields
 - [ ] **Step 5: Open submodule PR + admin-merge**
 
 ```bash
-gh pr create --base main --head feat/168-embedded-sdk-fields \
+gh pr create --repo android-sigma-rules/rules --base main --head feat/168-embedded-sdk-fields \
   --title "feat(taxonomy): add embedded-SDK fields to app_scanner (AndroDR #168)" \
   --body "Adds embedded_component_class + embedded_native_lib under app_scanner.fields, both list-typed. Used by AndroDR #168 scanner extension (parent: docs/superpowers/specs/2026-05-17-data-broker-sdk-scanner-design.md in AndroDR repo). No rule-side consumers in this submodule yet; rules land in AndroDR-side PRs after the scanner ships."
-gh pr merge --admin --squash --delete-branch
+gh pr merge --repo android-sigma-rules/rules --admin --squash --delete-branch feat/168-embedded-sdk-fields
 ```
+
+(Pass `--repo` explicitly because the engineer may be running `gh` from the parent AndroDR working directory, where gh would otherwise default to the AndroDR repo.)
 
 Capture the merged commit SHA — you will need it for the submodule pointer bump in Task 2:
 
@@ -177,11 +180,15 @@ fun `extractComponentClassNames returns emptyList when all four arrays are null`
 }
 
 @Test
-fun `extractComponentClassNames truncates to MAX_COMPONENTS_PER_APP`() {
+fun `extractComponentClassNames truncates to MAX_COMPONENTS_PER_APP and keeps lexicographically-first entries`() {
     val many = (1..2000).map { ActivityInfo().apply { name = "com.example.A$it" } }.toTypedArray()
     val pkgInfo = PackageInfo().apply { activities = many; services = null; receivers = null; providers = null }
     val result = scanner.extractComponentClassNames(pkgInfo)
+    // 1024-cap fires.
     assertEquals(1024, result.size)
+    // sort-then-take guarantees lexicographic stability — the smallest name survives.
+    // ("com.example.A1" lex-precedes "com.example.A1000", "A1001", ..., as well as "A2".)
+    assertEquals("com.example.A1", result.first())
 }
 ```
 
@@ -208,8 +215,10 @@ Open `app/src/main/java/com/androdr/scanner/AppScanner.kt`. Add this `internal` 
  * spec `docs/superpowers/specs/2026-05-17-data-broker-sdk-scanner-design.md`.
  *
  * Output is capped at [MAX_COMPONENTS_PER_APP] to bound memory against
- * pathological/malicious manifests. Stable sort produces consistent
- * diffs in scan history.
+ * pathological/malicious manifests. Sort happens BEFORE truncation so
+ * the truncated subset is the lexicographically-first N — stable under
+ * small manifest perturbations (a manifest gaining one component
+ * doesn't shift the survival window arbitrarily).
  */
 internal fun extractComponentClassNames(packageInfo: PackageInfo): List<String> {
     val out = LinkedHashSet<String>()
@@ -217,21 +226,26 @@ internal fun extractComponentClassNames(packageInfo: PackageInfo): List<String> 
     packageInfo.receivers?.forEach { it.name?.takeIf { n -> n.isNotBlank() }?.let { n -> out.add(n) } }
     packageInfo.activities?.forEach { it.name?.takeIf { n -> n.isNotBlank() }?.let { n -> out.add(n) } }
     packageInfo.providers?.forEach { it.name?.takeIf { n -> n.isNotBlank() }?.let { n -> out.add(n) } }
-    return out.asSequence().take(MAX_COMPONENTS_PER_APP).sorted().toList()
+    return out.asSequence().sorted().take(MAX_COMPONENTS_PER_APP).toList()
 }
 ```
 
-Add the cap constant to the `companion object` (find the existing one in `AppScanner.kt` — there is one for `TAG` etc.):
+Add the cap constants **INSIDE the existing `private companion object`** at the top of the class (around line 35-49, alongside `TAG` and `TELEMETRY_PARALLELISM`). Do NOT declare a second `companion object` — Kotlin will reject the redeclaration. The block should end up looking like:
 
 ```kotlin
-companion object {
-    // existing entries unchanged
+private companion object {
+    private const val TAG = "AppScanner"
+
+    /** ... existing TELEMETRY_PARALLELISM kdoc ... */
+    private const val TELEMETRY_PARALLELISM = 16
+
+    // NEW (#168):
     private const val MAX_COMPONENTS_PER_APP = 1024
     private const val MAX_NATIVE_LIBS_PER_APP = 256
 }
 ```
 
-(Add both constants together — Task 4 will use `MAX_NATIVE_LIBS_PER_APP`.)
+(Both consts go in this task — Task 4 will reference `MAX_NATIVE_LIBS_PER_APP`.)
 
 - [ ] **Step 4: Run the test to verify it passes**
 
@@ -259,7 +273,7 @@ The test builds a synthetic ZIP at runtime via `ZipOutputStream` — no binary f
 
 - [ ] **Step 1: Write the failing tests**
 
-Append to `AppScannerTelemetryTest.kt`:
+**Imports** — add at file top with the other `import` lines (not adjacent to the test methods):
 
 ```kotlin
 import java.io.File
@@ -268,8 +282,11 @@ import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
 import org.junit.rules.TemporaryFolder
 import org.junit.Rule
+```
 
-// ... if @Rule already declared elsewhere in the class, don't redeclare; just reuse
+**Class-level rule + helper** — place these at class scope (not inside any `@Test` method), alongside the existing `lateinit var scanner: AppScanner` declaration near the top of the class body. If a `@get:Rule TemporaryFolder` already exists in this file, reuse it and skip this declaration; do NOT redeclare.
+
+```kotlin
 @get:Rule
 val tempFolder = TemporaryFolder()
 
@@ -319,12 +336,15 @@ fun `extractNativeLibFileNames returns emptyList for a corrupt zip`() {
 }
 
 @Test
-fun `extractNativeLibFileNames truncates to MAX_NATIVE_LIBS_PER_APP`() {
+fun `extractNativeLibFileNames truncates to MAX_NATIVE_LIBS_PER_APP and keeps lexicographically-first entries`() {
     val entries = (1..400).map { "lib/arm64-v8a/lib$it.so" }
     val apk = buildSyntheticApk("big.apk", entries)
     val appInfo = ApplicationInfo().apply { publicSourceDir = apk.absolutePath }
     val result = scanner.extractNativeLibFileNames(appInfo)
     assertEquals(256, result.size)
+    // sort-then-take guarantees lexicographic stability — "lib1.so" precedes
+    // "lib100.so", "lib1000.so" (well there is no lib1000 but lib100 yes), etc.
+    assertEquals("lib1.so", result.first())
 }
 ```
 
@@ -346,9 +366,11 @@ Add an import: `import java.util.zip.ZipFile`. Then add this `internal` function
  * in the APK at [applicationInfo.publicSourceDir]. ABI prefix is stripped
  * so `lib/arm64-v8a/libxmode.so` and `lib/x86_64/libxmode.so` collapse
  * to a single `libxmode.so` entry. Output is capped at
- * [MAX_NATIVE_LIBS_PER_APP]. Failures (unreadable APK, corrupt zip) are
- * logged and produce an empty list — never thrown — so one bad APK
- * cannot abort the whole scan.
+ * [MAX_NATIVE_LIBS_PER_APP]. Sort happens BEFORE truncation so the
+ * surviving subset is the lexicographically-first N (deterministic
+ * under small APK perturbations). Failures (unreadable APK, corrupt
+ * zip) are logged and produce an empty list — never thrown — so one
+ * bad APK cannot abort the whole scan.
  */
 @Suppress("TooGenericExceptionCaught", "SwallowedException")
 internal fun extractNativeLibFileNames(applicationInfo: ApplicationInfo): List<String> {
@@ -369,7 +391,7 @@ internal fun extractNativeLibFileNames(applicationInfo: ApplicationInfo): List<S
         Log.w(TAG, "extractNativeLibFileNames failed for $path: ${e.message}")
         return emptyList()
     }
-    return out.asSequence().take(MAX_NATIVE_LIBS_PER_APP).sorted().toList()
+    return out.asSequence().sorted().take(MAX_NATIVE_LIBS_PER_APP).toList()
 }
 ```
 
@@ -398,22 +420,14 @@ git -c commit.gpgsign=false commit -m "feat(scanner): extract embedded native li
 
 - [ ] **Step 1: Write the failing integration test**
 
-Append to `AppScannerTelemetryTest.kt`:
+Append to `AppScannerTelemetryTest.kt`. The existing mock fixture in this file already programs `every { packageManager.getInstalledPackages(any<Int>()) }` — the new test reuses that mockk wiring by overriding the return value just for this case.
 
 ```kotlin
 @Test
 fun `collectTelemetry populates embeddedComponentClasses and embeddedNativeLibs`() = runTest {
-    // Use the existing test scaffolding to install a stub package via
-    // the same `packageManager` mockk that other tests in this file
-    // already program. The pattern is: every { packageManager.getInstalledPackages(any()) }
-    // returns a list including a PackageInfo whose services/receivers/etc
-    // and applicationInfo.publicSourceDir are set to the synthetic APK from buildSyntheticApk.
-    //
-    // If unsure how the existing `@Before` builds the mock, copy the
-    // pattern from `collectTelemetry returns expected metadata for an installed app`
-    // (or the closest equivalent already in this file).
-
-    val apk = buildSyntheticApk("integration.apk", listOf("lib/arm64-v8a/libxmode.so"))
+    val apk = buildSyntheticApk("integration.apk", listOf(
+        "lib/arm64-v8a/libxmode.so"
+    ))
     val pkgInfo = PackageInfo().apply {
         packageName = "com.example.broker"
         applicationInfo = ApplicationInfo().apply {
@@ -422,7 +436,12 @@ fun `collectTelemetry populates embeddedComponentClasses and embeddedNativeLibs`
         }
         services = arrayOf(ServiceInfo().apply { name = "com.outlogic.GeoCollectorService" })
         receivers = null
-        activities = arrayOf(ActivityInfo().apply { name = "com.example.broker.MainActivity" })
+        // Three activities chosen so the lex-sort behavior is observable:
+        // "com.example.broker.MainActivity" < "com.outlogic.GeoCollectorService" < "com.zzz.LastActivity"
+        activities = arrayOf(
+            ActivityInfo().apply { name = "com.example.broker.MainActivity" },
+            ActivityInfo().apply { name = "com.zzz.LastActivity" }
+        )
         providers = null
     }
     every { packageManager.getInstalledPackages(any<Int>()) } returns listOf(pkgInfo)
@@ -431,14 +450,16 @@ fun `collectTelemetry populates embeddedComponentClasses and embeddedNativeLibs`
 
     val entry = telemetry.single { it.packageName == "com.example.broker" }
     assertEquals(
-        listOf("com.example.broker.MainActivity", "com.outlogic.GeoCollectorService"),
+        listOf(
+            "com.example.broker.MainActivity",
+            "com.outlogic.GeoCollectorService",
+            "com.zzz.LastActivity"
+        ),
         entry.embeddedComponentClasses
     )
     assertEquals(listOf("libxmode.so"), entry.embeddedNativeLibs)
 }
 ```
-
-If `every { packageManager.getInstalledPackages(...) }` isn't already set up in this file, match the existing pattern from `AppScannerTelemetryTest` (search the file for `getInstalledPackages` to see how other tests stub it).
 
 - [ ] **Step 2: Run the failing test**
 
@@ -450,21 +471,36 @@ Expected: compile error — `embeddedComponentClasses` and `embeddedNativeLibs` 
 
 - [ ] **Step 3: Add the two fields to `AppTelemetry`**
 
-Open `app/src/main/java/com/androdr/data/model/AppTelemetry.kt`. Find the data class declaration. Add these two fields **at the end** of the constructor parameter list, both with `= emptyList()` defaults so no existing call sites need updating:
+Open `app/src/main/java/com/androdr/data/model/AppTelemetry.kt`. The constructor currently ends with `val source: TelemetrySource,` at line 37 followed by `) {` at line 38. Insert the two new fields between `source` and the closing `)`. Both default to `emptyList()` so existing call sites that don't pass them are unaffected:
 
 ```kotlin
-// ... existing fields ...
-val firstInstallTime: Long = 0L,
-val lastUpdateTime: Long = 0L,
-val source: TelemetrySource,
-// NEW (#168):
-val embeddedComponentClasses: List<String> = emptyList(),
-val embeddedNativeLibs: List<String> = emptyList(),
+    val firstInstallTime: Long = 0L,
+    val lastUpdateTime: Long = 0L,
+    val source: TelemetrySource,
+    // NEW (#168):
+    val embeddedComponentClasses: List<String> = emptyList(),
+    val embeddedNativeLibs: List<String> = emptyList(),
+) {
 ```
 
-If the data class has a trailing field or different shape, the principle is: append, never insert; default to `emptyList()`; no behavior change for callers that don't pass them.
+- [ ] **Step 4: Add the two keys to `toFieldMap()`**
 
-- [ ] **Step 4: Wire the extractors into `collectTelemetry()`**
+`AppTelemetry.toFieldMap()` (at line 39) is what `LogsourceTaxonomyCrossCheckTest` inspects — adding constructor fields alone won't make the cross-check happy because the test compares `toFieldMap().keys` against the taxonomy YAML. Append the two new entries at the end of the map (after `"last_update_time" to lastUpdateTime`):
+
+```kotlin
+    fun toFieldMap(): Map<String, Any?> = mapOf(
+        // ... existing entries unchanged ...
+        "first_install_time" to firstInstallTime,
+        "last_update_time" to lastUpdateTime,
+        // NEW (#168):
+        "embedded_component_class" to embeddedComponentClasses,
+        "embedded_native_lib" to embeddedNativeLibs
+    )
+```
+
+The snake_case map keys must match the taxonomy YAML byte-for-byte; the cross-check does NOT do case conversion. `LogsourceTaxonomyCrossCheckTest.kt` itself does NOT need to be modified — its `memberFunctionFieldMaps()` constructs `AppTelemetry(...)` with named args and the two new fields take their `emptyList()` defaults without breaking the call.
+
+- [ ] **Step 5: Wire the extractors into `collectTelemetry()`**
 
 In `AppScanner.kt`, find the body of `collectTelemetry()` where each `AppTelemetry(...)` is constructed. Just before constructing the `AppTelemetry`, compute:
 
@@ -484,7 +520,7 @@ AppTelemetry(
 )
 ```
 
-- [ ] **Step 5: Run the integration test**
+- [ ] **Step 6: Run the integration test**
 
 ```bash
 ./gradlew testDebugUnitTest --tests "com.androdr.scanner.AppScannerTelemetryTest.collectTelemetry populates embeddedComponentClasses*"
@@ -492,7 +528,7 @@ AppTelemetry(
 
 Expected: PASS.
 
-- [ ] **Step 6: Run the entire AppScannerTelemetryTest to check nothing else broke**
+- [ ] **Step 7: Run the entire AppScannerTelemetryTest to check nothing else broke**
 
 ```bash
 ./gradlew testDebugUnitTest --tests "com.androdr.scanner.AppScannerTelemetryTest"
@@ -500,7 +536,7 @@ Expected: PASS.
 
 Expected: all tests pass.
 
-- [ ] **Step 7: Commit**
+- [ ] **Step 8: Commit**
 
 ```bash
 git add app/src/main/java/com/androdr/data/model/AppTelemetry.kt \
@@ -513,17 +549,19 @@ git -c commit.gpgsign=false commit -m "feat(scanner): wire embedded-SDK signals 
 
 **Files:** (none modified; this is a verification gate)
 
-- [ ] **Step 1: Run the schema cross-check test**
+- [ ] **Step 1: Run the logsource taxonomy cross-check test**
 
 ```bash
-./gradlew testDebugUnitTest --tests "com.androdr.sigma.BundledRulesSchemaCrossCheckTest"
+./gradlew testDebugUnitTest --tests "com.androdr.sigma.LogsourceTaxonomyCrossCheckTest"
 ```
 
-Expected: PASS. The two new YAML fields (in the bumped submodule) now have matching Kotlin properties on `AppTelemetry`.
+Expected: PASS. The two new YAML fields (in the bumped submodule) now have matching keys in `AppTelemetry.toFieldMap()`.
 
-If it fails with "field X declared in YAML but not in Kotlin": you misnamed a field — YAML uses `embedded_component_class` / `embedded_native_lib` (snake_case), Kotlin uses `embeddedComponentClasses` / `embeddedNativeLibs` (camelCase). The cross-check converts between cases; if it complains, the case-conversion expects exactly that mapping.
+This test does NOT do case conversion — it compares `toFieldMap().keys` byte-for-byte against the YAML keys. Both sides use snake_case (`embedded_component_class` / `embedded_native_lib`). If you forgot Task 5 Step 4 (the `toFieldMap()` update), the test fails with "fields in taxonomy but missing from Kotlin: embedded_component_class, embedded_native_lib" — fix that and re-run.
 
-If it fails with "field Y declared in Kotlin but not in YAML": submodule pointer wasn't bumped, or the submodule PR didn't include both fields. Fix and re-run.
+If it fails with "fields in Kotlin but missing from taxonomy": the submodule pointer wasn't bumped, or the submodule PR didn't include both YAML entries. Fix and re-run.
+
+(Note: `BundledRulesSchemaCrossCheckTest` is a different, separate test that validates rule YAMLs against `rule-schema.json`. It does not exercise the taxonomy field parity and won't catch the issue this step is meant to verify.)
 
 - [ ] **Step 2: Run lint**
 
@@ -563,19 +601,24 @@ $ADB install -r app/build/outputs/apk/debug/app-debug.apk
 
 Expected: `Success`.
 
-- [ ] **Step 2: Add a one-time debug log so on-device verification is possible**
+- [ ] **Step 2: Add a per-scan summary debug log**
 
-In `AppScanner.collectTelemetry()`, after building the full `List<AppTelemetry>`, add a debug-only summary log (the spec promises this in the acceptance criteria):
+In `AppScanner.collectTelemetry()`, add a one-line `Log.d` immediately before the function's return value, summarising the new signal counts. This is a permanent log (not a removal-pending instrumentation): it stays after merge and helps any future diagnosis of "is the feed actually emitting anything?". The commit message reflects that.
+
+Locate the final expression in `collectTelemetry()` (the file is small enough to skim — there is exactly one terminal expression that produces the `List<AppTelemetry>`). Bind it to a local variable if it isn't already, then log + return:
 
 ```kotlin
-val telemetryList = installed.map { /* ... existing construction ... */ }
+// existing code that produces the list — name it `telemetryList` if not already bound
+val telemetryList = /* the expression already there */
+
 Log.d(TAG, "collectTelemetry: ${telemetryList.size} apps, " +
     "${telemetryList.count { it.embeddedComponentClasses.isNotEmpty() }} with components, " +
     "${telemetryList.count { it.embeddedNativeLibs.isNotEmpty() }} with native libs")
-return@withContext telemetryList
+
+telemetryList
 ```
 
-Place this immediately before the existing return statement of `collectTelemetry()`. The exact return shape may vary — match what's already there.
+(The `withContext(Dispatchers.IO)` block in `collectTelemetry()` already returns the value of its last expression, so the local-variable pattern works without an explicit `return@withContext`.)
 
 - [ ] **Step 3: Rebuild and reinstall**
 
@@ -586,9 +629,19 @@ $ADB install -r app/build/outputs/apk/debug/app-debug.apk
 
 - [ ] **Step 4: Launch the app + trigger a scan**
 
+First verify the launcher activity FQCN (it should be `com.androdr.MainActivity`, but confirm before assuming):
+
+```bash
+$ADB shell cmd package resolve-activity --brief com.androdr.debug | tail -1
+```
+
+Then launch:
+
 ```bash
 $ADB shell am start -W -n com.androdr.debug/com.androdr.MainActivity
 ```
+
+If the resolve-activity output shows a different FQCN, use that instead.
 
 Then in the device UI: Dashboard → "Run Scan". Wait for completion (a few seconds on a low-app-count test phone).
 
@@ -607,7 +660,7 @@ If `K == 0` on a phone with Google Play Services installed: the ZIP iteration is
 
 ```bash
 git add app/src/main/java/com/androdr/scanner/AppScanner.kt
-git -c commit.gpgsign=false commit -m "chore(scanner): one-time debug log of embedded-SDK signal counts (#168)"
+git -c commit.gpgsign=false commit -m "chore(scanner): per-scan summary log of embedded-SDK signal counts (#168)"
 ```
 
 ### Task 8: Two-reviewer cycle + PR
@@ -663,10 +716,10 @@ Implements the scanner extension specified in docs/superpowers/specs/2026-05-17-
 - Harsh reviewer findings + triage table
 
 ## Test plan
-- ./gradlew testDebugUnitTest — all tests pass (count: ___)
+- ./gradlew testDebugUnitTest — all tests pass (replace this line with the actual `Tests run: N, Failures: 0` summary from Task 6 Step 3)
 - ./gradlew lintDebug — BUILD SUCCESSFUL
 - ./gradlew assembleDebug — BUILD SUCCESSFUL
-- adb install on Z Fold 2 (R3CR300WRRH) — Success; logcat shows non-zero component/native-lib counts
+- adb install on Z Fold 2 (R3CR300WRRH) — Success; logcat shows non-zero component/native-lib counts (paste the actual line from Task 7 Step 5)
 
 Closes nothing yet — issue #168 stays open. This is the first of several PRs.
 
@@ -697,7 +750,7 @@ Expected: the squash-merge commit at HEAD, with the matching `feat(scanner)` sub
 
 - Submodule PR merged with the two new taxonomy entries.
 - AndroDR PR merged with the AppTelemetry + AppScanner changes.
-- `BundledRulesSchemaCrossCheckTest` passes.
+- `LogsourceTaxonomyCrossCheckTest` passes.
 - On-device debug log confirms non-zero embedded-component and native-lib counts.
 - Two-reviewer cycle completed with all BLOCKERs and MAJORs resolved or documented as rejected.
 

--- a/docs/superpowers/specs/2026-05-17-data-broker-sdk-scanner-design.md
+++ b/docs/superpowers/specs/2026-05-17-data-broker-sdk-scanner-design.md
@@ -28,7 +28,7 @@ Two new fields on `AppTelemetry`, both list-type:
 | Field (Kotlin)               | Wire name in SIGMA              | Type            | Description                                                                                       |
 |------------------------------|----------------------------------|-----------------|---------------------------------------------------------------------------------------------------|
 | `embeddedComponentClasses`   | `embedded_component_class`       | `List<String>`  | Concatenation of `.name` from `PackageInfo.services`, `receivers`, `activities`, `providers`. Each entry is a fully-qualified class name (e.g., `com.outlogic.collector.GeoSyncService`). Deduplicated. Capped at `MAX_COMPONENTS_PER_APP=1024` per app to bound memory. |
-| `embeddedNativeLibs`         | `embedded_native_lib`            | `List<String>`  | Filenames of `lib/*/*.so` entries inside the APK. ABI prefix stripped — we report `libfoo.so`, not `lib/arm64-v8a/libfoo.so`. Deduplicated across ABIs. Capped at `MAX_NATIVE_LIBS_PER_APP=128`.                                  |
+| `embeddedNativeLibs`         | `embedded_native_lib`            | `List<String>`  | Filenames of `lib/*/*.so` entries inside the APK. ABI prefix stripped — we report `libfoo.so`, not `lib/arm64-v8a/libfoo.so`. Deduplicated across ABIs. Capped at `MAX_NATIVE_LIBS_PER_APP=256`.                                  |
 
 Both fields default to `emptyList()` so the model is fully backward-compatible (no migration of in-place code that constructs `AppTelemetry`).
 

--- a/docs/superpowers/specs/2026-05-17-data-broker-sdk-scanner-design.md
+++ b/docs/superpowers/specs/2026-05-17-data-broker-sdk-scanner-design.md
@@ -27,7 +27,7 @@ Two new fields on `AppTelemetry`, both list-type:
 
 | Field (Kotlin)               | Wire name in SIGMA              | Type            | Description                                                                                       |
 |------------------------------|----------------------------------|-----------------|---------------------------------------------------------------------------------------------------|
-| `embeddedComponentClasses`   | `embedded_component_class`       | `List<String>`  | Concatenation of `.name` from `PackageInfo.services`, `receivers`, `activities`, `providers`. Each entry is a fully-qualified class name (e.g., `com.outlogic.collector.GeoSyncService`). Deduplicated. Capped at `MAX_COMPONENTS_PER_APP=256` per app to bound memory. |
+| `embeddedComponentClasses`   | `embedded_component_class`       | `List<String>`  | Concatenation of `.name` from `PackageInfo.services`, `receivers`, `activities`, `providers`. Each entry is a fully-qualified class name (e.g., `com.outlogic.collector.GeoSyncService`). Deduplicated. Capped at `MAX_COMPONENTS_PER_APP=1024` per app to bound memory. |
 | `embeddedNativeLibs`         | `embedded_native_lib`            | `List<String>`  | Filenames of `lib/*/*.so` entries inside the APK. ABI prefix stripped — we report `libfoo.so`, not `lib/arm64-v8a/libfoo.so`. Deduplicated across ABIs. Capped at `MAX_NATIVE_LIBS_PER_APP=128`.                                  |
 
 Both fields default to `emptyList()` so the model is fully backward-compatible (no migration of in-place code that constructs `AppTelemetry`).
@@ -65,10 +65,26 @@ Both functions are `internal` so the existing `AppScannerTest` source-set patter
 
 ### Performance budget
 
-- **Manifest components:** PackageInfo is already fetched today for permissions; reading `.services[i].name` is O(1) per component. Negligible cost.
-- **Native libs:** opening a ZipFile is ~5-15 ms on a Z Fold 2; iterating the central directory is another ~1-5 ms; we never decompress. Worst case 20 ms per app × 500 apps = **10 s added** to a cold full scan. Acceptable (current scan ~14 s; new ceiling ~24 s).
+Expressed per-app so the budget scales correctly across the wide spread of real-device app counts (median ~80-150 apps; high-risk users ~50-150; power users ~300-500; the project's existing `ScanOrchestrator.kt` comment anchors at ~500 as the conservative ceiling):
+
+- **Manifest components:** PackageInfo is already fetched today for permissions; reading `.services[i].name` is O(1) per component. **Negligible** added cost — sub-millisecond per app.
+- **Native libs:** opening a ZipFile is ~5-15 ms on a Z Fold 2; iterating the central directory is another ~1-5 ms; we never decompress. Adds **~20 ms per app worst case**, often less for tiny apps.
 - We open the ZipFile once per app, NOT per-rule. Persisted output is reused at rule-evaluation time.
-- The dex-string path was rejected on this exact budget; revisit only if rule-coverage gaps demand it.
+
+| Device profile | Apps | Added scan time |
+|---|---|---|
+| Test phone (constrained) | <50 | <1 s |
+| Median user | 80-150 | 1.6-3 s |
+| Power user | 300-500 | 6-10 s |
+| Hard ceiling | 500 (per existing comment) | ~10 s |
+
+Current full scan baseline on a 500-app device: ~14 s. New ceiling after this change: ~24 s. Median users will see scan time go from ~5 s to ~7 s.
+
+The dex-string path was rejected on this exact budget; revisit only if rule-coverage gaps demand it.
+
+### On-device validation against a test phone
+
+The Samsung Z Fold 2 (R3CR300WRRH) attached to the dev VM is a *test* phone with fewer installed apps than a real-user phone. Use it to verify correctness (`embeddedComponentClasses` non-empty for the launcher activity, native libs non-empty for at least Google Play Services) — NOT as a stress test of the perf budget. Stress testing against a 500-app device is out of scope for this spec's acceptance criteria.
 
 ### Decoupling guarantee
 

--- a/docs/superpowers/specs/2026-05-17-data-broker-sdk-scanner-design.md
+++ b/docs/superpowers/specs/2026-05-17-data-broker-sdk-scanner-design.md
@@ -1,0 +1,146 @@
+# Spec: Scanner extension — embedded-SDK signals for data-broker detection
+
+**Issue:** [#168](https://github.com/yasirhamza/AndroDR/issues/168) (parent: data-broker SDK detection rule pack).
+**Scope of this spec:** **only** the scanner extension that emits embedded-SDK signals from installed apps. The accompanying rule packs (`installed_app`, `dns`, combination) are explicitly out of scope; they get their own spec→plan→PR cycles in subsequent sessions. This spec is a prerequisite for all of them.
+**Date:** 2026-05-17
+
+---
+
+## Why
+
+AndroDR can already see *app-level* signals (package name, cert hash, surveillance permissions, accessibility, device-admin) but cannot see what is *embedded inside* an app. Ad-broker SDKs — X-Mode/Outlogic, Venntel, Mobilewalla, Adsquare, Predicio, Cuebiq, Gravy Analytics, Babel Street — ship as libraries bundled into otherwise-mainstream apps (weather, classifieds, dating, games). Without telemetry from *inside* the APK, the broker pipeline is invisible to us regardless of how good our rule corpus becomes.
+
+The threat model in issue #168 maps to AndroDR's high-risk-user thesis (dissidents, journalists, soldiers, EU/US officials), so closing this gap is detection-strategic, not opportunistic.
+
+## Non-goals
+
+- **No judgment about which SDKs are bad** in the scanner. The scanner emits raw signals (component class names, native library names). The judgment "this class-name pattern is the X-Mode SDK" lives in SIGMA rules, authored separately, against the new fields.
+- **No DNS work.** That's a separate sub-project under #168.
+- **No dex string scanning.** Deferred to a phase-2 spec if intel coverage gaps emerge. Reason: ~5-10× the per-app CPU cost of the chosen signals, against marginal coverage gain (most broker SDKs register components or ship native libs).
+- **No new permissions.** Everything in scope is reachable via existing PackageManager API and world-readable APK paths on non-root stock Android.
+- **No root or device-admin elevation.** Confirmed: `applicationInfo.publicSourceDir` returns world-readable APK paths, `PackageInfo.services|receivers|activities|providers` are public API.
+- **No retroactive scan of uninstalled apps.** New signals appear on the next full scan after this lands.
+
+## Telemetry schema additions
+
+Two new fields on `AppTelemetry`, both list-type:
+
+| Field (Kotlin)               | Wire name in SIGMA              | Type            | Description                                                                                       |
+|------------------------------|----------------------------------|-----------------|---------------------------------------------------------------------------------------------------|
+| `embeddedComponentClasses`   | `embedded_component_class`       | `List<String>`  | Concatenation of `.name` from `PackageInfo.services`, `receivers`, `activities`, `providers`. Each entry is a fully-qualified class name (e.g., `com.outlogic.collector.GeoSyncService`). Deduplicated. Capped at `MAX_COMPONENTS_PER_APP=256` per app to bound memory. |
+| `embeddedNativeLibs`         | `embedded_native_lib`            | `List<String>`  | Filenames of `lib/*/*.so` entries inside the APK. ABI prefix stripped — we report `libfoo.so`, not `lib/arm64-v8a/libfoo.so`. Deduplicated across ABIs. Capped at `MAX_NATIVE_LIBS_PER_APP=128`.                                  |
+
+Both fields default to `emptyList()` so the model is fully backward-compatible (no migration of in-place code that constructs `AppTelemetry`).
+
+### Why lists, not booleans
+
+Rules need to match *specific* substrings (e.g., `embedded_component_class|contains: "com.outlogic."`). The SIGMA modifier set already supports `|contains`/`|startswith`/`|all` on list fields (see `permissions` and `service_permissions` precedent).
+
+### Why no provider/receiver/service split
+
+A separate field per component kind would 4× the schema surface and rule complexity for no detection gain — SDK-fingerprinting rules care about the *class name pattern*, not which manifest tag declared it. If we ever need that distinction we add it later (additive change, no migration).
+
+## Scanner changes
+
+Module: `app/src/main/java/com/androdr/scanner/AppScanner.kt`.
+
+Inside the existing `collectTelemetry()` loop, after the current per-app PackageInfo fetch:
+
+```kotlin
+val componentClasses = extractComponentClassNames(packageInfo)   // new
+val nativeLibs       = extractNativeLibFileNames(applicationInfo) // new
+```
+
+Two new package-private functions on `AppScanner`:
+
+- `extractComponentClassNames(packageInfo: PackageInfo): List<String>`
+  Iterates `services`, `receivers`, `activities`, `providers`. For each non-null `ComponentInfo`, reads `.name`. Filters blanks. Deduplicates. Caps at `MAX_COMPONENTS_PER_APP`. Returns sorted list (stable output for diffing in scan history).
+  Failure mode: if any sub-array is null on this Android version, just skip it; never throw.
+
+- `extractNativeLibFileNames(applicationInfo: ApplicationInfo): List<String>`
+  Opens `ZipFile(applicationInfo.publicSourceDir)`, iterates entries matching `Regex("""lib/[^/]+/lib[^/]+\.so""")`, extracts the leaf filename, deduplicates, caps at `MAX_NATIVE_LIBS_PER_APP`, sorts.
+  Failure modes: `IOException` (APK unreadable, e.g. some OEM-protected system apps) → log at `Log.w`, return `emptyList()`. `SecurityException` → same. The scan must continue past one bad APK without bailing.
+
+Both functions are `internal` so the existing `AppScannerTest` source-set pattern can reach them.
+
+### Performance budget
+
+- **Manifest components:** PackageInfo is already fetched today for permissions; reading `.services[i].name` is O(1) per component. Negligible cost.
+- **Native libs:** opening a ZipFile is ~5-15 ms on a Z Fold 2; iterating the central directory is another ~1-5 ms; we never decompress. Worst case 20 ms per app × 500 apps = **10 s added** to a cold full scan. Acceptable (current scan ~14 s; new ceiling ~24 s).
+- We open the ZipFile once per app, NOT per-rule. Persisted output is reused at rule-evaluation time.
+- The dex-string path was rejected on this exact budget; revisit only if rule-coverage gaps demand it.
+
+### Decoupling guarantee
+
+`AppScanner` has zero knowledge of which class-name patterns or .so filenames are interesting. That intel lives in the SIGMA rule corpus authored separately. This preserves the existing decoupled-telemetry architecture (telemetry collectors are pure emitters; rule engine does all the matching).
+
+## Persistence
+
+`AppTelemetry` is currently persisted via Room as part of `ScanResult` (JSON serialization through the existing converter).
+
+The new fields are list-of-strings, which the existing converter already handles for `permissions`/`service_permissions`/`receiver_permissions`. No schema migration is needed: the JSON column gains two new keys, and missing keys deserialize to `emptyList()` on read.
+
+Confirmed by reading `ScanResult.kt` — it stores `findings: List<Finding>`, not `appTelemetry: List<AppTelemetry>` directly. AppTelemetry is transient (collected per scan, fed to the rule engine, not persisted as a separate table). So **no Room migration is required.**
+
+That said: forensic export *does* surface telemetry-derived findings. The display of those findings is rule-domain, not scanner-domain, so it's also out of scope here.
+
+## Schema cross-check coordination
+
+`logsource-taxonomy.yml` in the `android-sigma-rules` submodule defines the canonical field set per service. `BundledRulesSchemaCrossCheckTest` in AndroDR fails if Kotlin properties drift from the taxonomy.
+
+### Coordinated PR sequence
+
+1. **Submodule PR (in `android-sigma-rules`)**: add two entries to `app_scanner.fields`:
+   ```yaml
+   embedded_component_class:
+     type: list
+     description: "Class names from manifest services/receivers/activities/providers; used for embedded-SDK fingerprinting"
+   embedded_native_lib:
+     type: list
+     description: "Native .so filenames inside the APK (ABI prefix stripped); used for embedded-SDK fingerprinting"
+   ```
+2. **AndroDR PR**: bumps the submodule pointer to the merged commit, adds the two new fields to `AppTelemetry`, adds the two new functions to `AppScanner`, adds tests. `BundledRulesSchemaCrossCheckTest` passes because Kotlin and YAML now agree.
+
+The submodule PR must merge first. AndroDR PR is a single squash commit so the change is reviewable as one diff post-bump.
+
+## Testing
+
+### Unit (`AppScannerTest.kt`)
+- `extractComponentClassNames` given a PackageInfo with services + receivers + activities + providers → returns deduped, sorted list. Use `mockk` for PackageInfo (matches existing AppScannerTest pattern).
+- `extractComponentClassNames` given a PackageInfo with all null sub-arrays → returns `emptyList()`, no NPE.
+- `extractComponentClassNames` given >`MAX_COMPONENTS_PER_APP` components → output is truncated, no exception.
+- `extractNativeLibFileNames` given a real test-fixture APK in `app/src/test/resources/` containing two `lib/arm64-v8a/lib*.so` and one `lib/x86_64/lib*.so` (different names) → returns deduped leaf names sorted.
+- `extractNativeLibFileNames` given a non-existent path → returns `emptyList()`, logs warning, no throw.
+- `extractNativeLibFileNames` given a corrupt zip → returns `emptyList()`, no throw.
+
+### Integration (`AppScannerIntegrationTest.kt`, existing)
+- Add a check that the collected `AppTelemetry` for an installed test app includes a non-empty `embeddedComponentClasses` (every real app has at least its launcher activity).
+- New field `embeddedNativeLibs` may be empty for pure-Java/Kotlin apps — assert "non-null list", not "non-empty".
+
+### Schema parity (`BundledRulesSchemaCrossCheckTest`)
+- After submodule bump, the test must pass without modification. If it fails, the submodule PR shipped the wrong field names; fix in coordination.
+
+## Open decisions (not blocking implementation)
+
+1. **Component-kind subfields:** the unified `embedded_component_class` field collapses services/receivers/activities/providers. If rule authors later need to distinguish "broker SDK declared as a service" vs "as a receiver", we add `embedded_service_class` etc. as additive fields. Not doing it now (YAGNI).
+2. **Multi-ABI native libs:** today we dedupe by leaf filename, so a SDK shipping both arm64 and x86_64 variants of the same `.so` produces one entry. If a broker SDK ever ships *different filenames* per ABI we'd see both; that's correct.
+3. **Obfuscation:** SDKs that are run through R8/ProGuard before bundling have their class names mangled. The scanner emits the mangled names; rules will under-match. This is intentional — pretending we can de-obfuscate is harder than the user's threat model warrants. Native lib names are NOT renamed by R8, so they remain a reliable channel.
+
+## Acceptance criteria
+
+- [ ] Submodule PR adds `embedded_component_class` + `embedded_native_lib` to `app_scanner.fields` and is merged.
+- [ ] AndroDR PR bumps submodule pointer, adds the two `AppTelemetry` fields, adds the two `AppScanner` extraction functions with proper failure handling.
+- [ ] `BundledRulesSchemaCrossCheckTest` passes.
+- [ ] New unit tests pass.
+- [ ] `./gradlew assembleDebug testDebugUnitTest lintDebug` green.
+- [ ] On-device sanity: install on Samsung Z Fold 2 (R3CR300WRRH), trigger a full scan from the Dashboard, watch `adb logcat -s AppScanner:D` for a one-time debug log (added in the implementation PR) reporting per-app counts of embedded components and native libs across the run. Confirm: `embeddedComponentClasses` is non-empty for the overwhelming majority of installed apps (launcher activity alone guarantees this); `embeddedNativeLibs` is non-empty for Google Play Services and at least a few other native-using apps; scan total runtime stays under the 30 s headroom of today's ~14 s baseline + the 10 s budgeted addition.
+- [ ] Two-reviewer cycle (spec compliance + harsh quality) on the AndroDR PR.
+
+## What lands next (NOT in this spec)
+
+- Spec for SIR research on the named broker SDKs (X-Mode, Outlogic, Venntel, Mobilewalla, Adsquare, Predicio, Cuebiq, Gravy Analytics, Babel Street).
+- Spec for the `installed_app` rule pack consuming the new fields.
+- Spec for the DNS broker-hostname rule pack.
+- Spec for the combination rule (sensitive location permission + broker SDK).
+
+Each is sized to a separate brainstorming session.


### PR DESCRIPTION
## Summary

Prerequisite spec for issue #168 (data-broker SDK detection). Scope-limited to the scanner extension that emits embedded-SDK signals — rule packs (installed_app, dns, combo) get separate spec→plan→PR cycles after this lands.

## Key design decisions

| Decision | Choice | Why |
|---|---|---|
| Model shape | Extend `AppTelemetry` directly with two list fields | `logsource-taxonomy.yml` uses `model_class: AppTelemetry` + `field_map: member`; a sibling class would break the schema-cross-check contract |
| Signal coverage | Manifest components + native lib filenames | Both O(1) per app via existing APIs; ~10 s added to a full scan vs ~60-120 s for dex strings |
| Decoupling | Scanner emits raw signal strings; rules carry SDK identity | Preserves existing decoupled-telemetry architecture |
| Non-root | All signal sources are public API + world-readable APK paths | Verified against PackageManager + `applicationInfo.publicSourceDir` |
| Dex strings | Deferred to a phase-2 spec | Marginal coverage gain for 5-10× CPU cost; SDKs with no manifest + no native footprint are rare among broker SDKs |

## Submodule coordination

The taxonomy lives in `android-sigma-rules`. Submodule PR adds two field entries to `app_scanner.fields`; AndroDR PR bumps the pointer and adds the Kotlin side. `BundledRulesSchemaCrossCheckTest` enforces parity in one direction; the submodule PR must merge first.

## What follows this

After this spec is approved + admin-merged, I'll invoke `superpowers:writing-plans` to produce a detailed implementation plan. The implementation PR will then go through the regular two-reviewer cycle.

## Test plan

- [x] Spec self-review (placeholder scan, internal consistency, scope check, ambiguity check) passed; one ambiguous on-device verification step (referenced a content-query path that doesn't exist) fixed inline to use logcat instead
- [ ] User review of the written spec at `docs/superpowers/specs/2026-05-17-data-broker-sdk-scanner-design.md`

Refs #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)