### PR TITLE
fix(rules): narrow androdr-078 Massistant selector (exact package match)

### DIFF
--- a/app/src/main/res/raw/sigma_androdr_078_meiya_pico_forensics.yml
+++ b/app/src/main/res/raw/sigma_androdr_078_meiya_pico_forensics.yml
@@ -12,7 +12,7 @@ description: >
     androdr-051 (Cellebrite UFED) which covers the same threat category
     (state mobile-forensics tooling) from the workstation/exploit angle.
 author: AndroDR (AI-generated)
-date: 2026/05/16
+date: 2026/05/17
 references:
     - https://www.lookout.com/threat-intelligence/article/massistant-chinese-mobile-forensics
     - https://thehackernews.com/2025/07/chinas-massistant-tool-secretly.html
@@ -26,7 +26,8 @@ logsource:
     service: app_scanner
 detection:
     selection:
-        package_name|ioc_lookup: package_ioc_db
+        package_name:
+            - "com.meyapico.massistant"
     filter_system_app:
         is_system_app: true
     condition: selection and not filter_system_app
@@ -38,7 +39,7 @@ display:
     evidence_type: ioc_match
     guidance: "CRITICAL -- this device may have been physically accessed by law enforcement using Chinese mobile forensics tooling. The app may auto-uninstall on USB disconnect."
 falsepositives:
-    - Vendor-internal Meiya Pico QA installs (cross-check package_name against the published Massistant identifier).
+    - Vendor-internal Meiya Pico QA installs (the published Massistant identifier is com.meyapico.massistant; cross-check install source and signing certificate before treating as malicious).
 remediation:
     - "Massistant is a mobile forensic client used by Chinese law enforcement to extract data from seized devices."
     - "If you did not install this app yourself, your device may have been accessed without your knowledge. Seek advice from a digital security trainer or a relevant civil-society organization."

--- a/app/src/test/resources/gate4-fixtures/meiya-pico-forensics.yml
+++ b/app/src/test/resources/gate4-fixtures/meiya-pico-forensics.yml
@@ -1,6 +1,7 @@
 # Fixture for androdr-078: Massistant Chinese mobile forensic tool installed.
-# Verifies the dedicated labeled wrapper fires on the documented Meiya Pico
-# package and stays silent on system apps + benign user apps.
+# Uses narrow `package_name` equality match (not the generic package_ioc_db
+# lookup) so the rule's "Massistant Forensic Tool" attribution only attaches
+# to actual Massistant installs, not every IOC-DB hit.
 #
 # Companion to androdr-051 (Cellebrite UFED); both target state mobile-forensics
 # tooling but from different angles (Cellebrite = unpatched-CVE detector for
@@ -8,22 +9,22 @@
 # client-side forensic agent).
 rule_file: sigma_androdr_078_meiya_pico_forensics.yml
 service: app_scanner
-ioc_stubs:
-  package_ioc_db:
-    - "com.meyapico.massistant"
-    - "com.thetruthspy"  # decoy from another family; rule still keys on IOC DB
 true_positives:
   - package_name: "com.meyapico.massistant"
-    is_system_app: false
-  - package_name: "com.thetruthspy"  # any package in the IOC DB fires the wrapper
     is_system_app: false
 true_negatives:
   # System-app masquerade — filter_system_app suppresses
   - package_name: "com.meyapico.massistant"
     is_system_app: true
-  # Benign user app not in IOC DB
+  # Other IOC families must NOT trigger Massistant attribution
+  - package_name: "com.thetruthspy"
+    is_system_app: false
+  # Benign user app
   - package_name: "com.google.android.gm"
     is_system_app: false
-  # Common settings package not in IOC DB
+  # Benign system app
   - package_name: "com.android.settings"
     is_system_app: true
+  # Similar-looking but different vendor (defense against accidental contains-style match)
+  - package_name: "com.meyapico.legitimate-other-app"
+    is_system_app: false


### PR DESCRIPTION
## Summary

Pulls in [sigma#19](https://github.com/android-sigma-rules/rules/pull/19) (merged as \`fbc17c9\`). Fixes the wrong-attribution blocker on \`androdr-078\` Massistant rule.

## Why this matters

In the harness validation from #181, planting a fixture with \`applicationId = com.meyapico.massistant\` correctly triggered detection — but the rule's selector was \`package_name|ioc_lookup: package_ioc_db\`, which would attribute "Massistant Forensic Tool" to **any** package in the IOC database, including stalkerware, banking RATs, NoviSpy, etc. That's a misleading nation-state-forensics label on unrelated families.

## Change

```diff
 detection:
     selection:
-        package_name|ioc_lookup: package_ioc_db
+        package_name:
+            - "com.meyapico.massistant"
     filter_system_app:
         is_system_app: true
     condition: selection and not filter_system_app
```

- Submodule bump: \`third-party/android-sigma-rules\` 57f1a28 → fbc17c9
- Bundled copy synced to canonical sigma version
- Gate 4 fixture's TN set expanded — \`com.thetruthspy\` (other family) and \`com.meyapico.legitimate-other-app\` (defense against accidental contains-style match) must NOT trigger the Massistant attribution

## Local validation (now possible with JDK + SDK confirmed on this machine)

- \`python3 third-party/android-sigma-rules/validation/validate-rule.py\` → PASS
- \`./gradlew testDebugUnitTest --tests "com.androdr.sigma.GateFourFixtureTest"\` → BUILD SUCCESSFUL, 13/13 fixtures green

## Same issue on \`androdr-005\` (flagged for follow-up)

\`androdr_005_graphite_paragon.yml\` has the same broad \`domain|ioc_lookup: domain_ioc_db\` selector — fires the "Graphite/Paragon Spyware" attribution on every domain-IOC hit. Same architectural cleanup needed, separate PR.

## Test plan

- [ ] CI \`build-and-test\` runs Gate 4 — 5 narrowed-fixture cases (meiya-pico-forensics et al.) should pass
- [ ] Optional on-device: re-run the planting test from #181 with a non-Massistant IOC-DB package — should now surface "Known Malicious Package" only, NOT "Massistant Forensic Tool"

🤖 Generated with [Claude Code](https://claude.com/claude-code)