### PR TITLE
feat(scanner): emit embedded-SDK signals for AppTelemetry (#168, prereq)

### DIFF
--- a/app/src/main/java/com/androdr/data/model/AppTelemetry.kt
+++ b/app/src/main/java/com/androdr/data/model/AppTelemetry.kt
@@ -35,6 +35,9 @@ data class AppTelemetry(
      */
     val lastUpdateTime: Long = 0L,
     val source: TelemetrySource,
+    // NEW (#168):
+    val embeddedComponentClasses: List<String> = emptyList(),
+    val embeddedNativeLibs: List<String> = emptyList(),
 ) {
     fun toFieldMap(): Map<String, Any?> = mapOf(
         "package_name" to packageName,
@@ -56,6 +59,9 @@ data class AppTelemetry(
         "receiver_permissions" to receiverPermissions,
         "has_launcher_activity" to hasLauncherActivity,
         "first_install_time" to firstInstallTime,
-        "last_update_time" to lastUpdateTime
+        "last_update_time" to lastUpdateTime,
+        // NEW (#168):
+        "embedded_component_class" to embeddedComponentClasses,
+        "embedded_native_lib" to embeddedNativeLibs
     )
 }

--- a/app/src/main/java/com/androdr/scanner/AppScanner.kt
+++ b/app/src/main/java/com/androdr/scanner/AppScanner.kt
@@ -252,6 +252,9 @@ class AppScanner @Inject constructor(
         // Launcher activity check (API call — not derivable from manifest alone)
         val hasLauncherActivity = pm.getLaunchIntentForPackage(packageName) != null
 
+        val embeddedComponentClasses = extractComponentClassNames(pkg)
+        val embeddedNativeLibs = extractNativeLibFileNames(appInfo)
+
         return AppTelemetry(
             packageName = packageName,
             appName = appName,
@@ -274,6 +277,8 @@ class AppScanner @Inject constructor(
             firstInstallTime = pkg.firstInstallTime,
             lastUpdateTime = pkg.lastUpdateTime,
             source = TelemetrySource.LIVE_SCAN,
+            embeddedComponentClasses = embeddedComponentClasses,
+            embeddedNativeLibs = embeddedNativeLibs,
         )
     }
 

--- a/app/src/main/java/com/androdr/scanner/AppScanner.kt
+++ b/app/src/main/java/com/androdr/scanner/AppScanner.kt
@@ -13,6 +13,7 @@ import com.androdr.ioc.DeviceIdentity
 import com.androdr.ioc.KnownAppResolver
 import com.androdr.ioc.OemPrefixResolver
 import java.security.MessageDigest
+import java.util.zip.ZipFile
 import android.content.pm.PackageInfo
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
@@ -295,6 +296,39 @@ class AppScanner @Inject constructor(
         packageInfo.activities?.forEach { it.name?.takeIf { n -> n.isNotBlank() }?.let { n -> out.add(n) } }
         packageInfo.providers?.forEach { it.name?.takeIf { n -> n.isNotBlank() }?.let { n -> out.add(n) } }
         return out.asSequence().sorted().take(MAX_COMPONENTS_PER_APP).toList()
+    }
+
+    /**
+     * Returns deduped, sorted leaf filenames of native libraries embedded
+     * in the APK at [applicationInfo.publicSourceDir]. ABI prefix is stripped
+     * so `lib/arm64-v8a/libxmode.so` and `lib/x86_64/libxmode.so` collapse
+     * to a single `libxmode.so` entry. Output is capped at
+     * [MAX_NATIVE_LIBS_PER_APP]. Sort happens BEFORE truncation so the
+     * surviving subset is the lexicographically-first N (deterministic
+     * under small APK perturbations). Failures (unreadable APK, corrupt
+     * zip) are logged and produce an empty list — never thrown — so one
+     * bad APK cannot abort the whole scan.
+     */
+    @Suppress("TooGenericExceptionCaught", "SwallowedException")
+    internal fun extractNativeLibFileNames(applicationInfo: ApplicationInfo): List<String> {
+        val path = applicationInfo.publicSourceDir ?: return emptyList()
+        val out = LinkedHashSet<String>()
+        try {
+            ZipFile(path).use { zip ->
+                val entries = zip.entries()
+                while (entries.hasMoreElements()) {
+                    val name = entries.nextElement().name
+                    if (name.startsWith("lib/") && name.endsWith(".so")) {
+                        val leaf = name.substringAfterLast('/')
+                        if (leaf.isNotBlank()) out.add(leaf)
+                    }
+                }
+            }
+        } catch (e: Exception) {
+            Log.w(TAG, "extractNativeLibFileNames failed for $path: ${e.message}")
+            return emptyList()
+        }
+        return out.asSequence().sorted().take(MAX_NATIVE_LIBS_PER_APP).toList()
     }
 
     private fun computeApkHash(appInfo: ApplicationInfo): String? {

--- a/app/src/main/java/com/androdr/scanner/AppScanner.kt
+++ b/app/src/main/java/com/androdr/scanner/AppScanner.kt
@@ -4,7 +4,6 @@ import android.Manifest
 import android.content.Context
 import android.content.pm.ApplicationInfo
 import android.content.pm.PackageManager
-import android.content.pm.ProviderInfo
 import android.os.Build
 import android.util.Log
 import com.androdr.data.model.AppTelemetry

--- a/app/src/main/java/com/androdr/scanner/AppScanner.kt
+++ b/app/src/main/java/com/androdr/scanner/AppScanner.kt
@@ -4,6 +4,7 @@ import android.Manifest
 import android.content.Context
 import android.content.pm.ApplicationInfo
 import android.content.pm.PackageManager
+import android.content.pm.ProviderInfo
 import android.os.Build
 import android.util.Log
 import com.androdr.data.model.AppTelemetry
@@ -46,6 +47,10 @@ class AppScanner @Inject constructor(
          * thrashing the storage queue or saturating the CPU schedulers.
          */
         private const val TELEMETRY_PARALLELISM = 16
+
+        // NEW (#168):
+        private const val MAX_COMPONENTS_PER_APP = 1024
+        private const val MAX_NATIVE_LIBS_PER_APP = 256
     }
 
     /**
@@ -270,6 +275,27 @@ class AppScanner @Inject constructor(
             lastUpdateTime = pkg.lastUpdateTime,
             source = TelemetrySource.LIVE_SCAN,
         )
+    }
+
+    /**
+     * Returns deduped, sorted class names from a PackageInfo's services,
+     * receivers, activities, and providers arrays. Used downstream by SIGMA
+     * rules that fingerprint embedded SDKs by class-name prefix. See
+     * spec `docs/superpowers/specs/2026-05-17-data-broker-sdk-scanner-design.md`.
+     *
+     * Output is capped at [MAX_COMPONENTS_PER_APP] to bound memory against
+     * pathological/malicious manifests. Sort happens BEFORE truncation so
+     * the truncated subset is the lexicographically-first N — stable under
+     * small manifest perturbations (a manifest gaining one component
+     * doesn't shift the survival window arbitrarily).
+     */
+    internal fun extractComponentClassNames(packageInfo: PackageInfo): List<String> {
+        val out = LinkedHashSet<String>()
+        packageInfo.services?.forEach { it.name?.takeIf { n -> n.isNotBlank() }?.let { n -> out.add(n) } }
+        packageInfo.receivers?.forEach { it.name?.takeIf { n -> n.isNotBlank() }?.let { n -> out.add(n) } }
+        packageInfo.activities?.forEach { it.name?.takeIf { n -> n.isNotBlank() }?.let { n -> out.add(n) } }
+        packageInfo.providers?.forEach { it.name?.takeIf { n -> n.isNotBlank() }?.let { n -> out.add(n) } }
+        return out.asSequence().sorted().take(MAX_COMPONENTS_PER_APP).toList()
     }
 
     private fun computeApkHash(appInfo: ApplicationInfo): String? {

--- a/app/src/main/java/com/androdr/scanner/AppScanner.kt
+++ b/app/src/main/java/com/androdr/scanner/AppScanner.kt
@@ -125,7 +125,7 @@ class AppScanner @Inject constructor(
         @Suppress("OPT_IN_USAGE")
         val workerDispatcher = Dispatchers.IO.limitedParallelism(TELEMETRY_PARALLELISM)
 
-        coroutineScope {
+        val telemetryList = coroutineScope {
             installedPackages
                 .map { pkg ->
                     async(workerDispatcher) { buildTelemetryForPackage(pm, pkg) }
@@ -133,6 +133,12 @@ class AppScanner @Inject constructor(
                 .awaitAll()
                 .filterNotNull()
         }
+
+        Log.d(TAG, "collectTelemetry: ${telemetryList.size} apps, " +
+            "${telemetryList.count { it.embeddedComponentClasses.isNotEmpty() }} with components, " +
+            "${telemetryList.count { it.embeddedNativeLibs.isNotEmpty() }} with native libs")
+
+        telemetryList
     }
 
     /**

--- a/app/src/main/java/com/androdr/scanner/AppScanner.kt
+++ b/app/src/main/java/com/androdr/scanner/AppScanner.kt
@@ -258,7 +258,7 @@ class AppScanner @Inject constructor(
         // Launcher activity check (API call — not derivable from manifest alone)
         val hasLauncherActivity = pm.getLaunchIntentForPackage(packageName) != null
 
-        val embeddedComponentClasses = extractComponentClassNames(pkg)
+        val embeddedComponentClasses = extractComponentClassNames(pkg, pkgDetail)
         val embeddedNativeLibs = extractNativeLibFileNames(appInfo)
 
         return AppTelemetry(
@@ -300,12 +300,19 @@ class AppScanner @Inject constructor(
      * small manifest perturbations (a manifest gaining one component
      * doesn't shift the survival window arbitrarily).
      */
-    internal fun extractComponentClassNames(packageInfo: PackageInfo): List<String> {
+    internal fun extractComponentClassNames(
+        primary: PackageInfo,
+        fallback: PackageInfo? = null,
+    ): List<String> {
         val out = LinkedHashSet<String>()
-        packageInfo.services?.forEach { it.name?.takeIf { n -> n.isNotBlank() }?.let { n -> out.add(n) } }
-        packageInfo.receivers?.forEach { it.name?.takeIf { n -> n.isNotBlank() }?.let { n -> out.add(n) } }
-        packageInfo.activities?.forEach { it.name?.takeIf { n -> n.isNotBlank() }?.let { n -> out.add(n) } }
-        packageInfo.providers?.forEach { it.name?.takeIf { n -> n.isNotBlank() }?.let { n -> out.add(n) } }
+        val services   = primary.services   ?: fallback?.services
+        val receivers  = primary.receivers  ?: fallback?.receivers
+        val activities = primary.activities ?: fallback?.activities
+        val providers  = primary.providers  ?: fallback?.providers
+        services?.forEach   { it.name?.takeIf { n -> n.isNotBlank() }?.let { n -> out.add(n) } }
+        receivers?.forEach  { it.name?.takeIf { n -> n.isNotBlank() }?.let { n -> out.add(n) } }
+        activities?.forEach { it.name?.takeIf { n -> n.isNotBlank() }?.let { n -> out.add(n) } }
+        providers?.forEach  { it.name?.takeIf { n -> n.isNotBlank() }?.let { n -> out.add(n) } }
         return out.asSequence().sorted().take(MAX_COMPONENTS_PER_APP).toList()
     }
 

--- a/app/src/test/java/com/androdr/scanner/AppScannerTelemetryTest.kt
+++ b/app/src/test/java/com/androdr/scanner/AppScannerTelemetryTest.kt
@@ -382,4 +382,43 @@ class AppScannerTelemetryTest {
         // "lib100.so" etc.
         assertEquals("lib1.so", result.first())
     }
+
+    // ── 11. Integration: collectTelemetry populates embedded SDK fields ──────
+
+    @Test
+    fun `collectTelemetry populates embeddedComponentClasses and embeddedNativeLibs`() = runTest {
+        val apk = buildSyntheticApk("integration.apk", listOf(
+            "lib/arm64-v8a/libxmode.so"
+        ))
+        val pkgInfo = PackageInfo().apply {
+            packageName = "com.example.broker"
+            applicationInfo = ApplicationInfo().apply {
+                publicSourceDir = apk.absolutePath
+                sourceDir = apk.absolutePath
+            }
+            services = arrayOf(ServiceInfo().apply { name = "com.outlogic.GeoCollectorService" })
+            receivers = null
+            // Three components chosen so the lex-sort behavior is observable end-to-end:
+            // "com.example.broker.MainActivity" < "com.outlogic.GeoCollectorService" < "com.zzz.LastActivity"
+            activities = arrayOf(
+                ActivityInfo().apply { name = "com.example.broker.MainActivity" },
+                ActivityInfo().apply { name = "com.zzz.LastActivity" }
+            )
+            providers = null
+        }
+        installPackages(pkgInfo)
+
+        val telemetry = scanner.collectTelemetry()
+
+        val entry = telemetry.single { it.packageName == "com.example.broker" }
+        assertEquals(
+            listOf(
+                "com.example.broker.MainActivity",
+                "com.outlogic.GeoCollectorService",
+                "com.zzz.LastActivity"
+            ),
+            entry.embeddedComponentClasses
+        )
+        assertEquals(listOf("libxmode.so"), entry.embeddedNativeLibs)
+    }
 }

--- a/app/src/test/java/com/androdr/scanner/AppScannerTelemetryTest.kt
+++ b/app/src/test/java/com/androdr/scanner/AppScannerTelemetryTest.kt
@@ -17,19 +17,40 @@ import com.androdr.ioc.OemPrefixResolver
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
+import java.io.File
+import java.io.FileOutputStream
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.TemporaryFolder
 
 class AppScannerTelemetryTest {
+
+    @get:Rule
+    val tempFolder = TemporaryFolder()
 
     private lateinit var context: Context
     private lateinit var pm: PackageManager
     private lateinit var knownAppResolver: KnownAppResolver
     private lateinit var oemPrefixResolver: OemPrefixResolver
     private lateinit var scanner: AppScanner
+
+    private fun buildSyntheticApk(name: String, entries: List<String>): File {
+        val file = tempFolder.newFile(name)
+        ZipOutputStream(FileOutputStream(file)).use { zip ->
+            for (entry in entries) {
+                zip.putNextEntry(ZipEntry(entry))
+                zip.write(byteArrayOf(0)) // placeholder body so the entry is well-formed
+                zip.closeEntry()
+            }
+        }
+        return file
+    }
 
     @Before
     fun setUp() {
@@ -313,5 +334,52 @@ class AppScannerTelemetryTest {
         // sort-then-take guarantees lexicographic stability — the smallest name survives.
         // ("com.example.A1" lex-precedes "com.example.A1000", "A1001", ..., as well as "A2".)
         assertEquals("com.example.A1", result.first())
+    }
+
+    // ── 10. extractNativeLibFileNames ────────────────────────────────────────
+
+    @Test
+    fun `extractNativeLibFileNames returns deduped leaf filenames across ABIs`() {
+        val apk = buildSyntheticApk("test.apk", listOf(
+            "AndroidManifest.xml",
+            "classes.dex",
+            "lib/arm64-v8a/libxmode.so",
+            "lib/arm64-v8a/libcollector.so",
+            "lib/x86_64/libxmode.so",                 // dup of arm64-v8a leaf
+            "lib/armeabi-v7a/libcollector.so",        // dup of arm64-v8a leaf
+            "lib/arm64-v8a/libunique.so",
+            "res/values/strings.xml"
+        ))
+        val appInfo = ApplicationInfo().apply { publicSourceDir = apk.absolutePath }
+
+        val result = scanner.extractNativeLibFileNames(appInfo)
+
+        assertEquals(listOf("libcollector.so", "libunique.so", "libxmode.so"), result)
+    }
+
+    @Test
+    fun `extractNativeLibFileNames returns emptyList for a non-existent path`() {
+        val appInfo = ApplicationInfo().apply { publicSourceDir = "/does/not/exist.apk" }
+        assertEquals(emptyList<String>(), scanner.extractNativeLibFileNames(appInfo))
+    }
+
+    @Test
+    fun `extractNativeLibFileNames returns emptyList for a corrupt zip`() {
+        val bogus = tempFolder.newFile("bogus.apk")
+        bogus.writeText("not a zip file")
+        val appInfo = ApplicationInfo().apply { publicSourceDir = bogus.absolutePath }
+        assertEquals(emptyList<String>(), scanner.extractNativeLibFileNames(appInfo))
+    }
+
+    @Test
+    fun `extractNativeLibFileNames truncates to MAX_NATIVE_LIBS_PER_APP and keeps lexicographically-first entries`() {
+        val entries = (1..400).map { "lib/arm64-v8a/lib$it.so" }
+        val apk = buildSyntheticApk("big.apk", entries)
+        val appInfo = ApplicationInfo().apply { publicSourceDir = apk.absolutePath }
+        val result = scanner.extractNativeLibFileNames(appInfo)
+        assertEquals(256, result.size)
+        // sort-then-take guarantees lexicographic stability — "lib1.so" precedes
+        // "lib100.so" etc.
+        assertEquals("lib1.so", result.first())
     }
 }

--- a/app/src/test/java/com/androdr/scanner/AppScannerTelemetryTest.kt
+++ b/app/src/test/java/com/androdr/scanner/AppScannerTelemetryTest.kt
@@ -7,6 +7,7 @@ import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
 import android.content.pm.ServiceInfo
 import android.content.pm.ActivityInfo
+import android.content.pm.ProviderInfo
 import android.content.res.Resources
 import com.androdr.R
 import com.androdr.data.model.KnownAppCategory
@@ -255,5 +256,62 @@ class AppScannerTelemetryTest {
         val fieldMap = telemetry.toFieldMap()
         assertEquals(firstInstall, fieldMap["first_install_time"])
         assertEquals(lastUpdate, fieldMap["last_update_time"])
+    }
+
+    // ── 9. extractComponentClassNames ────────────────────────────────────────
+
+    @Test
+    fun `extractComponentClassNames returns deduped sorted class names from all four component kinds`() {
+        val pkgInfo = PackageInfo().apply {
+            services = arrayOf(
+                ServiceInfo().apply { name = "com.outlogic.collector.GeoSyncService" },
+                ServiceInfo().apply { name = "com.example.legit.NormalService" }
+            )
+            receivers = arrayOf(
+                ActivityInfo().apply { name = "com.outlogic.collector.WakeReceiver" }
+            )
+            activities = arrayOf(
+                ActivityInfo().apply { name = "com.example.legit.MainActivity" },
+                ActivityInfo().apply { name = "com.example.legit.MainActivity" } // dup
+            )
+            providers = arrayOf(
+                ProviderInfo().apply { name = "com.example.legit.SettingsProvider" }
+            )
+        }
+
+        val result = scanner.extractComponentClassNames(pkgInfo)
+
+        assertEquals(
+            listOf(
+                "com.example.legit.MainActivity",
+                "com.example.legit.NormalService",
+                "com.example.legit.SettingsProvider",
+                "com.outlogic.collector.GeoSyncService",
+                "com.outlogic.collector.WakeReceiver"
+            ),
+            result
+        )
+    }
+
+    @Test
+    fun `extractComponentClassNames returns emptyList when all four arrays are null`() {
+        val pkgInfo = PackageInfo().apply {
+            services = null
+            receivers = null
+            activities = null
+            providers = null
+        }
+        assertEquals(emptyList<String>(), scanner.extractComponentClassNames(pkgInfo))
+    }
+
+    @Test
+    fun `extractComponentClassNames truncates to MAX_COMPONENTS_PER_APP and keeps lexicographically-first entries`() {
+        val many = (1..2000).map { ActivityInfo().apply { name = "com.example.A$it" } }.toTypedArray()
+        val pkgInfo = PackageInfo().apply { activities = many; services = null; receivers = null; providers = null }
+        val result = scanner.extractComponentClassNames(pkgInfo)
+        assertEquals(1024, result.size)
+        // sort-then-take guarantees lexicographic stability — the smallest name survives.
+        // ("com.example.A1" lex-precedes "com.example.A1000", "A1001", ..., as well as "A2".)
+        assertEquals("com.example.A1", result.first())
     }
 }

--- a/app/src/test/java/com/androdr/scanner/AppScannerTelemetryTest.kt
+++ b/app/src/test/java/com/androdr/scanner/AppScannerTelemetryTest.kt
@@ -336,6 +336,43 @@ class AppScannerTelemetryTest {
         assertEquals("com.example.A1", result.first())
     }
 
+    @Test
+    fun `extractComponentClassNames falls back to second PackageInfo when primary has null services and receivers`() {
+        // Primary mimics a Binder-truncated PackageInfo: services + receivers nulled
+        // by the framework's parcel-size limit. Activities + providers untouched.
+        val primary = PackageInfo().apply {
+            services = null
+            receivers = null
+            activities = arrayOf(
+                ActivityInfo().apply { name = "com.example.broker.MainActivity" }
+            )
+            providers = null
+        }
+        // Fallback mimics the per-package re-fetch: services + receivers populated,
+        // activities + providers null (the re-fetch flag set is GET_SERVICES | GET_RECEIVERS only).
+        val fallback = PackageInfo().apply {
+            services = arrayOf(
+                ServiceInfo().apply { name = "com.outlogic.collector.GeoSyncService" }
+            )
+            receivers = arrayOf(
+                ActivityInfo().apply { name = "com.outlogic.collector.WakeReceiver" }
+            )
+            activities = null
+            providers = null
+        }
+
+        val result = scanner.extractComponentClassNames(primary, fallback)
+
+        assertEquals(
+            listOf(
+                "com.example.broker.MainActivity",
+                "com.outlogic.collector.GeoSyncService",
+                "com.outlogic.collector.WakeReceiver"
+            ),
+            result
+        )
+    }
+
     // ── 10. extractNativeLibFileNames ────────────────────────────────────────
 
     @Test


### PR DESCRIPTION
## Summary

Implements the scanner extension specified in `docs/superpowers/specs/2026-05-17-data-broker-sdk-scanner-design.md`. Adds two list-typed fields to `AppTelemetry` — `embeddedComponentClasses` and `embeddedNativeLibs` — and the corresponding extraction logic in `AppScanner`. This is the prerequisite PR for issue #168 (data-broker SDK detection rule pack); the rule packs follow in separate PRs.

## What changed

- **Submodule bumped** (`bf02e27`): `third-party/android-sigma-rules` advances to `3c31596` (taxonomy PR rules#18). `logsource-taxonomy.yml` now declares `embedded_component_class` + `embedded_native_lib` under `app_scanner.fields`.
- **`AppTelemetry`** gains two list fields (both default `emptyList()` — additive, no caller breaks) and two corresponding snake_case `toFieldMap()` entries.
- **`AppScanner`** gains two `internal` extractors placed next to each other after `buildTelemetryForPackage`:
  - `extractComponentClassNames(primary, fallback?)` — services + receivers + activities + providers from the manifest; deduped via `LinkedHashSet`; sort-then-take to `MAX_COMPONENTS_PER_APP = 1024`. Accepts an optional fallback `PackageInfo` to honor the existing Binder-truncation re-fetch pattern at the call site.
  - `extractNativeLibFileNames(applicationInfo)` — opens the APK via `ZipFile(applicationInfo.publicSourceDir)`, iterates `lib/*/*.so` entries, strips ABI prefix via `substringAfterLast('/')`, dedupes, sort-then-take to `MAX_NATIVE_LIBS_PER_APP = 256`. Any IOException/ZipException is logged and yields `emptyList()` — one bad APK cannot abort the scan.
- **`buildTelemetryForPackage`** wires both extractors before constructing `AppTelemetry`. Uses the existing null-checked `appInfo` local and passes `pkgDetail` to the component extractor so Binder-truncated manifests are recovered.
- **Per-scan summary log** (`fa6bbb1`): one-line `Log.d` in `collectTelemetry()` reporting per-scan counts, so on-device or production diagnosis of "is the feed actually emitting anything?" doesn't need a Room round-trip.
- **Tests**: 9 new in `AppScannerTelemetryTest` covering all four extraction paths + the integration wiring + the Binder fallback case.

## Two-reviewer cycle (per-task + final cumulative)

Per-task reviews ran during SDD execution (Tasks 3, 4, 5 each got spec + harsh reviewers). All findings triaged inline. Final cumulative review at end of branch:

**Final spec reviewer** (general-purpose): **APPROVE FOR MERGE** — all 6 spec acceptance criteria + all 8 spec-level decisions verified against the actual diff.

**Final harsh reviewer** (`git-pr-workflows:code-reviewer`): 1 MAJOR caught — `extractComponentClassNames` originally ignored the existing Binder-truncation fallback at the call site, so large-manifest apps (the exact broker-SDK profile we're targeting) would have silently emitted `embeddedComponentClasses = []`. **Fixed in `7399684`** with a function-signature extension and a new dedicated test (`extractComponentClassNames falls back to second PackageInfo when primary has null services and receivers`). All other findings were MINOR (commit-history opinions, naming preferences) and rejected with reasoning.

## Test plan

- [x] `./gradlew testDebugUnitTest --tests "com.androdr.sigma.LogsourceTaxonomyCrossCheckTest"` — BUILD SUCCESSFUL (Task 6)
- [x] `./gradlew testDebugUnitTest` — BUILD SUCCESSFUL, **519 tests** run, 0 failures, 0 errors (Task 6)
- [x] `./gradlew lintDebug` — BUILD SUCCESSFUL, no new findings (Task 6)
- [x] `./gradlew assembleDebug` — BUILD SUCCESSFUL, 19 MiB APK at `app/build/outputs/apk/debug/app-debug.apk` (Task 6)
- [ ] **On-device sanity** deferred to follow-up issue **#182** — USB passthrough was unavailable on the dev VM at merge time. The summary log added in `fa6bbb1` makes the device-side check mechanically possible; #182 has the exact steps.
- [ ] CI `build` check passes

## What lands next (separate sessions / separate PRs per #168 spec decomposition)

- Spec for SIR research on named broker SDKs (X-Mode, Outlogic, Venntel, Mobilewalla, Adsquare, Predicio, Cuebiq, Gravy Analytics, Babel Street).
- Spec for the `installed_app` rule pack consuming the new fields.
- Spec for the DNS broker-hostname rule pack.
- Spec for the combination rule (sensitive location permission + broker SDK).

## Related

- Parent issue: #168 (data-broker SDK detection)
- Spec: `docs/superpowers/specs/2026-05-17-data-broker-sdk-scanner-design.md` (merged in #178)
- Plan: `docs/superpowers/plans/2026-05-17-data-broker-sdk-scanner-plan.md` (merged in #178)
- Follow-up: #182 (on-device sanity check, deferred)

🤖 Generated with [Claude Code](https://claude.com/claude-code)