### PR TITLE
feat(rules): wire androdr-078 Massistant into bundled engine loader

### DIFF
--- a/app/src/main/java/com/androdr/sigma/SigmaRuleEngine.kt
+++ b/app/src/main/java/com/androdr/sigma/SigmaRuleEngine.kt
@@ -339,6 +339,7 @@ class SigmaRuleEngine @Inject constructor(
             R.raw.sigma_androdr_074_package_install_history_pattern,
             R.raw.sigma_androdr_075_platform_compat_override,
             R.raw.sigma_androdr_076_database_path_access,
+            R.raw.sigma_androdr_078_meiya_pico_forensics,
             // Atom rules — pass-through matchers for raw timeline event categories.
             // Referenced by sprint-75 correlation rules (Task 9); tagged
             // level: informational so they are filtered out of the user-facing


### PR DESCRIPTION
## Summary

Companion to [sigma#21](https://github.com/android-sigma-rules/rules/pull/21) (\`3a35fa7\`, merged) which promoted \`androdr-078\` to production. This PR wires the rule into AndroDR's bundled \`SigmaRuleEngine.kt\` loader list so it's active offline-first for new APK installs.

Before: rule was bundled in \`res/raw/\` but never loaded by the engine (the same dormant state as 069/070/077, documented in [#180](https://github.com/yasirhamza/AndroDR/issues/180)). After: joins the active loader set, matching the pattern for production labeled wrappers like \`androdr-051\` Cellebrite and \`androdr-005\` Graphite/Paragon.

## Changes

- Submodule bump: \`third-party/android-sigma-rules\` a37b596 → 3a35fa7
- \`app/src/main/java/com/androdr/sigma/SigmaRuleEngine.kt\`: +1 entry (\`R.raw.sigma_androdr_078_meiya_pico_forensics\`, inserted after \`_076\` in numeric order)

## After this merges

\`androdr-078\` is active via two parallel paths:

| Path | Triggers when |
|------|---------------|
| Bundled loader (this PR) | App startup, every scan, on new APK installs |
| Remote fetch (sigma#21's \`rules.txt\` entry) | Next \`IocUpdateWorker\` run on existing installs |

## Local validation

- \`./gradlew testDebugUnitTest\` BUILD SUCCESSFUL in 11s
- Submodule pointer matches sigma main HEAD (3a35fa7)
- Per [\`feedback_local_ci_policy\`](https://github.com/yasirhamza/AndroDR/tree/main/.claude/memory): local validation only, GHA cancelled to save budget

🤖 Generated with [Claude Code](https://claude.com/claude-code)