### PR TITLE
fix(rules): narrow androdr-005 Graphite/Paragon selector (honest stub)

### DIFF
--- a/app/src/main/res/raw/sigma_androdr_005_graphite_paragon.yml
+++ b/app/src/main/res/raw/sigma_androdr_005_graphite_paragon.yml
@@ -3,19 +3,32 @@ id: androdr-005
 status: production
 description: >
     Detects DNS queries to infrastructure associated with Paragon's
-    Graphite mercenary spyware, based on Citizen Lab research.
+    Graphite mercenary spyware. Previously this rule used the generic
+    domain_ioc_db lookup — that caused the "Graphite/Paragon Spyware"
+    nation-state attribution to fire on every malicious-domain match
+    (stalkerware C2, banking RAT infrastructure, etc.). Narrowed to an
+    explicit domain list so the attribution is honest.
 author: AndroDR
-date: 2026/03/27
+date: 2026/05/17
 references:
     - https://citizenlab.ca/tag/paragon/
 tags:
     - attack.t1437
+    - campaign.paragon
+    - campaign.graphite
 logsource:
     product: androdr
     service: dns_monitor
 detection:
+    # NOTE: These are placeholder domains that have been in the bundled
+    # blocklist as demo data. Real Citizen Lab Paragon C2 indicators have
+    # not yet been sourced into ioc-data/c2-domains.yml with explicit
+    # family attribution. When real Paragon-attributed C2 domains are
+    # published and ingested, add them here and remove the placeholders.
     selection:
-        domain|ioc_lookup: domain_ioc_db
+        domain:
+            - "paragon-graphite.net"
+            - "graphite-spyware.xyz"
     condition: selection
 level: critical
 category: incident
@@ -27,6 +40,7 @@ display:
     guidance: "CRITICAL -- nation-state spyware indicators; seek expert forensic assistance"
 falsepositives:
     - Domains may be repurposed after takedown
+    - Current list is placeholder data; the rule will not fire on real Paragon infrastructure until that data is sourced
 remediation:
     - "A connection to infrastructure associated with Paragon Graphite spyware was blocked."
     - "This may indicate your device is targeted by a nation-state level threat."

--- a/app/src/test/resources/gate4-fixtures/graphite-paragon-narrow.yml
+++ b/app/src/test/resources/gate4-fixtures/graphite-paragon-narrow.yml
@@ -1,0 +1,25 @@
+# Fixture for androdr-005: DNS query to known Graphite/Paragon C2 domain.
+# Validates the post-narrowing behavior — only the 2 explicitly-listed
+# placeholder domains fire the "Graphite/Paragon Spyware" attribution.
+# Other malicious-domain hits (e.g., NGate, BITTER, stalkerware) must NOT
+# trigger Graphite attribution; they surface via generic androdr-003 instead.
+#
+# When real Paragon C2 indicators are sourced into the rule, expand the TP
+# set here to include them.
+rule_file: sigma_androdr_005_graphite_paragon.yml
+service: dns_monitor
+true_positives:
+  - domain: "paragon-graphite.net"
+  - domain: "graphite-spyware.xyz"
+true_negatives:
+  # Other malicious families — must NOT trigger Graphite/Paragon attribution
+  - domain: "protecaocartao.online"           # NGate
+  - domain: "noblico.net"                     # BITTER
+  - domain: "comodo-vpn.com"                  # DCHSpy MuddyWater
+  - domain: "thetruthspy.com"                 # stalkerware
+  # Near-substring on the original Graphite name — must NOT match equality selector
+  - domain: "not-paragon-graphite.net.evil"
+  - domain: "paragon-graphite.net.evil.example.com"
+  # Benign domains
+  - domain: "www.google.com"
+  - domain: "github.com"


### PR DESCRIPTION
## Summary

Pulls in [sigma#20](https://github.com/android-sigma-rules/rules/pull/20) (merged as \`a37b596\`). Companion to #184 (androdr-078 fix). Same architectural bug — broad \`ioc_lookup\` selector causing misleading nation-state attribution on unrelated malicious-domain hits.

## Change

```diff
 detection:
     selection:
-        domain|ioc_lookup: domain_ioc_db
+        domain:
+            - "paragon-graphite.net"
+            - "graphite-spyware.xyz"
     condition: selection
```

- Submodule bump: \`third-party/android-sigma-rules\` fbc17c9 → a37b596
- Bundled copy synced
- New Gate 4 fixture \`graphite-paragon-narrow.yml\` with TN set including NGate / BITTER / DCHSpy / stalkerware domains — none should trigger Graphite attribution

## Known limitation (intentional)

The 2 narrowed domains are demo placeholders, not real Paragon C2 infrastructure. They've been in \`domain_blocklist.txt\` without being traced to a Citizen Lab source. This PR fixes the wrong-attribution bug but doesn't fix the missing-data problem. Follow-up: source real Paragon C2 indicators into \`ioc-data/c2-domains.yml\` with \`family: Paragon\`, expand the rule's selector to include them.

## Local validation

- \`validate-rule.py\` PASS on the canonical sigma rule
- \`./gradlew testDebugUnitTest --tests "com.androdr.sigma.GateFourFixtureTest"\` BUILD SUCCESSFUL — 14/14 fixtures green (the new graphite-paragon-narrow fixture's TN set explicitly verifies other malicious-family domains do NOT trigger Graphite attribution)

## Test plan

- [ ] CI \`build-and-test\` runs Gate 4 — graphite-paragon-narrow should pass
- [ ] Confirm no behavioral regression: generic \`androdr-003\` ("Malicious Domain") still fires on all the previously-broad-attributed domains; only the misleading Graphite label was removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)