### PR TITLE
feat(#168): promote broker-SDK rules to production

### DIFF
--- a/app/src/main/res/raw/sigma_androdr_079_data_broker_outlogic.yml
+++ b/app/src/main/res/raw/sigma_androdr_079_data_broker_outlogic.yml
@@ -1,6 +1,6 @@
 title: Embedded data-broker SDK — Outlogic (X-Mode Social)
 id: androdr-079
-status: experimental
+status: production
 category: incident
 description: >
     Detects the Outlogic (formerly X-Mode Social) location-data broker SDK

--- a/app/src/main/res/raw/sigma_androdr_080_data_broker_venntel.yml
+++ b/app/src/main/res/raw/sigma_androdr_080_data_broker_venntel.yml
@@ -1,6 +1,6 @@
 title: Embedded data-broker SDK — Venntel (Gravy GOLD legacy)
 id: androdr-080
-status: experimental
+status: production
 category: incident
 description: >
     Detects the legacy Gravy GOLD SDK (published under TimeRAZOR Inc.,

--- a/app/src/main/res/raw/sigma_androdr_081_data_broker_predicio.yml
+++ b/app/src/main/res/raw/sigma_androdr_081_data_broker_predicio.yml
@@ -1,6 +1,6 @@
 title: Embedded data-broker SDK — Predicio (Telescope)
 id: androdr-081
-status: experimental
+status: production
 category: incident
 description: >
     Detects the Predicio 'Telescope' SDK embedded inside an installed app.

--- a/app/src/main/res/raw/sigma_androdr_082_data_broker_cuebiq.yml
+++ b/app/src/main/res/raw/sigma_androdr_082_data_broker_cuebiq.yml
@@ -1,6 +1,6 @@
 title: Embedded data-broker SDK — Cuebiq
 id: androdr-082
-status: experimental
+status: production
 category: incident
 description: >
     Detects the Cuebiq location-data broker SDK embedded inside an


### PR DESCRIPTION
## Summary
- Bumps submodule pointer to `android-sigma-rules` PR #23 / squash `1e46f59` (which moved `androdr-079..082` from `staging/app_scanner/` to `app_scanner/` and flipped `status: experimental` → `status: production`).
- Re-copies the 4 broker-SDK rule YAMLs into `app/src/main/res/raw/` with `status: production`.

No content changes beyond the status line — detection, references, display, tags, level (`medium`), and `filter_system_app` are unchanged.

## Promotion criteria met
- End-to-end positive verification on Z Fold 2 (PR #190): all 4 rules fired exactly once on synthetic fixtures, cross-isolation held.
- Zero FPs on a 435-app real device inventory (PR #189 on-device dry-run).
- Two-reviewer cycle + Gate 5 LLM review: PASS at PR-189 time.

## Test plan
- [x] `./gradlew :app:testDebugUnitTest --tests 'com.androdr.sigma.GateFourFixtureTest' --tests 'com.androdr.sigma.BundledRulesManifestCompletenessTest' --tests 'com.androdr.sigma.BundledRulesSchemaCrossCheckTest' --tests 'com.androdr.sigma.SigmaRuleParserTest'`: green
- [x] Existing 4 broker-SDK Gate-4 fixtures continue to pass (their `rule_file` references didn't change; only the rule's `status` field).

🤖 Generated with [Claude Code](https://claude.com/claude-code)