### PR TITLE
fix(#168): register broker-SDK rules in SigmaRuleEngine loader manifest

### DIFF
--- a/app/src/main/java/com/androdr/sigma/SigmaRuleEngine.kt
+++ b/app/src/main/java/com/androdr/sigma/SigmaRuleEngine.kt
@@ -340,6 +340,10 @@ class SigmaRuleEngine @Inject constructor(
             R.raw.sigma_androdr_075_platform_compat_override,
             R.raw.sigma_androdr_076_database_path_access,
             R.raw.sigma_androdr_078_meiya_pico_forensics,
+            R.raw.sigma_androdr_079_data_broker_outlogic,
+            R.raw.sigma_androdr_080_data_broker_venntel,
+            R.raw.sigma_androdr_081_data_broker_predicio,
+            R.raw.sigma_androdr_082_data_broker_cuebiq,
             // Atom rules — pass-through matchers for raw timeline event categories.
             // Referenced by sprint-75 correlation rules (Task 9); tagged
             // level: informational so they are filtered out of the user-facing


### PR DESCRIPTION
## Summary
- One-line fix: add `R.raw.sigma_androdr_07{9,80,81,82}_data_broker_*` to the explicit-manifest list in `SigmaRuleEngine.kt`.
- Closes the loader gap surfaced by an end-to-end positive on-device verification on the Z Fold 2: the rule YAMLs shipped to `res/raw/` in PR #189 were not being registered with the loader, so they never fired on device.

## Repro
Built 4 minimal stub APKs declaring services/receivers under `io.xmode.*`, `com.timerazor.gravysdk.*`, `com.telescope.android.*`, `com.cuebiq.cuebiqsdk.*`. Installed via `adb install`; triggered AndroDR scan.

**Before this fix:**
```
SigmaRuleEngine: Loaded 45 bundled SIGMA rules     # missing 4
ScanOrchestrator: SIGMA: 19 findings from 48 rules
Broker-SDK findings: 0
```

**After this fix (rebuilt + reinstalled):**
```
SigmaRuleEngine: Loaded 49 bundled SIGMA rules
ScanOrchestrator: SIGMA: 23 findings from 52 rules
Broker-SDK findings:
  androdr-079 (Outlogic) — 1 firing, on com.androdr.fixture.broker.outlogic
  androdr-080 (Venntel)  — 1 firing, on com.androdr.fixture.broker.venntel
  androdr-081 (Predicio) — 1 firing, on com.androdr.fixture.broker.predicio
  androdr-082 (Cuebiq)   — 1 firing, on com.androdr.fixture.broker.cuebiq
```

Cross-isolation held (no cross-fixture FPs).

## Test plan
- [x] `./gradlew :app:testDebugUnitTest --tests 'com.androdr.sigma.GateFourFixtureTest' --tests 'com.androdr.sigma.BundledRulesSchemaCrossCheckTest' --tests 'com.androdr.sigma.SigmaRuleParserTest'`: green
- [x] On-device end-to-end positive verification (see Repro)
- [x] All 4 stub fixtures uninstalled afterward — device state restored

## Follow-up to consider
`BundledRulesSchemaCrossCheckTest` does not detect the case where a `res/raw/sigma_androdr_*.yml` file exists on disk but is missing from `SigmaRuleEngine.kt`'s manifest list. Adding a completeness check would catch this class of gap automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)