### PR TITLE
fix(skill): repair stale lookout + google-tag URLs in discover

### DIFF
--- a/.claude/commands/update-rules-discover.md
+++ b/.claude/commands/update-rules-discover.md
@@ -30,14 +30,17 @@ URL hostname bindings are locked by `test_discover_source_urls.py`. DO NOT edit 
 |---|---|
 | `securelist` | `https://securelist.com/feed/` |
 | `welivesecurity` | `https://www.welivesecurity.com/en/feed/` |
-| `google-tag` | `https://blog.google/threat-analysis-group/rss/` |
+| `google-tag` | `https://blog.google/security/rss/` |
+
+> Note: source-id `google-tag` historically pointed at `https://blog.google/threat-analysis-group/rss/`, which Google retired (returns 404). The id is retained for feed-state cursor continuity, but the feed now covers Google's broader Security blog (which still includes TAG posts among other Google security/privacy content). Per-post LLM extraction handles the broader scope.
+
 
 ### Web path (WebFetch + synthesized-RSS)
 
 | Source ID | Index URL |
 |---|---|
 | `zimperium` | `https://www.zimperium.com/blog/` |
-| `lookout` | `https://www.lookout.com/threat-intelligence/blog` |
+| `lookout` | `https://www.lookout.com/threat-intelligence` |
 
 ## Process
 


### PR DESCRIPTION
## Summary

- Two source URLs in `/update-rules discover` were stale and broke this morning's discover run
- Patches both URLs in `.claude/commands/update-rules-discover.md`; tests still pass
- Companion PR on `android-sigma-rules/rules`: [#17 (7-threat harvest)](https://github.com/android-sigma-rules/rules/pull/17)

## What was broken

- `https://www.lookout.com/threat-intelligence/blog` → **HTTP 404**. Lookout reorganized to `/threat-intelligence` (no `/blog`). Path-only change; hostname binding (`lookout.com`) in `test_discover_source_urls.py` unchanged, so the test stays green without modification.
- `https://blog.google/threat-analysis-group/rss/` → **HTTP 404**. Google retired the dedicated TAG RSS feed. The only working `blog.google` security RSS today is `https://blog.google/security/rss/`, which is a superset — it still includes TAG posts among other Google security/privacy content. Source-id `google-tag` kept for `feed-state.json` cursor continuity; added an inline note in the skill explaining the broadened scope.

## Verification

- `python3 -m pytest .claude/commands/scripts/` — 19 passed
- Live `curl` against both new URLs — HTTP 200 as of 2026-05-16
- `chromium --headless` fetch of lookout `/threat-intelligence` returns 6 article entries (BITTER, DarkSword, EagleMsgSpy, APT37, Massistant, MuddyWater/DCHSpy) — all surfaced as candidates in the discover run

## Test plan

- [ ] Re-run `/update-rules discover` after merge — confirm lookout + google-tag cursors advance (this run didn't advance them due to fetch_errors)
- [ ] Confirm `test_each_source_url_matches_hostname` stays green
- [ ] Spot-check the `google-tag` source now picks up Android-specific Google blog posts (e.g., "What's New in Android Security and Privacy in 2026")

🤖 Generated with [Claude Code](https://claude.com/claude-code)