### PR TITLE
feat(theme): light/dark mode with OS-following + semantic-color migration

### DIFF
--- a/app/src/main/java/com/androdr/MainActivity.kt
+++ b/app/src/main/java/com/androdr/MainActivity.kt
@@ -2,6 +2,7 @@ package com.androdr
 
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Dashboard
@@ -12,14 +13,23 @@ import androidx.compose.material.icons.outlined.Apps
 import androidx.compose.material3.Icon
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.luminance
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.LocalView
+import androidx.core.view.WindowCompat
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.compose.NavHost
 import androidx.navigation.NavType
@@ -35,21 +45,56 @@ import com.androdr.ui.history.HistoryScreen
 import com.androdr.ui.network.DnsMonitorScreen
 import com.androdr.ui.timeline.TimelineScreen
 import com.androdr.ui.settings.SettingsScreen
+import com.androdr.data.repo.SettingsRepository
 import com.androdr.ui.theme.AndroDRTheme
+import com.androdr.ui.theme.ThemeMode
 import android.app.Activity
 import android.net.Uri
 import dagger.hilt.android.AndroidEntryPoint
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
 
+    @Inject lateinit var settingsRepository: SettingsRepository
+
     override fun onCreate(savedInstanceState: android.os.Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
-            AndroDRTheme {
-                AndroDRApp()
+            val themeMode by settingsRepository.themeMode
+                .collectAsStateWithLifecycle(initialValue = ThemeMode.AUTO)
+            AndroDRTheme(themeMode = themeMode) {
+                SystemBarsEffect()
+                Surface(
+                    modifier = Modifier.fillMaxSize(),
+                    color = MaterialTheme.colorScheme.background
+                ) {
+                    AndroDRApp()
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SystemBarsEffect() {
+    val view = LocalView.current
+    val surface = MaterialTheme.colorScheme.surface
+    val surfaceArgb = surface.toArgb()
+    // Drive icon brightness from the actual surface luminance — this is the
+    // only truthful signal when the user has forced LIGHT on a system-dark
+    // device or vice versa. isSystemInDarkTheme() lies in that case.
+    val barsLookDark = surface.luminance() < 0.5f
+    if (!view.isInEditMode) {
+        SideEffect {
+            val window = (view.context as android.app.Activity).window
+            window.statusBarColor = surfaceArgb
+            window.navigationBarColor = surfaceArgb
+            WindowCompat.getInsetsController(window, view).apply {
+                isAppearanceLightStatusBars = !barsLookDark
+                isAppearanceLightNavigationBars = !barsLookDark
             }
         }
     }

--- a/app/src/main/java/com/androdr/data/repo/SettingsRepository.kt
+++ b/app/src/main/java/com/androdr/data/repo/SettingsRepository.kt
@@ -5,6 +5,7 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
+import com.androdr.ui.theme.ThemeMode
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
@@ -34,6 +35,19 @@ class SettingsRepository @Inject constructor(
 
     suspend fun setDomainIocBlockMode(value: Boolean) {
         dataStore.edit { it[KEY_DOMAIN_IOC_BLOCK_MODE] = value }
+    }
+
+    val themeMode: Flow<ThemeMode> = dataStore.data
+        .map { prefs ->
+            when (prefs[KEY_THEME_MODE]) {
+                "LIGHT" -> ThemeMode.LIGHT
+                "DARK"  -> ThemeMode.DARK
+                else    -> ThemeMode.AUTO
+            }
+        }
+
+    suspend fun setThemeMode(mode: ThemeMode) {
+        dataStore.edit { it[KEY_THEME_MODE] = mode.name }
     }
 
     /**
@@ -103,5 +117,6 @@ class SettingsRepository @Inject constructor(
         private val KEY_BLOCKLIST_BLOCK_MODE  = booleanPreferencesKey("blocklist_block_mode")
         private val KEY_DOMAIN_IOC_BLOCK_MODE = booleanPreferencesKey("domain_ioc_block_mode")
         private val KEY_CUSTOM_RULE_URLS = stringPreferencesKey("custom_sigma_rule_urls")
+        private val KEY_THEME_MODE = stringPreferencesKey("theme_mode")
     }
 }

--- a/app/src/main/java/com/androdr/ui/apps/AppScanScreen.kt
+++ b/app/src/main/java/com/androdr/ui/apps/AppScanScreen.kt
@@ -52,7 +52,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -63,6 +62,7 @@ import com.androdr.R
 import com.androdr.sigma.Finding
 import com.androdr.ui.common.SeverityChip
 import com.androdr.ui.common.severityColor
+import com.androdr.ui.theme.androdrColors
 
 private val FILTER_LEVELS = listOf("critical", "high", "medium", "low")
 
@@ -167,7 +167,8 @@ fun AppScanScreen(
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun AppGroupCard(group: AppGroup, onClick: () -> Unit) {
-    val color = severityColor(group.highestLevel)
+    val colors = MaterialTheme.androdrColors
+    val color = severityColor(group.highestLevel, colors)
 
     Card(
         modifier = Modifier
@@ -244,7 +245,8 @@ private fun AppGroupDetailSheet(
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val context = LocalContext.current
-    val color = severityColor(group.highestLevel)
+    val colors = MaterialTheme.androdrColors
+    val color = severityColor(group.highestLevel, colors)
 
     ModalBottomSheet(
         onDismissRequest = onDismiss,
@@ -322,7 +324,7 @@ private fun AppGroupDetailSheet(
                         Icon(
                             imageVector = Icons.Filled.Warning,
                             contentDescription = null,
-                            tint = severityColor(finding.level),
+                            tint = severityColor(finding.level, colors),
                             modifier = Modifier.size(18.dp)
                         )
                         Column {
@@ -425,7 +427,8 @@ private fun AppGroupDetailSheet(
 
 @Composable
 fun RiskChip(level: String, modifier: Modifier = Modifier) {
-    val color = severityColor(level)
+    val colors = MaterialTheme.androdrColors
+    val color = severityColor(level, colors)
     SuggestionChip(
         onClick = {},
         label = {
@@ -442,5 +445,3 @@ fun RiskChip(level: String, modifier: Modifier = Modifier) {
         modifier = modifier
     )
 }
-
-fun riskLevelColor(level: String): Color = severityColor(level)

--- a/app/src/main/java/com/androdr/ui/bugreport/BugReportScreen.kt
+++ b/app/src/main/java/com/androdr/ui/bugreport/BugReportScreen.kt
@@ -54,6 +54,8 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.androdr.R
 import com.androdr.ui.common.FindingCard
+import com.androdr.ui.theme.ExtendedColors
+import com.androdr.ui.theme.androdrColors
 
 @Suppress("LongMethod") // Bug report screen combines file-picker launch, progress state,
 // empty-state, completion confirmation, error card, findings list, timeline, and export.
@@ -438,7 +440,7 @@ fun BugReportScreen(
 
 @Composable
 private fun TimelineEventCard(event: com.androdr.data.model.TimelineEvent) {
-    val (icon, color) = findingIconAndColor(event.severity)
+    val (icon, color) = findingIconAndColor(event.severity, MaterialTheme.androdrColors)
 
     Card(
         modifier = Modifier.fillMaxWidth(),
@@ -487,10 +489,13 @@ private fun TimelineEventCard(event: com.androdr.data.model.TimelineEvent) {
     }
 }
 
-private fun findingIconAndColor(severity: String): Pair<ImageVector, Color> = when (severity.uppercase()) {
-    "CRITICAL" -> Pair(Icons.Filled.Error, Color(0xFFCF6679))
-    "HIGH" -> Pair(Icons.Filled.Warning, Color(0xFFFF9800))
-    "MEDIUM" -> Pair(Icons.Filled.Warning, Color(0xFFE6A800))
-    "ERROR" -> Pair(Icons.Filled.Error, Color(0xFFCF6679))
-    else -> Pair(Icons.Filled.Info, Color(0xFF00D4AA))
+private fun findingIconAndColor(
+    severity: String,
+    colors: ExtendedColors
+): Pair<ImageVector, Color> = when (severity.uppercase()) {
+    "CRITICAL" -> Pair(Icons.Filled.Error, colors.critical)
+    "HIGH"     -> Pair(Icons.Filled.Warning, colors.high)
+    "MEDIUM"   -> Pair(Icons.Filled.Warning, colors.medium)
+    "ERROR"    -> Pair(Icons.Filled.Error, colors.critical)
+    else       -> Pair(Icons.Filled.Info, colors.neutral)
 }

--- a/app/src/main/java/com/androdr/ui/common/EvidenceSheet.kt
+++ b/app/src/main/java/com/androdr/ui/common/EvidenceSheet.kt
@@ -24,13 +24,13 @@ import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.androdr.sigma.CveEvidence
 import com.androdr.sigma.Evidence
 import com.androdr.sigma.Finding
+import com.androdr.ui.theme.androdrColors
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -105,7 +105,7 @@ private fun CveListContent(evidence: Evidence.CveList, remediation: List<String>
         Text(
             text = "${evidence.campaignCount} CVE(s) linked to known spyware campaigns",
             style = MaterialTheme.typography.bodySmall,
-            color = Color(0xFFCF6679)
+            color = MaterialTheme.androdrColors.critical
         )
     }
 
@@ -155,7 +155,7 @@ private fun CveCard(cve: CveEvidence) {
         modifier = Modifier.fillMaxWidth(),
         colors = CardDefaults.cardColors(
             containerColor = if (cve.campaigns.isNotEmpty())
-                Color(0xFFCF6679).copy(alpha = 0.06f)
+                MaterialTheme.androdrColors.critical.copy(alpha = 0.06f)
             else
                 MaterialTheme.colorScheme.surfaceContainer
         )
@@ -202,8 +202,8 @@ private fun CveCard(cve: CveEvidence) {
                                 )
                             },
                             colors = SuggestionChipDefaults.suggestionChipColors(
-                                containerColor = Color(0xFFCF6679).copy(alpha = 0.2f),
-                                labelColor = Color(0xFFCF6679)
+                                containerColor = MaterialTheme.androdrColors.criticalContainer,
+                                labelColor = MaterialTheme.androdrColors.critical
                             )
                         )
                     }
@@ -258,7 +258,7 @@ private fun PermissionClusterContent(evidence: Evidence.PermissionCluster) {
     Text(
         text = "${evidence.surveillanceCount} of ${evidence.permissions.size} permissions are surveillance-capable",
         style = MaterialTheme.typography.bodySmall,
-        color = Color(0xFFCF6679)
+        color = MaterialTheme.androdrColors.critical
     )
 
     Spacer(modifier = Modifier.height(4.dp))
@@ -278,8 +278,8 @@ private fun PermissionClusterContent(evidence: Evidence.PermissionCluster) {
                     )
                 },
                 colors = SuggestionChipDefaults.suggestionChipColors(
-                    containerColor = Color(0xFFFF9800).copy(alpha = 0.15f),
-                    labelColor = Color(0xFFFF9800)
+                    containerColor = MaterialTheme.androdrColors.high.copy(alpha = 0.15f),
+                    labelColor = MaterialTheme.androdrColors.high
                 )
             )
         }

--- a/app/src/main/java/com/androdr/ui/common/FindingCard.kt
+++ b/app/src/main/java/com/androdr/ui/common/FindingCard.kt
@@ -21,13 +21,13 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.androdr.R
 import com.androdr.sigma.Evidence
 import com.androdr.sigma.Finding
+import com.androdr.ui.theme.androdrColors
 
 // Compose composable rendering a finding card with evidence summary; splitting would fragment UI logic
 @Suppress("LongMethod")
@@ -39,8 +39,8 @@ fun FindingCard(finding: Finding, onEvidenceTap: ((Finding) -> Unit)? = null) {
             if (hasEvidence && onEvidenceTap != null) Modifier.clickable { onEvidenceTap(finding) } else Modifier
         ),
         colors = CardDefaults.cardColors(
-            containerColor = if (finding.triggered) Color(0xFFCF6679).copy(alpha = 0.08f)
-            else MaterialTheme.colorScheme.surfaceContainerHigh
+            containerColor = if (finding.triggered) MaterialTheme.androdrColors.critical.copy(alpha = 0.08f)
+                             else MaterialTheme.colorScheme.surfaceContainer
         )
     ) {
         Row(modifier = Modifier.padding(16.dp), horizontalArrangement = Arrangement.spacedBy(12.dp)) {
@@ -51,7 +51,8 @@ fun FindingCard(finding: Finding, onEvidenceTap: ((Finding) -> Unit)? = null) {
                 } else {
                     stringResource(R.string.finding_passed)
                 },
-                tint = if (finding.triggered) Color(0xFFCF6679) else MaterialTheme.colorScheme.primary,
+                tint = if (finding.triggered) MaterialTheme.androdrColors.critical
+                       else MaterialTheme.colorScheme.primary,
                 modifier = Modifier.size(24.dp)
             )
             Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(4.dp)) {

--- a/app/src/main/java/com/androdr/ui/common/SeverityChip.kt
+++ b/app/src/main/java/com/androdr/ui/common/SeverityChip.kt
@@ -7,16 +7,14 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
+import com.androdr.ui.theme.ExtendedColors
+import com.androdr.ui.theme.androdrColors
 
 @Composable
 fun SeverityChip(level: String, active: Boolean = true) {
-    val severityColor = when (level.lowercase()) {
-        "critical" -> Color(0xFFCF6679)
-        "high" -> Color(0xFFFF9800)
-        "medium" -> Color(0xFFE6A800)
-        else -> Color(0xFF00D4AA)
-    }
-    val color = if (active) severityColor else Color(0xFF888888)
+    val colors = MaterialTheme.androdrColors
+    val severityHue = severityColor(level, colors)
+    val color = if (active) severityHue else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
     SuggestionChip(
         onClick = {},
         label = {
@@ -33,9 +31,16 @@ fun SeverityChip(level: String, active: Boolean = true) {
     )
 }
 
-fun severityColor(level: String): Color = when (level.lowercase()) {
-    "critical" -> Color(0xFFCF6679)
-    "high" -> Color(0xFFFF9800)
-    "medium" -> Color(0xFFE6A800)
-    else -> Color(0xFF00D4AA)
+/**
+ * Non-Composable severity → color lookup. Takes the palette as a parameter so
+ * non-Composable callers (e.g. result-formatting helpers) can use it without
+ * having to become @Composable themselves. Composable callers should pass
+ * `MaterialTheme.androdrColors`.
+ */
+fun severityColor(level: String, colors: ExtendedColors): Color = when (level.lowercase()) {
+    "critical" -> colors.critical
+    "high"     -> colors.high
+    "medium"   -> colors.medium
+    "low"      -> colors.low
+    else       -> colors.neutral
 }

--- a/app/src/main/java/com/androdr/ui/common/SeverityChip.kt
+++ b/app/src/main/java/com/androdr/ui/common/SeverityChip.kt
@@ -1,13 +1,23 @@
 package com.androdr.ui.common
 
+import android.content.res.Configuration
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SuggestionChip
 import androidx.compose.material3.SuggestionChipDefaults
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.androdr.ui.theme.AndroDRTheme
 import com.androdr.ui.theme.ExtendedColors
+import com.androdr.ui.theme.ThemeMode
 import com.androdr.ui.theme.androdrColors
 
 @Composable
@@ -43,4 +53,22 @@ fun severityColor(level: String, colors: ExtendedColors): Color = when (level.lo
     "medium"   -> colors.medium
     "low"      -> colors.low
     else       -> colors.neutral
+}
+
+@Preview(name = "Severity chips — Dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Preview(name = "Severity chips — Light", uiMode = Configuration.UI_MODE_NIGHT_NO)
+@Composable
+private fun SeverityChipPreview() {
+    AndroDRTheme(themeMode = ThemeMode.AUTO) {
+        Surface(color = MaterialTheme.colorScheme.background) {
+            Row(
+                modifier = Modifier.padding(16.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                listOf("critical", "high", "medium", "low").forEach { level ->
+                    SeverityChip(level = level)
+                }
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/androdr/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/com/androdr/ui/dashboard/DashboardScreen.kt
@@ -48,7 +48,6 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -58,7 +57,7 @@ import com.androdr.R
 import com.androdr.data.model.RiskLevel
 import com.androdr.data.model.ScanResult
 import com.androdr.scanner.ScanProgress
-import com.androdr.ui.common.severityColor
+import com.androdr.ui.theme.androdrColors
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -285,6 +284,7 @@ fun DashboardScreen(
 
 @Composable
 private fun PostScanGuidance(riskLevel: RiskLevel?, latestScan: ScanResult?) {
+    val colors = MaterialTheme.androdrColors
     val hasCriticalAppRisks = latestScan?.appRisks?.any {
         it.triggered && it.level.lowercase() == "critical"
     } ?: false
@@ -297,22 +297,27 @@ private fun PostScanGuidance(riskLevel: RiskLevel?, latestScan: ScanResult?) {
                 stringResource(R.string.guidance_critical_device)
             },
             Icons.Filled.Error,
-            Color(0xFFCF6679)
+            colors.critical
         )
         RiskLevel.HIGH -> Triple(
             stringResource(R.string.guidance_high),
             Icons.Filled.Warning,
-            Color(0xFFFF9800)
+            colors.high
         )
         RiskLevel.MEDIUM -> Triple(
             stringResource(R.string.guidance_medium),
             Icons.Filled.Info,
-            Color(0xFFE6A800)
+            colors.medium
         )
-        RiskLevel.LOW, null -> Triple(
+        RiskLevel.LOW -> Triple(
             stringResource(R.string.guidance_low),
             Icons.Filled.CheckCircle,
-            Color(0xFF00D4AA)
+            colors.low
+        )
+        null -> Triple(
+            stringResource(R.string.guidance_low),
+            Icons.Filled.CheckCircle,
+            colors.neutral
         )
     }
 
@@ -342,12 +347,13 @@ private fun PostScanGuidance(riskLevel: RiskLevel?, latestScan: ScanResult?) {
 @Suppress("LongMethod") // Compose UI layout with conditional risk display
 @Composable
 private fun RiskLevelCard(latestScan: ScanResult?) {
+    val colors = MaterialTheme.androdrColors
     val (riskColor, riskLabel) = when (latestScan?.overallRiskLevel) {
-        RiskLevel.CRITICAL -> Pair(Color(0xFFFF1744), "CRITICAL")  // bold red — unmistakable danger
-        RiskLevel.HIGH     -> Pair(Color(0xFFFF6E40), "HIGH")     // deep orange
-        RiskLevel.MEDIUM   -> Pair(Color(0xFFFFD54F), "MEDIUM")   // amber
-        RiskLevel.LOW      -> Pair(Color(0xFF00D4AA), "LOW")      // brand teal — all clear
-        null               -> Pair(Color(0xFF00D4AA), "\u2014")
+        RiskLevel.CRITICAL -> Pair(colors.critical, "CRITICAL")
+        RiskLevel.HIGH     -> Pair(colors.high, "HIGH")
+        RiskLevel.MEDIUM   -> Pair(colors.medium, "MEDIUM")
+        RiskLevel.LOW      -> Pair(colors.low, "LOW")
+        null               -> Pair(colors.neutral, "\u2014")
     }
 
     Card(
@@ -405,10 +411,11 @@ private fun RiskLevelCard(latestScan: ScanResult?) {
 
 @Composable
 private fun DiffBanner(newCount: Int) {
+    val colors = MaterialTheme.androdrColors
     Card(
         modifier = Modifier.fillMaxWidth(),
         colors = CardDefaults.cardColors(
-            containerColor = Color(0xFFFF9800).copy(alpha = 0.15f)
+            containerColor = colors.high.copy(alpha = 0.15f)
         )
     ) {
         Row(
@@ -419,13 +426,13 @@ private fun DiffBanner(newCount: Int) {
             Icon(
                 imageVector = Icons.Filled.Warning,
                 contentDescription = null,
-                tint = Color(0xFFFF9800)
+                tint = colors.high
             )
             Text(
                 text = stringResource(R.string.dashboard_new_risks, newCount),
                 style = MaterialTheme.typography.bodyMedium,
                 fontWeight = FontWeight.SemiBold,
-                color = Color(0xFFFF9800)
+                color = colors.high
             )
         }
     }
@@ -561,10 +568,11 @@ private fun ScanProgressCard(progress: ScanProgress) {
  */
 @Composable
 private fun PartialScanBanner(scan: ScanResult) {
+    val colors = MaterialTheme.androdrColors
     Card(
         modifier = Modifier.fillMaxWidth(),
         colors = CardDefaults.cardColors(
-            containerColor = Color(0xFFFF9800).copy(alpha = 0.15f)
+            containerColor = colors.high.copy(alpha = 0.15f)
         )
     ) {
         Row(
@@ -575,14 +583,14 @@ private fun PartialScanBanner(scan: ScanResult) {
             Icon(
                 imageVector = Icons.Filled.Warning,
                 contentDescription = null,
-                tint = Color(0xFFFF9800)
+                tint = colors.high
             )
             Column(modifier = Modifier.weight(1f)) {
                 Text(
                     text = stringResource(R.string.partial_scan_banner_title),
                     style = MaterialTheme.typography.titleSmall,
                     fontWeight = FontWeight.SemiBold,
-                    color = Color(0xFFFF9800)
+                    color = colors.high
                 )
                 Text(
                     text = stringResource(

--- a/app/src/main/java/com/androdr/ui/device/DeviceAuditScreen.kt
+++ b/app/src/main/java/com/androdr/ui/device/DeviceAuditScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.androdr.ui.theme.androdrColors
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.androdr.R
@@ -85,7 +86,7 @@ fun DeviceAuditScreen(
                         Text(
                             text = stringResource(R.string.device_issues_attention, triggeredCount),
                             style = MaterialTheme.typography.bodySmall,
-                            color = Color(0xFFCF6679)
+                            color = MaterialTheme.androdrColors.critical
                         )
                     } else if (totalCount > 0) {
                         Text(
@@ -123,7 +124,7 @@ fun DeviceAuditScreen(
                 item {
                     SectionHeader(
                         text = stringResource(R.string.section_issues_found),
-                        color = Color(0xFFCF6679)
+                        color = MaterialTheme.androdrColors.critical
                     )
                 }
                 items(triggeredFindings) { finding ->

--- a/app/src/main/java/com/androdr/ui/history/HistoryScreen.kt
+++ b/app/src/main/java/com/androdr/ui/history/HistoryScreen.kt
@@ -58,7 +58,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
@@ -72,6 +71,7 @@ import com.androdr.reporting.ExportMode
 import com.androdr.scanner.ScanOrchestrator
 import com.androdr.ui.common.ExportModeDialog
 import com.androdr.ui.common.severityColor
+import com.androdr.ui.theme.androdrColors
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -249,7 +249,8 @@ private fun ScanReportBottomSheet(
     val context = LocalContext.current
     val dateFormatter = remember { SimpleDateFormat("MMM d, yyyy  HH:mm", Locale.getDefault()) }
     val dateString = dateFormatter.format(Date(scan.timestamp))
-    val riskColor = severityColor(scan.overallRiskLevel.name)
+    val colors = MaterialTheme.androdrColors
+    val riskColor = severityColor(scan.overallRiskLevel.name, colors)
 
     ModalBottomSheet(
         onDismissRequest = onDismiss,
@@ -396,7 +397,8 @@ private fun ScanHistoryItem(
     val dateString = dateFormatter.format(Date(scan.timestamp))
 
     val riskLevel = scan.overallRiskLevel
-    val riskColor = severityColor(riskLevel.name)
+    val colors = MaterialTheme.androdrColors
+    val riskColor = severityColor(riskLevel.name, colors)
 
     Card(
         modifier = Modifier
@@ -558,13 +560,13 @@ private fun DiffSection(diff: ScanOrchestrator.ScanDiff) {
                 text = stringResource(R.string.diff_new_risks),
                 style = MaterialTheme.typography.labelMedium,
                 fontWeight = FontWeight.Bold,
-                color = Color(0xFFCF6679)
+                color = MaterialTheme.androdrColors.critical
             )
             diff.newFindings.forEach { finding ->
                 Text(
                     text = "\u2022 ${finding.title} (${finding.level.uppercase()})",
                     style = MaterialTheme.typography.bodySmall,
-                    color = Color(0xFFCF6679)
+                    color = MaterialTheme.androdrColors.critical
                 )
             }
         }

--- a/app/src/main/java/com/androdr/ui/network/DnsMonitorScreen.kt
+++ b/app/src/main/java/com/androdr/ui/network/DnsMonitorScreen.kt
@@ -36,7 +36,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -46,6 +45,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.androdr.R
 import com.androdr.ui.settings.SettingsViewModel
 import com.androdr.data.model.DnsEvent
+import com.androdr.ui.theme.androdrColors
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -255,7 +255,7 @@ private fun DnsEventItem(event: DnsEvent) {
         modifier = Modifier.fillMaxWidth(),
         colors = CardDefaults.cardColors(
             containerColor = if (isMatched)
-                Color(0xFFCF6679).copy(alpha = 0.08f)
+                MaterialTheme.androdrColors.critical.copy(alpha = 0.08f)
             else
                 MaterialTheme.colorScheme.surfaceContainerHigh
         )
@@ -270,7 +270,7 @@ private fun DnsEventItem(event: DnsEvent) {
                     text = event.domain,
                     style = MaterialTheme.typography.bodyMedium,
                     fontWeight = FontWeight.SemiBold,
-                    color = if (isMatched) Color(0xFFCF6679)
+                    color = if (isMatched) MaterialTheme.androdrColors.critical
                     else MaterialTheme.colorScheme.onSurface
                 )
                 Text(
@@ -299,10 +299,10 @@ private fun DnsEventItem(event: DnsEvent) {
                 },
                 colors = SuggestionChipDefaults.suggestionChipColors(
                     containerColor = if (isMatched)
-                        Color(0xFFCF6679).copy(alpha = 0.2f)
+                        MaterialTheme.androdrColors.criticalContainer
                     else
                         MaterialTheme.colorScheme.primary.copy(alpha = 0.15f),
-                    labelColor = if (isMatched) Color(0xFFCF6679)
+                    labelColor = if (isMatched) MaterialTheme.androdrColors.critical
                     else MaterialTheme.colorScheme.primary
                 )
             )

--- a/app/src/main/java/com/androdr/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/androdr/ui/settings/SettingsScreen.kt
@@ -23,6 +23,9 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -35,6 +38,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.androdr.ui.theme.ThemeMode
 import com.androdr.util.appVersion
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -47,6 +51,7 @@ fun SettingsScreen(viewModel: SettingsViewModel = hiltViewModel()) {
     val blocklistBlockMode by viewModel.blocklistBlockMode.collectAsStateWithLifecycle()
     val domainIocBlockMode by viewModel.domainIocBlockMode.collectAsStateWithLifecycle()
     val customRuleUrls by viewModel.customRuleUrls.collectAsStateWithLifecycle()
+    val themeMode by viewModel.themeMode.collectAsStateWithLifecycle()
 
     val sigmaRuleCount by viewModel.sigmaRuleCount.collectAsStateWithLifecycle()
     val domainIocCount by viewModel.domainIocCount.collectAsStateWithLifecycle()
@@ -123,6 +128,22 @@ fun SettingsScreen(viewModel: SettingsViewModel = hiltViewModel()) {
                 fontWeight = FontWeight.Bold,
                 color = MaterialTheme.colorScheme.primary
             )
+
+            Text(
+                text = "Appearance",
+                style = MaterialTheme.typography.titleMedium,
+                modifier = Modifier.padding(top = 16.dp)
+            )
+            Text(
+                text = "Choose how AndroDR adapts to your system theme.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            ThemeModePicker(
+                selected = themeMode,
+                onSelect = { viewModel.setThemeMode(it) }
+            )
+            HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
 
             Text(
                 text = "DNS Blocklist",
@@ -425,5 +446,28 @@ private fun UpdateStatusRow(label: String, status: String) {
             color = if (status.startsWith("Failed")) MaterialTheme.colorScheme.error
                     else MaterialTheme.colorScheme.primary
         )
+    }
+}
+
+@Composable
+private fun ThemeModePicker(
+    selected: ThemeMode,
+    onSelect: (ThemeMode) -> Unit
+) {
+    val options = listOf(
+        ThemeMode.AUTO  to "System",
+        ThemeMode.LIGHT to "Light",
+        ThemeMode.DARK  to "Dark"
+    )
+    SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+        options.forEachIndexed { index, (mode, label) ->
+            SegmentedButton(
+                selected = selected == mode,
+                onClick  = { onSelect(mode) },
+                shape    = SegmentedButtonDefaults.itemShape(index = index, count = options.size)
+            ) {
+                Text(label)
+            }
+        }
     }
 }

--- a/app/src/main/java/com/androdr/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/androdr/ui/settings/SettingsViewModel.kt
@@ -20,6 +20,7 @@ import com.androdr.ioc.OemPrefixResolver
 import com.androdr.scanner.AppScanner
 import com.androdr.sigma.SigmaRuleEngine
 import com.androdr.sigma.SigmaRuleFeed
+import com.androdr.ui.theme.ThemeMode
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
@@ -65,6 +66,13 @@ class SettingsViewModel @Inject constructor(
 
     val domainIocBlockMode = settingsRepository.domainIocBlockMode
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), false)
+
+    val themeMode = settingsRepository.themeMode
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), ThemeMode.AUTO)
+
+    fun setThemeMode(mode: ThemeMode) {
+        viewModelScope.launch { settingsRepository.setThemeMode(mode) }
+    }
 
     val customRuleUrls: StateFlow<String> get() = _customRuleUrlsInput.asStateFlow()
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), "")

--- a/app/src/main/java/com/androdr/ui/theme/ExtendedColors.kt
+++ b/app/src/main/java/com/androdr/ui/theme/ExtendedColors.kt
@@ -1,0 +1,67 @@
+package com.androdr.ui.theme
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.graphics.Color
+
+/**
+ * App-specific semantic colors that Material 3's ColorScheme does not cover:
+ * the four severity tiers and their chip-background tints. Two instances —
+ * one dark, one light. AndroDRTheme provides the right one via
+ * LocalAndroDRColors. Access through MaterialTheme.androdrColors.
+ *
+ * Container values are calibrated for the ~20% chip-background use case.
+ * For sub-percent washes (alert card backgrounds, 6-15%), call sites should
+ * use the base hue with .copy(alpha = …) — e.g. critical.copy(alpha = 0.08f).
+ * Such call sites are NOT caught by HardcodedColorGuardTest (the guard only
+ * matches Color(0xFF…) literals).
+ */
+data class ExtendedColors(
+    val critical: Color,
+    val high: Color,
+    val medium: Color,
+    val low: Color,
+    val neutral: Color,
+    val criticalContainer: Color,
+    val highContainer: Color,
+    val mediumContainer: Color,
+    val lowContainer: Color,
+)
+
+// Dark values preserve the existing hues so the dark UI is visually unchanged.
+val DarkExtendedColors = ExtendedColors(
+    critical          = Color(0xFFCF6679),
+    high              = Color(0xFFFF9800),
+    medium            = Color(0xFFE6A800),
+    low               = Color(0xFF64B5F6),
+    neutral           = TealPrimary,
+    criticalContainer = Color(0x33CF6679), // alpha 0x33 ≈ 0.20
+    highContainer     = Color(0x33FF9800),
+    mediumContainer   = Color(0x33E6A800),
+    lowContainer      = Color(0x3364B5F6),
+)
+
+// Light values are darker, deeper shades chosen to satisfy WCAG AA UI contrast (≥ 3.0)
+// on background 0xFFFAFAFA. Verified by ExtendedColorsContrastTest.
+val LightExtendedColors = ExtendedColors(
+    critical          = Color(0xFFB3261E),
+    high              = Color(0xFFC25700),
+    medium            = Color(0xFF8B6B00),
+    low               = Color(0xFF1565C0),
+    neutral           = Color(0xFF00695C),  // darker teal (TealPrimaryVariant 0xFF00A882 fails AA on white)
+    criticalContainer = Color(0xFFFFDAD6),
+    highContainer     = Color(0xFFFFDCC2),
+    mediumContainer   = Color(0xFFF6E5B4),
+    lowContainer      = Color(0xFFD0E4FF),
+)
+
+val LocalAndroDRColors = staticCompositionLocalOf<ExtendedColors> {
+    error("AndroDRTheme must wrap the call site (LocalAndroDRColors not provided)")
+}
+
+val MaterialTheme.androdrColors: ExtendedColors
+    @Composable
+    @ReadOnlyComposable
+    get() = LocalAndroDRColors.current

--- a/app/src/main/java/com/androdr/ui/theme/Theme.kt
+++ b/app/src/main/java/com/androdr/ui/theme/Theme.kt
@@ -1,9 +1,11 @@
 package com.androdr.ui.theme
 
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.graphics.Color
 
 // Primary brand color: teal/security green
@@ -84,9 +86,18 @@ private val LightColorScheme = lightColorScheme(
 )
 
 @Composable
-fun AndroDRTheme(content: @Composable () -> Unit) {
-    MaterialTheme(
-        colorScheme = DarkColorScheme,
-        content = content
-    )
+fun AndroDRTheme(
+    themeMode: ThemeMode = ThemeMode.AUTO,
+    content: @Composable () -> Unit
+) {
+    val useDarkTheme = resolveDarkTheme(themeMode, systemInDark = isSystemInDarkTheme())
+    val colorScheme    = if (useDarkTheme) DarkColorScheme   else LightColorScheme
+    val extendedColors = if (useDarkTheme) DarkExtendedColors else LightExtendedColors
+
+    CompositionLocalProvider(LocalAndroDRColors provides extendedColors) {
+        MaterialTheme(
+            colorScheme = colorScheme,
+            content = content
+        )
+    }
 }

--- a/app/src/main/java/com/androdr/ui/theme/Theme.kt
+++ b/app/src/main/java/com/androdr/ui/theme/Theme.kt
@@ -2,6 +2,7 @@ package com.androdr.ui.theme
 
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 
@@ -50,6 +51,36 @@ private val DarkColorScheme = darkColorScheme(
     surfaceContainer = SurfaceContainerDark,
     surfaceContainerHigh = SurfaceContainerHighDark,
     surfaceContainerLow = Color(0xFF181818),
+)
+
+private val LightColorScheme = lightColorScheme(
+    primary              = TealPrimaryVariant,            // 0xFF00A882
+    onPrimary            = Color.White,
+    primaryContainer     = Color(0xFFB2FFF0),
+    onPrimaryContainer   = Color(0xFF003328),
+    secondary            = Color(0xFF006B62),
+    onSecondary          = Color.White,
+    secondaryContainer   = Color(0xFF70F2E6),
+    onSecondaryContainer = Color(0xFF00201D),
+    tertiary             = Color(0xFF00658E),
+    onTertiary           = Color.White,
+    tertiaryContainer    = Color(0xFFC5E7FF),
+    onTertiaryContainer  = Color(0xFF001E2E),
+    error                = Color(0xFFB3261E),
+    onError              = Color.White,
+    errorContainer       = Color(0xFFFFDAD6),
+    onErrorContainer     = Color(0xFF410002),
+    background           = Color(0xFFFAFAFA),
+    onBackground         = Color(0xFF1A1A1A),
+    surface              = Color.White,
+    onSurface            = Color(0xFF1A1A1A),
+    surfaceVariant       = Color(0xFFEEEEEE),
+    onSurfaceVariant     = Color(0xFF4A4A4A),
+    outline              = Color(0xFF747878),
+    outlineVariant       = Color(0xFFC4C7C7),
+    surfaceContainer     = Color(0xFFF1F1F1),
+    surfaceContainerHigh = Color(0xFFEAEAEA),
+    surfaceContainerLow  = Color(0xFFF6F6F6),
 )
 
 @Composable

--- a/app/src/main/java/com/androdr/ui/theme/ThemeMode.kt
+++ b/app/src/main/java/com/androdr/ui/theme/ThemeMode.kt
@@ -1,0 +1,10 @@
+package com.androdr.ui.theme
+
+enum class ThemeMode { AUTO, LIGHT, DARK }
+
+fun resolveDarkTheme(themeMode: ThemeMode, systemInDark: Boolean): Boolean =
+    when (themeMode) {
+        ThemeMode.LIGHT -> false
+        ThemeMode.DARK  -> true
+        ThemeMode.AUTO  -> systemInDark
+    }

--- a/app/src/main/java/com/androdr/ui/timeline/TimelineEventCard.kt
+++ b/app/src/main/java/com/androdr/ui/timeline/TimelineEventCard.kt
@@ -53,6 +53,8 @@ import com.androdr.R
 import com.androdr.data.model.ForensicTimelineEvent
 import com.androdr.sigma.FindingCategory
 import com.androdr.ui.common.SeverityChip
+import com.androdr.ui.theme.ExtendedColors
+import com.androdr.ui.theme.androdrColors
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -65,7 +67,8 @@ fun TimelineEventCard(
 ) {
     // Neutral telemetry card — no severity badge. Severity lives on
     // Finding rows only; telemetry is pure observation per spec §3.
-    val neutralColor = Color(0xFF00D4AA)
+    val colors = MaterialTheme.androdrColors
+    val neutralColor = colors.neutral
     Card(
         modifier = Modifier.fillMaxWidth().clickable(onClick = onClick),
         colors = CardDefaults.cardColors(
@@ -97,7 +100,7 @@ fun TimelineEventCard(
                     maxLines = 2, overflow = TextOverflow.Ellipsis
                 )
                 FlowRow(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
-                    if (event.campaignName.isNotEmpty()) TagChip(event.campaignName, Color(0xFFCF6679))
+                    if (event.campaignName.isNotEmpty()) TagChip(event.campaignName, colors.critical)
                     if (event.iocType.isNotEmpty()) TagChip(event.iocType, neutralColor)
                     TagChip(event.source, MaterialTheme.colorScheme.primary)
                 }
@@ -199,17 +202,15 @@ private fun CategoryChip(category: FindingCategory) {
 
 @Composable
 private fun severityBackgroundFor(level: String): Color {
-    // Dark-theme-appropriate severity tints: a faint wash of the severity color
-    // over the dark surface. The previous light-theme pastels (0xFFFFF8E1 etc.)
-    // produced bright backgrounds that made text unreadable on dark screens.
+    val colors = MaterialTheme.androdrColors
     val tint = when (level.uppercase()) {
-        "CRITICAL" -> Color(0xFFCF6679) // Material dark error
-        "HIGH" -> Color(0xFFFF8A65)     // deep orange 300
-        "MEDIUM" -> Color(0xFFFFD54F)   // amber 300
-        "LOW" -> Color(0xFF64B5F6)      // blue 300
-        else -> return MaterialTheme.colorScheme.surface
+        "CRITICAL" -> colors.critical
+        "HIGH"     -> colors.high
+        "MEDIUM"   -> colors.medium
+        "LOW"      -> colors.low
+        else       -> return MaterialTheme.colorScheme.surface
     }
-    return tint.copy(alpha = 0.10f) // 10% opacity over dark surface = subtle, readable
+    return tint.copy(alpha = 0.10f)
 }
 
 @Suppress("LongMethod") // Compose detail sheet renders header + all metadata sections + linked evidence
@@ -368,11 +369,12 @@ fun CorrelationClusterCard(
     cluster: EventCluster,
     onEventTap: (ForensicTimelineEvent) -> Unit
 ) {
+    val colors = MaterialTheme.androdrColors
     val clusterColor = when (cluster.pattern) {
         CorrelationPattern.PERMISSION_THEN_C2,
-        CorrelationPattern.INSTALL_THEN_ADMIN -> Color(0xFFCF6679) // Red box
-        CorrelationPattern.MULTI_PERMISSION_BURST -> Color(0xFFFF9800) // Orange box
-        else -> Color(0xFF00D4AA) // neutral
+        CorrelationPattern.INSTALL_THEN_ADMIN     -> colors.critical
+        CorrelationPattern.MULTI_PERMISSION_BURST -> colors.high
+        else                                      -> colors.neutral
     }
 
     Card(

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <style name="Theme.AndroDR" parent="android:Theme.Material.NoActionBar">
-        <item name="android:statusBarColor">#1A1A2E</item>
-        <item name="android:navigationBarColor">#1A1A2E</item>
+        <item name="android:forceDarkAllowed" tools:targetApi="29">false</item>
+        <item name="android:windowBackground">@android:color/transparent</item>
     </style>
 </resources>

--- a/app/src/test/java/com/androdr/data/repo/SettingsRepositoryThemeModeTest.kt
+++ b/app/src/test/java/com/androdr/data/repo/SettingsRepositoryThemeModeTest.kt
@@ -1,0 +1,58 @@
+package com.androdr.data.repo
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import com.androdr.ui.theme.ThemeMode
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class SettingsRepositoryThemeModeTest {
+
+    @get:Rule val tmp = TemporaryFolder()
+
+    private lateinit var dataStore: DataStore<Preferences>
+    private lateinit var repo: SettingsRepository
+
+    @Before
+    fun setUp() {
+        val file = java.io.File(tmp.root, "test.preferences_pb")
+        dataStore = PreferenceDataStoreFactory.create(produceFile = { file })
+        repo = SettingsRepository(dataStore)
+    }
+
+    @After
+    fun tearDown() {
+        // TemporaryFolder rule handles cleanup
+    }
+
+    @Test
+    fun `default themeMode is AUTO`() = runBlocking {
+        assertEquals(ThemeMode.AUTO, repo.themeMode.first())
+    }
+
+    @Test
+    fun `setThemeMode round-trips LIGHT`() = runBlocking {
+        repo.setThemeMode(ThemeMode.LIGHT)
+        assertEquals(ThemeMode.LIGHT, repo.themeMode.first())
+    }
+
+    @Test
+    fun `setThemeMode round-trips DARK`() = runBlocking {
+        repo.setThemeMode(ThemeMode.DARK)
+        assertEquals(ThemeMode.DARK, repo.themeMode.first())
+    }
+
+    @Test
+    fun `setThemeMode round-trips back to AUTO`() = runBlocking {
+        repo.setThemeMode(ThemeMode.DARK)
+        repo.setThemeMode(ThemeMode.AUTO)
+        assertEquals(ThemeMode.AUTO, repo.themeMode.first())
+    }
+}

--- a/app/src/test/java/com/androdr/ui/theme/ExtendedColorsContrastTest.kt
+++ b/app/src/test/java/com/androdr/ui/theme/ExtendedColorsContrastTest.kt
@@ -1,0 +1,69 @@
+package com.androdr.ui.theme
+
+import androidx.compose.ui.graphics.Color
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+private const val WCAG_AA_UI = 3.0  // UI components and large text; severity chips are UI.
+
+class ExtendedColorsContrastTest {
+
+    @Test
+    fun `dark severity colors meet AA against dark background`() {
+        val bg = Color(0xFF0A0A0A) // BackgroundDark
+        assertAaUi("critical", DarkExtendedColors.critical, bg)
+        assertAaUi("high",     DarkExtendedColors.high,     bg)
+        assertAaUi("medium",   DarkExtendedColors.medium,   bg)
+        assertAaUi("low",      DarkExtendedColors.low,      bg)
+        assertAaUi("neutral",  DarkExtendedColors.neutral,  bg)
+    }
+
+    @Test
+    fun `light severity colors meet AA against light background`() {
+        val bg = Color(0xFFFAFAFA)
+        assertAaUi("critical", LightExtendedColors.critical, bg)
+        assertAaUi("high",     LightExtendedColors.high,     bg)
+        assertAaUi("medium",   LightExtendedColors.medium,   bg)
+        assertAaUi("low",      LightExtendedColors.low,      bg)
+        assertAaUi("neutral",  LightExtendedColors.neutral,  bg)
+    }
+
+    @Test
+    fun `light severity colors meet AA against their containers`() {
+        val light = LightExtendedColors
+        assertAaUi("critical/container", light.critical, light.criticalContainer)
+        assertAaUi("high/container",     light.high,     light.highContainer)
+        assertAaUi("medium/container",   light.medium,   light.mediumContainer)
+        assertAaUi("low/container",      light.low,      light.lowContainer)
+    }
+
+    private fun assertAaUi(name: String, fg: Color, bg: Color) {
+        val ratio = contrastRatio(fg, bg)
+        assertTrue(
+            "$name: fg=${fg.toHex()} bg=${bg.toHex()} contrast=${"%.2f".format(ratio)} < $WCAG_AA_UI",
+            ratio >= WCAG_AA_UI
+        )
+    }
+}
+
+/** WCAG 2.x contrast ratio. fg/bg expected to be fully opaque; alpha is ignored. */
+internal fun contrastRatio(fg: Color, bg: Color): Double {
+    val l1 = relativeLuminance(fg)
+    val l2 = relativeLuminance(bg)
+    val lighter = maxOf(l1, l2)
+    val darker  = minOf(l1, l2)
+    return (lighter + 0.05) / (darker + 0.05)
+}
+
+private fun relativeLuminance(c: Color): Double {
+    fun chan(v: Float): Double {
+        val s = v.toDouble()
+        return if (s <= 0.03928) s / 12.92 else Math.pow((s + 0.055) / 1.055, 2.4)
+    }
+    return 0.2126 * chan(c.red) + 0.7152 * chan(c.green) + 0.0722 * chan(c.blue)
+}
+
+private fun Color.toHex(): String = String.format(
+    "#%02X%02X%02X",
+    (red * 255).toInt(), (green * 255).toInt(), (blue * 255).toInt()
+)

--- a/app/src/test/java/com/androdr/ui/theme/HardcodedColorGuardTest.kt
+++ b/app/src/test/java/com/androdr/ui/theme/HardcodedColorGuardTest.kt
@@ -1,0 +1,60 @@
+package com.androdr.ui.theme
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+/**
+ * Guards against re-introducing hardcoded Color(0xFF…) literals in UI code.
+ * The only allowed location for raw color values is inside ui/theme/.
+ * If you need a new semantic color, add it to ExtendedColors instead.
+ *
+ * Sub-percent washes — e.g. critical.copy(alpha = 0.08f) — are intentionally
+ * allowed and not matched by this regex.
+ *
+ * Suppress per-line with: // hardcoded-color-ok: <reason>
+ */
+class HardcodedColorGuardTest {
+
+    @Test
+    fun `no hardcoded Color(0xFF…) literals outside ui-theme package`() {
+        val sourceRoot = findSourceRoot()
+        val pattern = Regex("""Color\(0x[0-9A-Fa-f]{8}\)""")
+        val allowMarker = "hardcoded-color-ok"
+
+        val offenders = sourceRoot.walkTopDown()
+            .filter { it.isFile && it.extension == "kt" }
+            .filterNot { it.path.replace('\\', '/').contains("/ui/theme/") }
+            .flatMap { file ->
+                file.readLines().mapIndexedNotNull { idx, line ->
+                    if (pattern.containsMatchIn(line) && !line.contains(allowMarker)) {
+                        "${file.relativeTo(sourceRoot)}:${idx + 1}  ${line.trim()}"
+                    } else null
+                }
+            }
+            .toList()
+
+        assertTrue(
+            "Hardcoded Color(0xFF…) literals found outside ui/theme/.\n" +
+                "Move the color to ExtendedColors, or append `// hardcoded-color-ok: <reason>` " +
+                "to the line if it is genuinely a one-off (debug overlay, preview fixture, etc.):\n" +
+                offenders.joinToString("\n"),
+            offenders.isEmpty()
+        )
+    }
+
+    private fun findSourceRoot(): File {
+        // Gradle JVM tests run with cwd = module dir (app/). IDE run configs sometimes
+        // use the repo root. Cover both.
+        val candidates = listOf(
+            File("src/main/java/com/androdr"),
+            File("app/src/main/java/com/androdr"),
+            File("../app/src/main/java/com/androdr")
+        )
+        return candidates.firstOrNull { it.exists() }
+            ?: error(
+                "Could not locate source root from ${File(".").absolutePath}. " +
+                    "Tried: ${candidates.map { it.path }}"
+            )
+    }
+}

--- a/app/src/test/java/com/androdr/ui/theme/ThemeModeResolutionTest.kt
+++ b/app/src/test/java/com/androdr/ui/theme/ThemeModeResolutionTest.kt
@@ -1,0 +1,25 @@
+package com.androdr.ui.theme
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ThemeModeResolutionTest {
+
+    @Test
+    fun `AUTO mode follows system dark setting`() {
+        assertEquals(true,  resolveDarkTheme(ThemeMode.AUTO, systemInDark = true))
+        assertEquals(false, resolveDarkTheme(ThemeMode.AUTO, systemInDark = false))
+    }
+
+    @Test
+    fun `LIGHT mode forces light regardless of system`() {
+        assertEquals(false, resolveDarkTheme(ThemeMode.LIGHT, systemInDark = true))
+        assertEquals(false, resolveDarkTheme(ThemeMode.LIGHT, systemInDark = false))
+    }
+
+    @Test
+    fun `DARK mode forces dark regardless of system`() {
+        assertEquals(true, resolveDarkTheme(ThemeMode.DARK, systemInDark = true))
+        assertEquals(true, resolveDarkTheme(ThemeMode.DARK, systemInDark = false))
+    }
+}

--- a/docs/superpowers/plans/2026-05-18-light-dark-theme.md
+++ b/docs/superpowers/plans/2026-05-18-light-dark-theme.md
@@ -10,6 +10,8 @@
 
 **Drift-guard idiom — `.copy(alpha = …)`:** The drift-guard test only catches raw `Color(0xFF…)` literals. Sub-percent tints like the `0.06f`/`0.08f`/`0.15f` washes in `EvidenceSheet` / `DashboardScreen` are migrated to `MaterialTheme.androdrColors.critical.copy(alpha = 0.08f)` (etc.) — those are NOT caught by the guard and preserve the original visual weight. The `*Container` fields in `ExtendedColors` are calibrated for the 20%-ish chip-background use case only.
 
+**Line-number anchors in migration tasks (11-20):** Line numbers cited in migration tasks are correct against `main` at plan-write time. If a rebase has shifted lines, the literals (`Color(0xFFCF6679)` etc.) are unique enough — grep within the named file and migrate every hit. Cited line numbers are an aid, not a hard contract.
+
 **Tech Stack:** Kotlin, Jetpack Compose, Material 3, Hilt, Jetpack DataStore (Preferences), AndroidX `WindowCompat`. JVM unit tests with JUnit 4.
 
 **Spec:** `docs/superpowers/specs/2026-05-18-light-dark-theme-design.md`
@@ -693,13 +695,12 @@ git commit -m "feat(settings-ui): add Appearance section with System/Light/Dark 
 
 - [ ] **Step 1: Add imports**
 
-In `app/src/main/java/com/androdr/MainActivity.kt`, add to imports (alphabetical):
+In `app/src/main/java/com/androdr/MainActivity.kt`, add to imports (alphabetical). Skip any import already present in the file (e.g. `Composable` may already be imported — check before adding):
 
 ```kotlin
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
-import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.graphics.Color
@@ -712,6 +713,8 @@ import com.androdr.data.repo.SettingsRepository
 import com.androdr.ui.theme.ThemeMode
 import javax.inject.Inject
 ```
+
+(`Composable` is already imported; `Modifier` is also already imported.)
 
 - [ ] **Step 2: Inject SettingsRepository and rewire onCreate**
 
@@ -767,7 +770,7 @@ private fun SystemBarsEffect() {
 Notes for the implementer:
 - `androidx.compose.ui.graphics.luminance` is the Compose built-in WCAG luminance helper; do not write a custom one.
 - We do NOT call `WindowCompat.setDecorFitsSystemWindows(window, true)` because that is the platform default — adding it is misleading.
-- The `Surface` wrap is required because Task 10 makes the Activity window background transparent; without it, dialogs and translucent areas would show through to whatever the OEM put underneath.
+- The `Surface` wrap is required because Task 10 makes the Activity window background transparent; without it, dialogs and translucent areas would show through to whatever the OEM put underneath. `AndroDRApp` internally wraps in `Scaffold`, which also paints a surface — this is a deliberate double-paint: the outer Surface guarantees full-window coverage even at the brief moments before/around Scaffold layout.
 
 - [ ] **Step 3: Build the debug APK**
 
@@ -943,21 +946,17 @@ val colors = MaterialTheme.androdrColors
 
 Then change every `severityColor(X)` in that Composable to `severityColor(X, colors)`.
 
-- [ ] **Step 3: Update the `riskLevelColor` wrapper**
+- [ ] **Step 3: Delete the dead `riskLevelColor` wrapper**
 
-The wrapper at line 446 (`fun riskLevelColor(level: String): Color = severityColor(level)`) needs the same parameter:
+The wrapper at line 446 (`fun riskLevelColor(level: String): Color = severityColor(level)`) has **zero external callers** (verified by `grep -rn "riskLevelColor(" app/src/main/java --include="*.kt"` — only the definition matches). It is dead code. Refactoring it would just postpone removal.
+
+Delete the entire line:
 
 ```kotlin
-fun riskLevelColor(level: String, colors: ExtendedColors): Color = severityColor(level, colors)
+fun riskLevelColor(level: String): Color = severityColor(level)
 ```
 
-Then update every caller of `riskLevelColor(...)` in the project (grep first):
-
-```bash
-grep -rn "riskLevelColor(" app/src/main/java --include="*.kt"
-```
-
-For each Composable-scope caller, pass `MaterialTheme.androdrColors`. If a non-Composable caller exists, it must already have access to an `ExtendedColors` instance (or be refactored to receive one). **Verify the grep output before proceeding** — if any caller cannot easily get an `ExtendedColors`, flag it and request guidance; don't paper over it.
+If your grep returns any caller besides the definition itself (the codebase may have evolved since this plan was written): STOP, surface the caller list to the human reviewer, and treat that as a scope expansion. Do NOT silently keep the wrapper.
 
 - [ ] **Step 4: Verify it compiles**
 
@@ -1008,7 +1007,7 @@ tint = if (finding.triggered) MaterialTheme.androdrColors.critical
 - [ ] **Step 4: Verify it compiles**
 
 Run: `./gradlew :app:compileDebugKotlin`
-Expected: still failing on `HistoryScreen.kt` etc. Continue without committing.
+Expected: the ONLY compile errors should be of the form "No value passed for parameter 'colors'" at `severityColor(...)` call sites in files not yet migrated (`HistoryScreen.kt` etc.). If you see any other error class — especially in the file you just edited — STOP, do not commit, surface the error.
 
 ---
 
@@ -1040,7 +1039,7 @@ The rule of thumb: low-alpha washes (≤ 0.15) keep the `.copy(alpha = …)` for
 - [ ] **Step 3: Verify it compiles**
 
 Run: `./gradlew :app:compileDebugKotlin`
-Expected: still failing on other files. Don't commit yet.
+Expected: the ONLY compile errors should be of the form "No value passed for parameter 'colors'" at `severityColor(...)` call sites in files not yet migrated. If you see any other error class — especially in the file you just edited — STOP, do not commit, surface the error.
 
 ---
 
@@ -1078,42 +1077,76 @@ val colors = MaterialTheme.androdrColors
 if (event.campaignName.isNotEmpty()) TagChip(event.campaignName, colors.critical)
 ```
 
-- [ ] **Step 4: Refactor the severity switch (lines 205-210)**
+- [ ] **Step 4: Migrate `severityBackgroundFor` — keep it `@Composable`, preserve the surface fallback**
 
-If the current code is an inline `when` or a private helper, convert to a non-Composable helper:
+The current function at lines 200-213 is:
 
 ```kotlin
-private fun severityTier(severity: String, colors: ExtendedColors): Color =
-    when (severity.uppercase()) {
+@Composable
+private fun severityBackgroundFor(level: String): Color {
+    val tint = when (level.uppercase()) {
+        "CRITICAL" -> Color(0xFFCF6679)
+        "HIGH" -> Color(0xFFFF8A65)
+        "MEDIUM" -> Color(0xFFFFD54F)
+        "LOW" -> Color(0xFF64B5F6)
+        else -> return MaterialTheme.colorScheme.surface
+    }
+    return tint.copy(alpha = 0.10f)
+}
+```
+
+It is **already `@Composable`** (it reads `MaterialTheme.colorScheme.surface`) and the `else` branch *early-returns* the surface color, not a tinted version. Both behaviors must be preserved. Replace with:
+
+```kotlin
+@Composable
+private fun severityBackgroundFor(level: String): Color {
+    val colors = MaterialTheme.androdrColors
+    val tint = when (level.uppercase()) {
         "CRITICAL" -> colors.critical
         "HIGH"     -> colors.high
         "MEDIUM"   -> colors.medium
         "LOW"      -> colors.low
-        else       -> colors.neutral
+        else       -> return MaterialTheme.colorScheme.surface
     }
+    return tint.copy(alpha = 0.10f)
+}
 ```
 
-Call site passes `severityTier(severity, MaterialTheme.androdrColors)` (or the local `colors` from Step 3).
+Behavioral notes:
+- Stays `@Composable` (it must, to read `androdrColors` and `colorScheme.surface`).
+- Surface-fallback `else` branch unchanged.
+- The original `0xFFFF8A65` (deep orange 300) for HIGH and `0xFFFFD54F` (amber 300) for MEDIUM are intentionally unified with the standard `colors.high` / `colors.medium`. Document this in the PR description (the wash on HIGH/MEDIUM rows will look slightly different — deeper orange and darker amber).
+- Original `0xFF64B5F6` LOW maps to `colors.low` — same hue, no change.
 
-The original code uses `0xFFFF8A65` (deep orange 300) for HIGH and `0xFFFFD54F` (amber 300) for MEDIUM; both are now collapsed into the single `colors.high` / `colors.medium` fields. This is intentional — having two separate orange shades for HIGH was unintentional drift between this file and `SeverityChip`.
+- [ ] **Step 5: Migrate the correlation pattern switch in `CorrelationClusterCard` (lines 371-376)**
 
-- [ ] **Step 5: Refactor the correlation pattern switch (lines 373-375)**
+The current switch uses Kotlin fall-through to map two patterns to the same red:
 
 ```kotlin
-private fun correlationPatternColor(pattern: CorrelationPattern, colors: ExtendedColors): Color =
-    when (pattern) {
-        CorrelationPattern.INSTALL_THEN_ADMIN     -> colors.critical
-        CorrelationPattern.MULTI_PERMISSION_BURST -> colors.high
-        else                                      -> colors.neutral
-    }
+val clusterColor = when (cluster.pattern) {
+    CorrelationPattern.PERMISSION_THEN_C2,
+    CorrelationPattern.INSTALL_THEN_ADMIN -> Color(0xFFCF6679) // Red box
+    CorrelationPattern.MULTI_PERMISSION_BURST -> Color(0xFFFF9800) // Orange box
+    else -> Color(0xFF00D4AA) // neutral
+}
 ```
 
-Update the call site to pass `MaterialTheme.androdrColors`.
+`PERMISSION_THEN_C2` MUST stay grouped with `INSTALL_THEN_ADMIN` — dropping it silently demotes a critical correlation. Replace inline (no helper needed; the call site is the only consumer):
+
+```kotlin
+val colors = MaterialTheme.androdrColors
+val clusterColor = when (cluster.pattern) {
+    CorrelationPattern.PERMISSION_THEN_C2,
+    CorrelationPattern.INSTALL_THEN_ADMIN     -> colors.critical
+    CorrelationPattern.MULTI_PERMISSION_BURST -> colors.high
+    else                                      -> colors.neutral
+}
+```
 
 - [ ] **Step 6: Verify it compiles**
 
 Run: `./gradlew :app:compileDebugKotlin`
-Expected: still failing on remaining files. Don't commit yet.
+Expected: the ONLY compile errors should be of the form "No value passed for parameter 'colors'" at `severityColor(...)` call sites in files not yet migrated. If you see any other error class — especially in the file you just edited — STOP, do not commit, surface the error.
 
 ---
 
@@ -1141,7 +1174,7 @@ import com.androdr.ui.theme.androdrColors
 - [ ] **Step 3: Verify it compiles**
 
 Run: `./gradlew :app:compileDebugKotlin`
-Expected: still failing on remaining files. Don't commit yet.
+Expected: the ONLY remaining compile errors should be "No value passed for parameter 'colors'" at `severityColor(...)` call sites in `HistoryScreen.kt`. If you see any other error class — especially in `DnsMonitorScreen.kt` itself — STOP, do not commit, surface the error.
 
 ---
 
@@ -1160,15 +1193,13 @@ import com.androdr.ui.theme.androdrColors
 
 (`MaterialTheme` may already be imported — skip if so.)
 
-- [ ] **Step 2: Update `severityColor` call sites**
+- [ ] **Step 2: Update `severityColor` call sites — each Composable needs its own `colors`**
 
-At each of the two `severityColor(...)` sites (lines 252 and 399), add a local palette pull at the top of the enclosing Composable:
+The two `severityColor(...)` calls are in DIFFERENT enclosing Composables (line 252 in one card; line 399 in another). Compose locals don't leak across function boundaries, so **add `val colors = MaterialTheme.androdrColors` at the top of EACH of the two enclosing Composable bodies** — not just once.
 
-```kotlin
-val colors = MaterialTheme.androdrColors
-```
-
-Then change `severityColor(scan.overallRiskLevel.name)` → `severityColor(scan.overallRiskLevel.name, colors)`, and similarly for `severityColor(riskLevel.name)`.
+Then change:
+- `severityColor(scan.overallRiskLevel.name)` → `severityColor(scan.overallRiskLevel.name, colors)` at line 252.
+- `severityColor(riskLevel.name)` → `severityColor(riskLevel.name, colors)` at line 399.
 
 - [ ] **Step 3: Replace hardcoded literals**
 
@@ -1254,32 +1285,51 @@ else       -> Pair(Icons.Filled.Info, Color(0xFF00D4AA))
 import com.androdr.ui.theme.androdrColors
 ```
 
-- [ ] **Step 2: Replace the switch**
+- [ ] **Step 2: Refactor `findingIconAndColor` to take `colors`**
 
-If the switch is inside a `@Composable`, pull the palette at the top:
-
-```kotlin
-val colors = MaterialTheme.androdrColors
-```
-
-Then replace the literals:
+The switch is inside the non-Composable helper `findingIconAndColor(severity: String)` at line 490. Keep it non-Composable; add the palette parameter:
 
 ```kotlin
-"CRITICAL" -> Pair(Icons.Filled.Error, colors.critical)
-"HIGH"     -> Pair(Icons.Filled.Warning, colors.high)
-"MEDIUM"   -> Pair(Icons.Filled.Warning, colors.medium)
-"ERROR"    -> Pair(Icons.Filled.Error, colors.critical)
-else       -> Pair(Icons.Filled.Info, colors.neutral)
+private fun findingIconAndColor(
+    severity: String,
+    colors: ExtendedColors
+): Pair<ImageVector, Color> = when (severity.uppercase()) {
+    "CRITICAL" -> Pair(Icons.Filled.Error, colors.critical)
+    "HIGH"     -> Pair(Icons.Filled.Warning, colors.high)
+    "MEDIUM"   -> Pair(Icons.Filled.Warning, colors.medium)
+    "ERROR"    -> Pair(Icons.Filled.Error, colors.critical)
+    else       -> Pair(Icons.Filled.Info, colors.neutral)
+}
 ```
 
-If the switch lives in a non-Composable helper, convert it to take `colors: ExtendedColors` as the second parameter (same idiom as `severityColor`), and pass `MaterialTheme.androdrColors` from each call site.
+Add an import for `ExtendedColors`:
 
-- [ ] **Step 3: Verify it compiles**
+```kotlin
+import com.androdr.ui.theme.ExtendedColors
+```
+
+- [ ] **Step 3: Update the caller at line 441**
+
+The only caller is inside `@Composable fun TimelineEventCard(event: ...)` at line 441:
+
+```kotlin
+val (icon, color) = findingIconAndColor(event.severity)
+```
+
+Change to:
+
+```kotlin
+val (icon, color) = findingIconAndColor(event.severity, MaterialTheme.androdrColors)
+```
+
+(Verify there are no other callers with `grep -n "findingIconAndColor(" app/src/main/java/com/androdr/ui/bugreport/BugReportScreen.kt`. If new callers appeared, update each the same way.)
+
+- [ ] **Step 4: Verify it compiles**
 
 Run: `./gradlew :app:compileDebugKotlin`
 Expected: BUILD SUCCESSFUL.
 
-- [ ] **Step 4: Commit**
+- [ ] **Step 5: Commit**
 
 ```bash
 git add app/src/main/java/com/androdr/ui/bugreport/BugReportScreen.kt
@@ -1311,21 +1361,39 @@ The two "risk-level" hues at 346-348 (`0xFFFF1744`, `0xFFFF6E40`, `0xFFFFD54F`) 
 
 The plan proceeds with (a). If the dashboard's risk header *needs* a louder presentation for UX reasons, that's a follow-up design decision, not a migration concern.
 
-- [ ] **Step 1: Add import**
+DashboardScreen has **four separate `@Composable` functions** that each contain hardcoded literals:
+- `PostScanGuidance` (starts at line 287) — severity switch lines 300-315.
+- `RiskLevelCard` (starts at line 344) — risk-level switch lines 346-350.
+- `DiffBanner` (starts at line 407) — warning card lines 411-428.
+- `PartialScanBanner` (starts at line 563) — warning card lines 567-585.
+
+Each Composable needs its own `val colors = MaterialTheme.androdrColors` pull — Compose locals do not leak across function boundaries.
+
+- [ ] **Step 1: Add import + remove the dead one**
+
+Add:
 
 ```kotlin
 import com.androdr.ui.theme.androdrColors
 ```
 
-- [ ] **Step 2: Migrate lines 300-315 (severity switch)**
+Remove the now-dead import at line 61 (verified: no remaining usages of `severityColor` symbol in the file after this migration):
 
-At the top of the enclosing Composable:
+```kotlin
+import com.androdr.ui.common.severityColor   // delete this line
+```
+
+Skipping the removal will produce a "Unused import" warning that may fail release lint (CLAUDE.md notes warnings are treated as errors in release builds).
+
+- [ ] **Step 2: Migrate `PostScanGuidance` severity switch (lines 300-315)**
+
+Inside `PostScanGuidance`, add at the top of its body:
 
 ```kotlin
 val colors = MaterialTheme.androdrColors
 ```
 
-Replace each line in the switch:
+Replace each literal in the switch:
 
 | Old                  | New              |
 |----------------------|------------------|
@@ -1334,9 +1402,15 @@ Replace each line in the switch:
 | `Color(0xFFE6A800)`  | `colors.medium`  |
 | `Color(0xFF00D4AA)`  | `colors.neutral` |
 
-- [ ] **Step 3: Migrate lines 346-350 (risk-level switch)**
+- [ ] **Step 3: Migrate `RiskLevelCard` risk-level switch (lines 346-350)**
 
-Inside the enclosing Composable (palette already pulled in Step 2), replace each:
+Inside `RiskLevelCard` (a different Composable from PostScanGuidance), add its own:
+
+```kotlin
+val colors = MaterialTheme.androdrColors
+```
+
+Replace each:
 
 | Old                                | New                              |
 |------------------------------------|----------------------------------|
@@ -1346,23 +1420,39 @@ Inside the enclosing Composable (palette already pulled in Step 2), replace each
 | `Color(0xFF00D4AA)` (LOW)          | `colors.low`                     |
 | `Color(0xFF00D4AA)` (null branch)  | `colors.neutral`                 |
 
-Note the LOW branch was using the brand teal (`0xFF00D4AA`) in the original — now it correctly uses `colors.low` (blue). The null branch keeps the neutral teal. This is the same deliberate "LOW gets its own color" fix from Task 11.
+The LOW branch shifts from brand teal to actual blue (same deliberate fix as Task 11). Null branch keeps the neutral teal.
 
-- [ ] **Step 4: Migrate the warning cards (lines 411-428 and 567-585)**
+- [ ] **Step 4: Migrate `DiffBanner` warning card (lines 411-428)**
 
-Each card has three orange uses: container background (`0xFFFF9800).copy(alpha = 0.15f)`), icon tint, label color. Replace:
+Inside `DiffBanner` (yet another Composable), add its own:
+
+```kotlin
+val colors = MaterialTheme.androdrColors
+```
+
+Replace the three orange uses (container alpha wash, icon tint, label color):
 
 | Old                                       | New                                                  |
 |-------------------------------------------|------------------------------------------------------|
 | `Color(0xFFFF9800).copy(alpha = 0.15f)`   | `colors.high.copy(alpha = 0.15f)` (keep wash form)   |
 | `Color(0xFFFF9800)`                       | `colors.high`                                        |
 
-- [ ] **Step 5: Verify it compiles**
+- [ ] **Step 5: Migrate `PartialScanBanner` warning card (lines 567-585)**
+
+Inside `PartialScanBanner` (fourth Composable), add its own:
+
+```kotlin
+val colors = MaterialTheme.androdrColors
+```
+
+Apply the same mapping table as Step 4.
+
+- [ ] **Step 6: Verify it compiles**
 
 Run: `./gradlew :app:compileDebugKotlin`
 Expected: BUILD SUCCESSFUL.
 
-- [ ] **Step 6: Commit**
+- [ ] **Step 7: Commit**
 
 ```bash
 git add app/src/main/java/com/androdr/ui/dashboard/DashboardScreen.kt
@@ -1540,6 +1630,15 @@ If the tester's Honor device is reachable, re-test the exact screen where text w
 
 If no Honor device is available: explicitly note "Honor re-test pending — relies on tester verification post-merge" in the PR description. Do not claim the bug fixed without device confirmation.
 
+### Visual changes to call out in the PR description
+
+These are deliberate semantic-color migrations that a tester running visual regression WILL notice. Document them so they are not filed as regressions:
+
+- **LOW severity is now blue, not brand teal.** Affects severity chips, finding cards, dashboard risk swatches, timeline backgrounds. The original code lumped LOW into the neutral teal bucket; the new palette gives LOW its own blue (`androdrColors.low`). Intended fix.
+- **Dashboard CRITICAL / HIGH / MEDIUM risk swatches lose the "loud" presentation.** Previously `0xFFFF1744` (siren red), `0xFFFF6E40` (deep orange), `0xFFFFD54F` (amber 300). Now use the standard severity palette (`androdrColors.critical / .high / .medium`). The siren-red attention grab is gone; if a louder dashboard banner is wanted, raise as a separate UX decision.
+- **TimelineEventCard severity-row washes shift slightly on HIGH and MEDIUM.** Previously `0xFFFF8A65` (deep orange 300) and `0xFFFFD54F` (amber 300) used in `severityBackgroundFor`. Now use `androdrColors.high` (deeper orange) and `androdrColors.medium` (darker amber) at the same 10% alpha. Subtle but visible.
+- **SeverityChip disabled state changes from `0xFF888888`** to `colorScheme.onSurface.copy(alpha = 0.38f)` — adapts to theme instead of being a fixed grey.
+
 - [ ] **Step 7: Commit preview + close**
 
 ```bash
@@ -1553,7 +1652,7 @@ This task produces no further commits; verification output goes into the PR desc
 
 ## Self-Review Notes
 
-Plan has been through one full revision cycle after a two-reviewer plan-gate review. Verified post-revision:
+Plan has been through two full revision cycles, each preceded by a two-reviewer plan-gate review. Verified post-v2-revision:
 
 - **Spec coverage:** every spec section maps to at least one task. Migration covers all 9 files containing hardcoded `Color(0xFF…)` literals (verified by `grep -rn "Color(0x" app/src/main/java --include="*.kt" | grep -v "ui/theme/" | awk -F: '{print $1}' | sort -u`).
 - **`severityColor` cascade:** broken by keeping the function non-Composable and threading `ExtendedColors` through callers; Tasks 11-12-17 form one coherent compile-passing unit, committed together.

--- a/docs/superpowers/plans/2026-05-18-light-dark-theme.md
+++ b/docs/superpowers/plans/2026-05-18-light-dark-theme.md
@@ -1,0 +1,1259 @@
+# Light/Dark Theme Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make AndroDR's UI legible on every Android device by introducing a light color scheme that follows the OS setting, a user override (Auto/Light/Dark), a semantic-color layer, and migration of all hardcoded color literals. Fixes the tester-reported invisible-text bug on Honor MagicOS.
+
+**Architecture:** A new `ThemeMode` enum is persisted in `SettingsRepository` (DataStore). `AndroDRTheme` resolves it against `isSystemInDarkTheme()` and provides both a Material 3 `ColorScheme` and an app-specific `ExtendedColors` (severity hues, alert backgrounds) via `CompositionLocal`. The Activity theme drops hardcoded system-bar colors and `forceDarkAllowed` is disabled to stop OEM overrides. Five UI files migrate from hardcoded `Color(0xFF…)` literals to `MaterialTheme.androdrColors.*`, and a unit test guards against regression.
+
+**Tech Stack:** Kotlin, Jetpack Compose, Material 3, Hilt, Jetpack DataStore (Preferences), AndroidX `WindowCompat`. JVM unit tests with JUnit 4.
+
+**Spec:** `docs/superpowers/specs/2026-05-18-light-dark-theme-design.md`
+
+---
+
+## File Structure
+
+**Create (new):**
+- `app/src/main/java/com/androdr/ui/theme/ThemeMode.kt` — `ThemeMode` enum + `resolveDarkTheme` pure helper.
+- `app/src/main/java/com/androdr/ui/theme/ExtendedColors.kt` — data class, `LocalAndroDRColors`, `DarkExtendedColors`, `LightExtendedColors`, `MaterialTheme.androdrColors` extension.
+- `app/src/test/java/com/androdr/ui/theme/ThemeModeResolutionTest.kt` — truth table for `resolveDarkTheme`.
+- `app/src/test/java/com/androdr/ui/theme/ExtendedColorsContrastTest.kt` — WCAG AA contrast assertions on both palette instances.
+- `app/src/test/java/com/androdr/ui/theme/HardcodedColorGuardTest.kt` — drift guard scanning `*.kt` outside `ui/theme/`.
+- `app/src/test/java/com/androdr/data/repo/SettingsRepositoryThemeModeTest.kt` — round-trip test for the new DataStore key.
+
+**Modify:**
+- `app/src/main/java/com/androdr/ui/theme/Theme.kt` — add `LightColorScheme`, refactor `AndroDRTheme(themeMode = ...)`, wire `CompositionLocal`.
+- `app/src/main/java/com/androdr/data/repo/SettingsRepository.kt` — add `themeMode` Flow + `setThemeMode` + key constant.
+- `app/src/main/java/com/androdr/ui/settings/SettingsViewModel.kt` — expose `themeMode` StateFlow + `setThemeMode`.
+- `app/src/main/java/com/androdr/ui/settings/SettingsScreen.kt` — add "Appearance" section with 3-option picker.
+- `app/src/main/java/com/androdr/MainActivity.kt` — inject `SettingsRepository`, collect theme mode, pass into `AndroDRTheme`, drive system-bar colors from Compose.
+- `app/src/main/res/values/themes.xml` — drop hardcoded bar colors, add `android:forceDarkAllowed="false"`, switch parent to DayNight.
+- `app/src/main/java/com/androdr/ui/common/SeverityChip.kt` — migrate severity literals.
+- `app/src/main/java/com/androdr/ui/common/FindingCard.kt` — migrate severity literals.
+- `app/src/main/java/com/androdr/ui/common/EvidenceSheet.kt` — migrate severity literals.
+- `app/src/main/java/com/androdr/ui/timeline/TimelineEventCard.kt` — migrate severity literals.
+- `app/src/main/java/com/androdr/ui/network/DnsMonitorScreen.kt` — migrate severity literals.
+
+---
+
+## Task 1: ThemeMode enum + pure resolver
+
+**Files:**
+- Create: `app/src/main/java/com/androdr/ui/theme/ThemeMode.kt`
+- Test: `app/src/test/java/com/androdr/ui/theme/ThemeModeResolutionTest.kt`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `app/src/test/java/com/androdr/ui/theme/ThemeModeResolutionTest.kt`:
+
+```kotlin
+package com.androdr.ui.theme
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ThemeModeResolutionTest {
+
+    @Test
+    fun `AUTO mode follows system dark setting`() {
+        assertEquals(true,  resolveDarkTheme(ThemeMode.AUTO, systemInDark = true))
+        assertEquals(false, resolveDarkTheme(ThemeMode.AUTO, systemInDark = false))
+    }
+
+    @Test
+    fun `LIGHT mode forces light regardless of system`() {
+        assertEquals(false, resolveDarkTheme(ThemeMode.LIGHT, systemInDark = true))
+        assertEquals(false, resolveDarkTheme(ThemeMode.LIGHT, systemInDark = false))
+    }
+
+    @Test
+    fun `DARK mode forces dark regardless of system`() {
+        assertEquals(true, resolveDarkTheme(ThemeMode.DARK, systemInDark = true))
+        assertEquals(true, resolveDarkTheme(ThemeMode.DARK, systemInDark = false))
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :app:testDebugUnitTest --tests "com.androdr.ui.theme.ThemeModeResolutionTest"`
+Expected: FAIL (unresolved reference `ThemeMode`, `resolveDarkTheme`).
+
+- [ ] **Step 3: Implement ThemeMode + resolver**
+
+Create `app/src/main/java/com/androdr/ui/theme/ThemeMode.kt`:
+
+```kotlin
+package com.androdr.ui.theme
+
+enum class ThemeMode { AUTO, LIGHT, DARK }
+
+fun resolveDarkTheme(themeMode: ThemeMode, systemInDark: Boolean): Boolean =
+    when (themeMode) {
+        ThemeMode.LIGHT -> false
+        ThemeMode.DARK  -> true
+        ThemeMode.AUTO  -> systemInDark
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./gradlew :app:testDebugUnitTest --tests "com.androdr.ui.theme.ThemeModeResolutionTest"`
+Expected: PASS (3/3).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/java/com/androdr/ui/theme/ThemeMode.kt \
+        app/src/test/java/com/androdr/ui/theme/ThemeModeResolutionTest.kt
+git commit -m "feat(theme): add ThemeMode enum and pure resolveDarkTheme helper"
+```
+
+---
+
+## Task 2: Persist `themeMode` in SettingsRepository
+
+**Files:**
+- Modify: `app/src/main/java/com/androdr/data/repo/SettingsRepository.kt`
+- Test: `app/src/test/java/com/androdr/data/repo/SettingsRepositoryThemeModeTest.kt`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `app/src/test/java/com/androdr/data/repo/SettingsRepositoryThemeModeTest.kt`:
+
+```kotlin
+package com.androdr.data.repo
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import com.androdr.ui.theme.ThemeMode
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+class SettingsRepositoryThemeModeTest {
+
+    @get:Rule val tmp = TemporaryFolder()
+
+    private lateinit var dataStore: DataStore<Preferences>
+    private lateinit var repo: SettingsRepository
+    private lateinit var prefsFile: File
+
+    @Before
+    fun setUp() {
+        prefsFile = tmp.newFile("test_prefs.preferences_pb")
+        dataStore = PreferenceDataStoreFactory.create(produceFile = { prefsFile })
+        repo = SettingsRepository(dataStore)
+    }
+
+    @After
+    fun tearDown() {
+        prefsFile.delete()
+    }
+
+    @Test
+    fun `default themeMode is AUTO`() = runBlocking {
+        assertEquals(ThemeMode.AUTO, repo.themeMode.first())
+    }
+
+    @Test
+    fun `setThemeMode round-trips LIGHT`() = runBlocking {
+        repo.setThemeMode(ThemeMode.LIGHT)
+        assertEquals(ThemeMode.LIGHT, repo.themeMode.first())
+    }
+
+    @Test
+    fun `setThemeMode round-trips DARK`() = runBlocking {
+        repo.setThemeMode(ThemeMode.DARK)
+        assertEquals(ThemeMode.DARK, repo.themeMode.first())
+    }
+
+    @Test
+    fun `setThemeMode round-trips back to AUTO`() = runBlocking {
+        repo.setThemeMode(ThemeMode.DARK)
+        repo.setThemeMode(ThemeMode.AUTO)
+        assertEquals(ThemeMode.AUTO, repo.themeMode.first())
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :app:testDebugUnitTest --tests "com.androdr.data.repo.SettingsRepositoryThemeModeTest"`
+Expected: FAIL (unresolved reference `themeMode` / `setThemeMode`).
+
+- [ ] **Step 3: Add `themeMode` to SettingsRepository**
+
+In `app/src/main/java/com/androdr/data/repo/SettingsRepository.kt`:
+
+Add to the imports block (alphabetical):
+
+```kotlin
+import com.androdr.ui.theme.ThemeMode
+```
+
+Add inside the class body, after the `domainIocBlockMode` block (around line 30):
+
+```kotlin
+val themeMode: Flow<ThemeMode> = dataStore.data
+    .map { prefs ->
+        when (prefs[KEY_THEME_MODE]) {
+            "LIGHT" -> ThemeMode.LIGHT
+            "DARK"  -> ThemeMode.DARK
+            else    -> ThemeMode.AUTO
+        }
+    }
+
+suspend fun setThemeMode(mode: ThemeMode) {
+    dataStore.edit { it[KEY_THEME_MODE] = mode.name }
+}
+```
+
+Add to the `companion object` (around line 102):
+
+```kotlin
+private val KEY_THEME_MODE = stringPreferencesKey("theme_mode")
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./gradlew :app:testDebugUnitTest --tests "com.androdr.data.repo.SettingsRepositoryThemeModeTest"`
+Expected: PASS (4/4).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/java/com/androdr/data/repo/SettingsRepository.kt \
+        app/src/test/java/com/androdr/data/repo/SettingsRepositoryThemeModeTest.kt
+git commit -m "feat(settings): persist ThemeMode preference in DataStore"
+```
+
+---
+
+## Task 3: ExtendedColors data class + CompositionLocal
+
+**Files:**
+- Create: `app/src/main/java/com/androdr/ui/theme/ExtendedColors.kt`
+
+- [ ] **Step 1: Create the file**
+
+Create `app/src/main/java/com/androdr/ui/theme/ExtendedColors.kt`:
+
+```kotlin
+package com.androdr.ui.theme
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.graphics.Color
+
+/**
+ * App-specific semantic colors that Material 3's ColorScheme does not cover:
+ * the four severity tiers and their tinted backgrounds. Two instances exist —
+ * one for dark, one for light — and AndroDRTheme provides the right one via
+ * LocalAndroDRColors. Access through MaterialTheme.androdrColors.
+ */
+data class ExtendedColors(
+    val critical: Color,
+    val high: Color,
+    val medium: Color,
+    val low: Color,
+    val neutral: Color,
+    val criticalContainer: Color,
+    val highContainer: Color,
+    val mediumContainer: Color,
+    val lowContainer: Color,
+)
+
+val DarkExtendedColors = ExtendedColors(
+    critical          = Color(0xFFCF6679),
+    high              = Color(0xFFFF9800),
+    medium            = Color(0xFFE6A800),
+    low               = Color(0xFF64B5F6),
+    neutral           = TealPrimary,
+    criticalContainer = Color(0x33CF6679),
+    highContainer     = Color(0x33FF9800),
+    mediumContainer   = Color(0x33E6A800),
+    lowContainer      = Color(0x3364B5F6),
+)
+
+val LightExtendedColors = ExtendedColors(
+    critical          = Color(0xFFB3261E),
+    high              = Color(0xFFC25700),
+    medium            = Color(0xFF8B6B00),
+    low               = Color(0xFF1565C0),
+    neutral           = TealPrimaryVariant,
+    criticalContainer = Color(0xFFFFDAD6),
+    highContainer     = Color(0xFFFFDCC2),
+    mediumContainer   = Color(0xFFF6E5B4),
+    lowContainer      = Color(0xFFD0E4FF),
+)
+
+val LocalAndroDRColors = staticCompositionLocalOf<ExtendedColors> {
+    error("AndroDRTheme must wrap the call site (LocalAndroDRColors not provided)")
+}
+
+val MaterialTheme.androdrColors: ExtendedColors
+    @Composable
+    @ReadOnlyComposable
+    get() = LocalAndroDRColors.current
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `./gradlew :app:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL. Compilation errors here mean either `TealPrimary` / `TealPrimaryVariant` aren't visible (they're top-level in `Theme.kt` already, in the same package, so this should just work) or a typo in an import.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/src/main/java/com/androdr/ui/theme/ExtendedColors.kt
+git commit -m "feat(theme): add ExtendedColors data class with dark+light severity palettes"
+```
+
+---
+
+## Task 4: WCAG AA contrast test for ExtendedColors
+
+**Files:**
+- Test: `app/src/test/java/com/androdr/ui/theme/ExtendedColorsContrastTest.kt`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `app/src/test/java/com/androdr/ui/theme/ExtendedColorsContrastTest.kt`:
+
+```kotlin
+package com.androdr.ui.theme
+
+import androidx.compose.ui.graphics.Color
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+private const val WCAG_AA_LARGE_TEXT_AND_UI = 3.0
+private const val WCAG_AA_NORMAL_TEXT = 4.5
+
+class ExtendedColorsContrastTest {
+
+    @Test
+    fun `dark severity colors meet AA against dark background`() {
+        val bg = Color(0xFF0A0A0A) // BackgroundDark
+        assertAaUi("critical", DarkExtendedColors.critical, bg)
+        assertAaUi("high",     DarkExtendedColors.high,     bg)
+        assertAaUi("medium",   DarkExtendedColors.medium,   bg)
+        assertAaUi("low",      DarkExtendedColors.low,      bg)
+        assertAaUi("neutral",  DarkExtendedColors.neutral,  bg)
+    }
+
+    @Test
+    fun `light severity colors meet AA against light background`() {
+        val bg = Color(0xFFFAFAFA)
+        assertAaUi("critical", LightExtendedColors.critical, bg)
+        assertAaUi("high",     LightExtendedColors.high,     bg)
+        assertAaUi("medium",   LightExtendedColors.medium,   bg)
+        assertAaUi("low",      LightExtendedColors.low,      bg)
+        assertAaUi("neutral",  LightExtendedColors.neutral,  bg)
+    }
+
+    private fun assertAaUi(name: String, fg: Color, bg: Color) {
+        val ratio = contrastRatio(fg, bg)
+        assertTrue(
+            "$name (${fg.toHex()}) on (${bg.toHex()}) contrast $ratio < $WCAG_AA_LARGE_TEXT_AND_UI",
+            ratio >= WCAG_AA_LARGE_TEXT_AND_UI
+        )
+    }
+}
+
+/** WCAG 2.x contrast ratio. fg/bg expected to be fully opaque; alpha is ignored. */
+internal fun contrastRatio(fg: Color, bg: Color): Double {
+    val l1 = relativeLuminance(fg)
+    val l2 = relativeLuminance(bg)
+    val lighter = maxOf(l1, l2)
+    val darker  = minOf(l1, l2)
+    return (lighter + 0.05) / (darker + 0.05)
+}
+
+private fun relativeLuminance(c: Color): Double {
+    fun chan(v: Float): Double {
+        val s = v.toDouble()
+        return if (s <= 0.03928) s / 12.92 else Math.pow((s + 0.055) / 1.055, 2.4)
+    }
+    return 0.2126 * chan(c.red) + 0.7152 * chan(c.green) + 0.0722 * chan(c.blue)
+}
+
+private fun Color.toHex(): String = String.format(
+    "#%02X%02X%02X",
+    (red * 255).toInt(), (green * 255).toInt(), (blue * 255).toInt()
+)
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `./gradlew :app:testDebugUnitTest --tests "com.androdr.ui.theme.ExtendedColorsContrastTest"`
+Expected: PASS (2/2). If a specific color fails, the failure message tells you which one — adjust its value in `ExtendedColors.kt` and re-run until all pass.
+
+Note: The threshold is the WCAG AA UI-component / large-text threshold (3.0). Severity chips and pill backgrounds are UI components, not body text. If you want body-text-strength contrast (4.5), bump the constant — but be aware that some hues (orange in particular) struggle to hit 4.5 on white without going brown.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/src/test/java/com/androdr/ui/theme/ExtendedColorsContrastTest.kt
+git commit -m "test(theme): assert ExtendedColors meet WCAG AA contrast on both schemes"
+```
+
+---
+
+## Task 5: Add `LightColorScheme` to Theme.kt
+
+**Files:**
+- Modify: `app/src/main/java/com/androdr/ui/theme/Theme.kt`
+
+- [ ] **Step 1: Add the imports and new scheme**
+
+In `app/src/main/java/com/androdr/ui/theme/Theme.kt`:
+
+Add to imports (alphabetical):
+
+```kotlin
+import androidx.compose.material3.lightColorScheme
+```
+
+Add immediately after the existing `private val DarkColorScheme = …` block (before the `@Composable fun AndroDRTheme` line, around line 53):
+
+```kotlin
+private val LightColorScheme = lightColorScheme(
+    primary              = TealPrimaryVariant,            // 0xFF00A882
+    onPrimary            = Color.White,
+    primaryContainer     = Color(0xFFB2FFF0),
+    onPrimaryContainer   = Color(0xFF003328),
+    secondary            = Color(0xFF006B62),
+    onSecondary          = Color.White,
+    secondaryContainer   = Color(0xFF70F2E6),
+    onSecondaryContainer = Color(0xFF00201D),
+    tertiary             = Color(0xFF00658E),
+    onTertiary           = Color.White,
+    tertiaryContainer    = Color(0xFFC5E7FF),
+    onTertiaryContainer  = Color(0xFF001E2E),
+    error                = Color(0xFFB3261E),
+    onError              = Color.White,
+    errorContainer       = Color(0xFFFFDAD6),
+    onErrorContainer     = Color(0xFF410002),
+    background           = Color(0xFFFAFAFA),
+    onBackground         = Color(0xFF1A1A1A),
+    surface              = Color.White,
+    onSurface            = Color(0xFF1A1A1A),
+    surfaceVariant       = Color(0xFFEEEEEE),
+    onSurfaceVariant     = Color(0xFF4A4A4A),
+    outline              = Color(0xFF747878),
+    outlineVariant       = Color(0xFFC4C7C7),
+    surfaceContainer     = Color(0xFFF1F1F1),
+    surfaceContainerHigh = Color(0xFFEAEAEA),
+    surfaceContainerLow  = Color(0xFFF6F6F6),
+)
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `./gradlew :app:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/src/main/java/com/androdr/ui/theme/Theme.kt
+git commit -m "feat(theme): add LightColorScheme palette"
+```
+
+---
+
+## Task 6: Refactor `AndroDRTheme` to accept ThemeMode and provide ExtendedColors
+
+**Files:**
+- Modify: `app/src/main/java/com/androdr/ui/theme/Theme.kt`
+
+- [ ] **Step 1: Refactor the AndroDRTheme composable**
+
+In `app/src/main/java/com/androdr/ui/theme/Theme.kt`:
+
+Add to imports:
+
+```kotlin
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.runtime.CompositionLocalProvider
+```
+
+Replace the existing `AndroDRTheme` composable (lines 55-61 approximately) with:
+
+```kotlin
+@Composable
+fun AndroDRTheme(
+    themeMode: ThemeMode = ThemeMode.AUTO,
+    content: @Composable () -> Unit
+) {
+    val useDarkTheme = resolveDarkTheme(themeMode, systemInDark = isSystemInDarkTheme())
+    val colorScheme    = if (useDarkTheme) DarkColorScheme   else LightColorScheme
+    val extendedColors = if (useDarkTheme) DarkExtendedColors else LightExtendedColors
+
+    CompositionLocalProvider(LocalAndroDRColors provides extendedColors) {
+        MaterialTheme(
+            colorScheme = colorScheme,
+            content = content
+        )
+    }
+}
+```
+
+- [ ] **Step 2: Verify it compiles and existing usages still build**
+
+Run: `./gradlew :app:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL. Existing call sites (`AndroDRTheme { … }`) keep working because `themeMode` has a default value.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/src/main/java/com/androdr/ui/theme/Theme.kt
+git commit -m "feat(theme): wire AndroDRTheme to ThemeMode + provide ExtendedColors"
+```
+
+---
+
+## Task 7: Expose themeMode on SettingsViewModel
+
+**Files:**
+- Modify: `app/src/main/java/com/androdr/ui/settings/SettingsViewModel.kt`
+
+- [ ] **Step 1: Add the StateFlow and setter**
+
+In `app/src/main/java/com/androdr/ui/settings/SettingsViewModel.kt`:
+
+Add to imports (alphabetical, after the existing `com.androdr.…` block):
+
+```kotlin
+import com.androdr.ui.theme.ThemeMode
+```
+
+Add inside the class body, immediately after the existing `domainIocBlockMode` declaration (around line 67):
+
+```kotlin
+val themeMode = settingsRepository.themeMode
+    .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), ThemeMode.AUTO)
+
+fun setThemeMode(mode: ThemeMode) {
+    viewModelScope.launch { settingsRepository.setThemeMode(mode) }
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `./gradlew :app:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/src/main/java/com/androdr/ui/settings/SettingsViewModel.kt
+git commit -m "feat(settings-vm): expose themeMode StateFlow and setter"
+```
+
+---
+
+## Task 8: Add "Appearance" section to SettingsScreen
+
+**Files:**
+- Modify: `app/src/main/java/com/androdr/ui/settings/SettingsScreen.kt`
+
+- [ ] **Step 1: Add imports**
+
+In `app/src/main/java/com/androdr/ui/settings/SettingsScreen.kt`:
+
+Add to imports (alphabetical):
+
+```kotlin
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
+import com.androdr.ui.theme.ThemeMode
+```
+
+- [ ] **Step 2: Collect the state**
+
+Inside `fun SettingsScreen(...)`, after the existing `val customRuleUrls by …` line (around line 49), add:
+
+```kotlin
+val themeMode by viewModel.themeMode.collectAsStateWithLifecycle()
+```
+
+- [ ] **Step 3: Insert the Appearance section**
+
+Inside the `Column { … }` body, **immediately after** the headline `Text("Settings", …)` block (around line 125, before the `Text("DNS Blocklist", …)` line), insert:
+
+```kotlin
+Text(
+    text = "Appearance",
+    style = MaterialTheme.typography.titleMedium,
+    modifier = Modifier.padding(top = 16.dp)
+)
+Text(
+    text = "Choose how AndroDR adapts to your system theme.",
+    style = MaterialTheme.typography.bodySmall,
+    color = MaterialTheme.colorScheme.onSurfaceVariant
+)
+ThemeModePicker(
+    selected = themeMode,
+    onSelect = { viewModel.setThemeMode(it) }
+)
+HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+```
+
+- [ ] **Step 4: Add the picker composable**
+
+At the bottom of the file (after `UpdateStatusRow`, around line 429), add:
+
+```kotlin
+@Composable
+private fun ThemeModePicker(
+    selected: ThemeMode,
+    onSelect: (ThemeMode) -> Unit
+) {
+    val options = listOf(
+        ThemeMode.AUTO  to "System",
+        ThemeMode.LIGHT to "Light",
+        ThemeMode.DARK  to "Dark"
+    )
+    SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+        options.forEachIndexed { index, (mode, label) ->
+            SegmentedButton(
+                selected = selected == mode,
+                onClick  = { onSelect(mode) },
+                shape    = SegmentedButtonDefaults.itemShape(index = index, count = options.size)
+            ) {
+                Text(label)
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 5: Verify it compiles**
+
+Run: `./gradlew :app:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/src/main/java/com/androdr/ui/settings/SettingsScreen.kt
+git commit -m "feat(settings-ui): add Appearance section with System/Light/Dark picker"
+```
+
+---
+
+## Task 9: Wire themeMode in MainActivity + drive system bars from Compose
+
+**Files:**
+- Modify: `app/src/main/java/com/androdr/MainActivity.kt`
+
+- [ ] **Step 1: Add imports**
+
+In `app/src/main/java/com/androdr/MainActivity.kt`:
+
+Add to imports (alphabetical):
+
+```kotlin
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.LocalView
+import androidx.core.view.WindowCompat
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.androdr.data.repo.SettingsRepository
+import com.androdr.ui.theme.ThemeMode
+import javax.inject.Inject
+```
+
+- [ ] **Step 2: Inject SettingsRepository and collect themeMode**
+
+Replace the existing `MainActivity` class (lines 45-56) with:
+
+```kotlin
+@AndroidEntryPoint
+class MainActivity : ComponentActivity() {
+
+    @Inject lateinit var settingsRepository: SettingsRepository
+
+    override fun onCreate(savedInstanceState: android.os.Bundle?) {
+        super.onCreate(savedInstanceState)
+        WindowCompat.setDecorFitsSystemWindows(window, true)
+        setContent {
+            val themeMode by settingsRepository.themeMode
+                .collectAsStateWithLifecycle(initialValue = ThemeMode.AUTO)
+            AndroDRTheme(themeMode = themeMode) {
+                SystemBarsEffect()
+                AndroDRApp()
+            }
+        }
+    }
+}
+
+@Composable
+private fun SystemBarsEffect() {
+    val view = LocalView.current
+    val surface = MaterialTheme.colorScheme.surface
+    val surfaceArgb = surface.toArgb()
+    // Drive icon brightness from the actual surface luminance — this is the only
+    // truthful signal when the user has forced LIGHT on a system-dark device (or
+    // vice versa). isSystemInDarkTheme() lies in that case.
+    val barsLookDark = surface.computeLuminance() < 0.5f
+    if (!view.isInEditMode) {
+        SideEffect {
+            val window = (view.context as android.app.Activity).window
+            window.statusBarColor = surfaceArgb
+            window.navigationBarColor = surfaceArgb
+            WindowCompat.getInsetsController(window, view).apply {
+                isAppearanceLightStatusBars = !barsLookDark
+                isAppearanceLightNavigationBars = !barsLookDark
+            }
+        }
+    }
+}
+
+private fun Color.computeLuminance(): Float =
+    0.2126f * red + 0.7152f * green + 0.0722f * blue
+```
+
+Note: `computeLuminance` is a local extension (named to avoid shadowing Compose's built-in `Color.luminance()` on some versions). The check uses `MaterialTheme.colorScheme.surface` directly — the only truthful signal when the user has forced LIGHT on a system-dark device or vice versa.
+
+- [ ] **Step 3: Build the debug APK**
+
+Run: `./gradlew assembleDebug`
+Expected: BUILD SUCCESSFUL. If `@Inject lateinit var` fails Hilt validation, confirm `SettingsRepository` is `@Singleton` (it already is in `data/repo/SettingsRepository.kt:20`) and that `MainActivity` already has `@AndroidEntryPoint` (it does).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/src/main/java/com/androdr/MainActivity.kt
+git commit -m "feat(main): inject SettingsRepository, drive theme + system bars from Compose"
+```
+
+---
+
+## Task 10: Update Activity theme XML for OEM hardening
+
+**Files:**
+- Modify: `app/src/main/res/values/themes.xml`
+
+- [ ] **Step 1: Rewrite themes.xml**
+
+Replace the entire content of `app/src/main/res/values/themes.xml` with:
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <style name="Theme.AndroDR" parent="Theme.AppCompat.DayNight.NoActionBar">
+        <item name="android:forceDarkAllowed" tools:targetApi="29">false</item>
+        <item name="android:windowBackground">@android:color/transparent</item>
+    </style>
+</resources>
+```
+
+Changes vs. the previous version:
+- Parent switched to `Theme.AppCompat.DayNight.NoActionBar` so the Activity's base resources flip light/dark with the OS (Compose still owns the actual paint, but this keeps any non-Compose AppCompat widgets sane).
+- Hardcoded `statusBarColor` / `navigationBarColor` removed — `MainActivity.SystemBarsEffect` now sets these at runtime to track the Compose surface color.
+- `android:forceDarkAllowed="false"` added — blocks Honor MagicOS (and any other OEM force-dark / force-light) from overriding the app's intent. `tools:targetApi` suppresses lint on pre-API-29 where the attribute is ignored anyway.
+- `windowBackground` set to transparent so there is no flash of the Activity theme's default color before Compose draws.
+
+- [ ] **Step 2: Build the debug APK**
+
+Run: `./gradlew assembleDebug`
+Expected: BUILD SUCCESSFUL. If lint fails on `forceDarkAllowed` despite the `tools:targetApi`, add a baseline ignore or downgrade the lint rule — the attribute is genuinely safe on pre-29 (no-op).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/src/main/res/values/themes.xml
+git commit -m "fix(theme): drop hardcoded bar colors, disable forceDark, switch to DayNight parent"
+```
+
+---
+
+## Task 11: Migrate `SeverityChip.kt` to ExtendedColors
+
+**Files:**
+- Modify: `app/src/main/java/com/androdr/ui/common/SeverityChip.kt`
+
+- [ ] **Step 1: Read the current file**
+
+Open `app/src/main/java/com/androdr/ui/common/SeverityChip.kt` and identify every `Color(0xFF…)` literal. Expected (from initial grep): four severity colors at lines 14-17 (inside `severityColor()`), a grey at line 19, and a duplicate set at lines 37-40.
+
+- [ ] **Step 2: Replace literals with ExtendedColors lookups**
+
+Inside `SeverityChip.kt`:
+
+- Add to imports:
+  ```kotlin
+  import androidx.compose.material3.MaterialTheme
+  import com.androdr.ui.theme.androdrColors
+  ```
+  (Remove `import androidx.compose.ui.graphics.Color` only if no `Color(...)` remains after migration. Keep it otherwise.)
+
+- For the `severityColor` function (around line 13):
+  ```kotlin
+  @Composable
+  private fun severityColor(level: String): Color {
+      val colors = MaterialTheme.androdrColors
+      return when (level.lowercase()) {
+          "critical" -> colors.critical
+          "high"     -> colors.high
+          "medium"   -> colors.medium
+          else       -> colors.neutral
+      }
+  }
+  ```
+  (Note: if the original used `else -> Color(0xFF00D4AA)` for "low" plus catch-all, prefer the explicit `"low" -> colors.low` branch and keep `else -> colors.neutral` separately. Inspect the actual file to keep the existing branch semantics — the rule is *one severity in, the matching ExtendedColors field out*.)
+
+- For the disabled-grey `Color(0xFF888888)` at line 19:
+  ```kotlin
+  val color = if (active) severityColor(level) else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
+  ```
+
+- For the duplicate switch at lines 37-40, mirror the same lookup pattern (likely another `severityColor`-style function — apply the same replacement).
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `./gradlew :app:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/src/main/java/com/androdr/ui/common/SeverityChip.kt
+git commit -m "refactor(ui): SeverityChip uses MaterialTheme.androdrColors"
+```
+
+---
+
+## Task 12: Migrate `FindingCard.kt` to ExtendedColors
+
+**Files:**
+- Modify: `app/src/main/java/com/androdr/ui/common/FindingCard.kt`
+
+- [ ] **Step 1: Locate the literals**
+
+Open `app/src/main/java/com/androdr/ui/common/FindingCard.kt`. Expected (from initial grep): `Color(0xFFCF6679).copy(alpha = 0.08f)` at line 42 (background), `Color(0xFFCF6679)` at line 54 (icon tint). The `MaterialTheme.colorScheme.primary` branch at line 54 stays as-is.
+
+- [ ] **Step 2: Replace**
+
+Add to imports:
+
+```kotlin
+import com.androdr.ui.theme.androdrColors
+```
+
+(`MaterialTheme` is already imported.)
+
+Change the card background pattern (around line 42):
+
+```kotlin
+containerColor = if (finding.triggered) MaterialTheme.androdrColors.criticalContainer
+                 else MaterialTheme.colorScheme.surfaceContainer
+```
+
+Change the icon tint (around line 54):
+
+```kotlin
+tint = if (finding.triggered) MaterialTheme.androdrColors.critical
+       else MaterialTheme.colorScheme.primary
+```
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `./gradlew :app:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/src/main/java/com/androdr/ui/common/FindingCard.kt
+git commit -m "refactor(ui): FindingCard uses MaterialTheme.androdrColors"
+```
+
+---
+
+## Task 13: Migrate `EvidenceSheet.kt` to ExtendedColors
+
+**Files:**
+- Modify: `app/src/main/java/com/androdr/ui/common/EvidenceSheet.kt`
+
+- [ ] **Step 1: Locate the literals**
+
+Open `app/src/main/java/com/androdr/ui/common/EvidenceSheet.kt`. Expected (from initial grep): `Color(0xFFCF6679)` at lines 108, 158 (alpha 0.06), 205 (container alpha 0.2), 206 (label), 261; `Color(0xFFFF9800)` at lines 281 (container alpha 0.15), 282 (label).
+
+- [ ] **Step 2: Replace**
+
+Add to imports:
+
+```kotlin
+import com.androdr.ui.theme.androdrColors
+```
+
+Apply this mapping throughout the file:
+
+| Old expression                                  | New expression                                     |
+|-------------------------------------------------|----------------------------------------------------|
+| `Color(0xFFCF6679)`                             | `MaterialTheme.androdrColors.critical`             |
+| `Color(0xFFCF6679).copy(alpha = 0.06f)` or `0.08f` | `MaterialTheme.androdrColors.criticalContainer` (container hex already encodes the right tint) |
+| `Color(0xFFCF6679).copy(alpha = 0.2f)`          | `MaterialTheme.androdrColors.criticalContainer`    |
+| `Color(0xFFFF9800)`                             | `MaterialTheme.androdrColors.high`                 |
+| `Color(0xFFFF9800).copy(alpha = 0.15f)`         | `MaterialTheme.androdrColors.highContainer`        |
+
+Walk the file top-to-bottom and apply each replacement at every site.
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `./gradlew :app:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/src/main/java/com/androdr/ui/common/EvidenceSheet.kt
+git commit -m "refactor(ui): EvidenceSheet uses MaterialTheme.androdrColors"
+```
+
+---
+
+## Task 14: Migrate `TimelineEventCard.kt` to ExtendedColors
+
+**Files:**
+- Modify: `app/src/main/java/com/androdr/ui/timeline/TimelineEventCard.kt`
+
+- [ ] **Step 1: Locate the literals**
+
+Open `app/src/main/java/com/androdr/ui/timeline/TimelineEventCard.kt`. Expected (from initial grep): line 68 (`neutralColor = 0xFF00D4AA`), line 100 (CritRed tag), lines 206-209 (severity switch CRITICAL/HIGH/MEDIUM/LOW), lines 373-375 (correlation pattern colors).
+
+- [ ] **Step 2: Replace**
+
+Add to imports:
+
+```kotlin
+import androidx.compose.runtime.Composable
+import com.androdr.ui.theme.androdrColors
+```
+
+(`MaterialTheme` and `Composable` may already be imported — skip if so.)
+
+For the `neutralColor` at line 68: it's inside a Composable, so swap to a Composable-context read. If the variable is declared at top-of-Composable, change:
+
+```kotlin
+val neutralColor = MaterialTheme.androdrColors.neutral
+```
+
+For the tag chip at line 100 (`TagChip(event.campaignName, Color(0xFFCF6679))`): pull the color first then pass it:
+
+```kotlin
+val criticalColor = MaterialTheme.androdrColors.critical
+…
+if (event.campaignName.isNotEmpty()) TagChip(event.campaignName, criticalColor)
+```
+
+For the severity switch around lines 206-209 — convert the function to a `@Composable` (if not already) and replace:
+
+```kotlin
+@Composable
+private fun severityToColor(severity: String): Color {
+    val colors = MaterialTheme.androdrColors
+    return when (severity.uppercase()) {
+        "CRITICAL" -> colors.critical
+        "HIGH"     -> colors.high
+        "MEDIUM"   -> colors.medium
+        "LOW"      -> colors.low
+        else       -> colors.neutral
+    }
+}
+```
+
+For correlation pattern colors at lines 373-375:
+
+```kotlin
+@Composable
+private fun correlationPatternColor(pattern: CorrelationPattern): Color {
+    val colors = MaterialTheme.androdrColors
+    return when (pattern) {
+        CorrelationPattern.INSTALL_THEN_ADMIN       -> colors.critical
+        CorrelationPattern.MULTI_PERMISSION_BURST   -> colors.high
+        else                                        -> colors.neutral
+    }
+}
+```
+
+For the one-off `Color(0xFFFF8A65)` at line 207 (deep orange 300): replaced by `colors.high` in the severity switch above.
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `./gradlew :app:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL. If you converted a non-Composable function to `@Composable`, any caller that wasn't already inside a Composable scope must be moved into one. The whole timeline UI is Composable-only, so this should hold.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/src/main/java/com/androdr/ui/timeline/TimelineEventCard.kt
+git commit -m "refactor(ui): TimelineEventCard uses MaterialTheme.androdrColors"
+```
+
+---
+
+## Task 15: Migrate `DnsMonitorScreen.kt` to ExtendedColors
+
+**Files:**
+- Modify: `app/src/main/java/com/androdr/ui/network/DnsMonitorScreen.kt`
+
+- [ ] **Step 1: Locate the literals**
+
+Open `app/src/main/java/com/androdr/ui/network/DnsMonitorScreen.kt`. Expected (from initial grep): lines 258 (container alpha 0.08), 273 (label), 302 (container alpha 0.2), 305 (label).
+
+- [ ] **Step 2: Replace**
+
+Add to imports:
+
+```kotlin
+import com.androdr.ui.theme.androdrColors
+```
+
+Apply:
+
+| Old expression                                  | New expression                                  |
+|-------------------------------------------------|-------------------------------------------------|
+| `Color(0xFFCF6679)`                             | `MaterialTheme.androdrColors.critical`          |
+| `Color(0xFFCF6679).copy(alpha = 0.08f)` / `0.2f` | `MaterialTheme.androdrColors.criticalContainer` |
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `./gradlew :app:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/src/main/java/com/androdr/ui/network/DnsMonitorScreen.kt
+git commit -m "refactor(ui): DnsMonitorScreen uses MaterialTheme.androdrColors"
+```
+
+---
+
+## Task 16: Add the hardcoded-color drift guard test
+
+**Files:**
+- Test: `app/src/test/java/com/androdr/ui/theme/HardcodedColorGuardTest.kt`
+
+- [ ] **Step 1: Write the test**
+
+Create `app/src/test/java/com/androdr/ui/theme/HardcodedColorGuardTest.kt`:
+
+```kotlin
+package com.androdr.ui.theme
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+/**
+ * Guards against re-introducing hardcoded Color(0xFF…) literals in UI code.
+ * The only allowed locations for raw color values are inside ui/theme/.
+ * If you need a new semantic color, add it to ExtendedColors instead.
+ *
+ * Suppress per-line with: // hardcoded-color-ok: <reason>
+ */
+class HardcodedColorGuardTest {
+
+    @Test
+    fun `no hardcoded Color(0xFF…) literals outside ui-theme package`() {
+        val sourceRoot = findSourceRoot()
+        val pattern = Regex("""Color\(0x[0-9A-Fa-f]{8}\)""")
+        val allowMarker = "hardcoded-color-ok"
+
+        val offenders = sourceRoot.walkTopDown()
+            .filter { it.isFile && it.extension == "kt" }
+            .filterNot { it.path.replace('\\', '/').contains("/ui/theme/") }
+            .flatMap { file ->
+                file.readLines().mapIndexedNotNull { idx, line ->
+                    if (pattern.containsMatchIn(line) && !line.contains(allowMarker)) {
+                        "${file.relativeTo(sourceRoot)}:${idx + 1}  $line"
+                    } else null
+                }
+            }
+            .toList()
+
+        assertTrue(
+            "Hardcoded Color(0xFF…) literals found outside ui/theme/.\n" +
+                "Move the color to ExtendedColors, or append `// hardcoded-color-ok: <reason>` " +
+                "to the line if it is genuinely a one-off (debug overlay, preview fixture, etc.):\n" +
+                offenders.joinToString("\n"),
+            offenders.isEmpty()
+        )
+    }
+
+    private fun findSourceRoot(): File {
+        // Tests can run from either the repo root or the app module dir. Try both.
+        val candidates = listOf(
+            File("src/main/java/com/androdr"),
+            File("app/src/main/java/com/androdr")
+        )
+        return candidates.firstOrNull { it.exists() }
+            ?: error("Could not locate source root from ${File(".").absolutePath}")
+    }
+}
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `./gradlew :app:testDebugUnitTest --tests "com.androdr.ui.theme.HardcodedColorGuardTest"`
+Expected: PASS. If it FAILS, the failure message lists every remaining `Color(0xFF…)` literal — either migrate the listed sites to `ExtendedColors`, or add a `// hardcoded-color-ok: <reason>` marker on lines that genuinely belong outside the theme (uncommon — most likely the case is "I forgot to migrate one file").
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/src/test/java/com/androdr/ui/theme/HardcodedColorGuardTest.kt
+git commit -m "test(theme): guard against hardcoded Color(0xFF…) literals outside ui/theme"
+```
+
+---
+
+## Task 17: Add Compose previews for migrated severity-coded UI
+
+**Files:**
+- Modify: `app/src/main/java/com/androdr/ui/common/SeverityChip.kt`
+- Modify: `app/src/main/java/com/androdr/ui/common/FindingCard.kt`
+- Modify: `app/src/main/java/com/androdr/ui/common/EvidenceSheet.kt`
+- Modify: `app/src/main/java/com/androdr/ui/timeline/TimelineEventCard.kt`
+
+- [ ] **Step 1: Add a preview helper at the bottom of `SeverityChip.kt`**
+
+Append to `app/src/main/java/com/androdr/ui/common/SeverityChip.kt`:
+
+```kotlin
+@androidx.compose.ui.tooling.preview.Preview(
+    name = "Severity chips — Dark",
+    uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES
+)
+@androidx.compose.ui.tooling.preview.Preview(
+    name = "Severity chips — Light",
+    uiMode = android.content.res.Configuration.UI_MODE_NIGHT_NO
+)
+@Composable
+private fun SeverityChipPreview() {
+    com.androdr.ui.theme.AndroDRTheme(themeMode = com.androdr.ui.theme.ThemeMode.AUTO) {
+        androidx.compose.foundation.layout.Surface(
+            color = MaterialTheme.colorScheme.background
+        ) {
+            androidx.compose.foundation.layout.Row(
+                modifier = androidx.compose.ui.Modifier
+                    .padding(androidx.compose.ui.unit.dp.let { 16.dp }),
+                horizontalArrangement = androidx.compose.foundation.layout.Arrangement.spacedBy(8.dp)
+            ) {
+                listOf("critical", "high", "medium", "low").forEach { level ->
+                    SeverityChip(level = level)
+                }
+            }
+        }
+    }
+}
+```
+
+(Adjust the `SeverityChip(...)` call to match the file's actual public API — if it takes more parameters, supply sensible defaults. The point is one composable preview per severity, in both themes.)
+
+- [ ] **Step 2: Do the same for `FindingCard.kt`, `EvidenceSheet.kt`, `TimelineEventCard.kt`**
+
+For each file: add two `@Preview` annotations (Dark/Light) wrapping the public composable with mock data. The previews exist for the implementer and for visual review during PR — not for asserting in CI.
+
+If supplying mock data for `FindingCard` / `EvidenceSheet` / `TimelineEventCard` is more work than the value of the preview, **skip that specific preview** with a `// TODO(post-merge): add preview once Finding/Event factories are extracted` and mention it in the PR description. Don't block this task on building large fixture builders.
+
+- [ ] **Step 3: Verify Android Studio renders the previews**
+
+Run: `./gradlew :app:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL. Open the migrated files in Android Studio and confirm the previews render in both Dark and Light modes without contrast issues.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/src/main/java/com/androdr/ui/common/SeverityChip.kt \
+        app/src/main/java/com/androdr/ui/common/FindingCard.kt \
+        app/src/main/java/com/androdr/ui/common/EvidenceSheet.kt \
+        app/src/main/java/com/androdr/ui/timeline/TimelineEventCard.kt
+git commit -m "test(ui): add light+dark previews for migrated severity-coded composables"
+```
+
+---
+
+## Task 18: Final verification — full test suite, lint, smoke
+
+**Files:** none modified.
+
+- [ ] **Step 1: Run the full unit test suite**
+
+Run: `./gradlew :app:testDebugUnitTest`
+Expected: ALL TESTS PASS. If a pre-existing test breaks, investigate — but unrelated breakage is not part of this plan's scope. Theme-related failures should not occur if previous tasks passed.
+
+- [ ] **Step 2: Run lint**
+
+Run: `./gradlew lintDebug`
+Expected: No NEW errors introduced. Warnings about `android:forceDarkAllowed` requiring API 29 should be suppressed by the `tools:targetApi` attribute added in Task 10. If a true error remains, fix at the source.
+
+- [ ] **Step 3: Build the release APK to confirm shrinker/proguard don't break**
+
+Run: `./gradlew assembleRelease`
+Expected: BUILD SUCCESSFUL. If R8 strips a Composable preview unexpectedly, that's fine — previews are dev-only. If R8 strips something real, add the necessary keep rule.
+
+- [ ] **Step 4: Smoke test on emulator**
+
+Run the existing script:
+```bash
+./scripts/smoke-test.sh
+```
+Expected: APK installs, app launches, logcat is crash-free. Then manually:
+1. Open Settings on the emulator's system, toggle dark mode off → confirm AndroDR follows to light mode within seconds.
+2. In AndroDR Settings → Appearance, switch to "Dark" → confirm app forces dark regardless of system.
+3. Switch to "Light" → confirm app forces light.
+4. Switch to "System" → confirm app re-follows the system setting.
+5. Open Dashboard, Apps, Network, Timeline screens in both modes — visually confirm severity chips and finding cards are legible.
+
+- [ ] **Step 5: Manual smoke on Honor device (if available)**
+
+If the tester's Honor device is available, re-test the exact screen where text was reported invisible. Confirm legibility in both system-light and system-dark modes. Capture screenshots for the PR description.
+
+If no Honor device is available: explicitly note "Honor re-test pending — relies on tester verification post-merge" in the PR description. Do not claim the bug fixed without device confirmation.
+
+- [ ] **Step 6: No commit (verification only)**
+
+This task produces no commits. Output goes into the PR description.
+
+---
+
+## Self-Review Notes
+
+Run through the plan once more before handoff:
+
+- **Spec coverage:** every spec section maps to at least one task — ThemeMode (T1), persistence (T2), ExtendedColors (T3), contrast test (T4), light scheme (T5), AndroDRTheme refactor (T6), Settings VM+UI (T7-T8), MainActivity wiring + system bars (T9), manifest hardening (T10), the 5 migration files (T11-T15), drift guard (T16), previews (T17), full verification (T18). Out-of-scope items (dynamic color, androdr-015 FP) remain out.
+- **Type consistency:** `ThemeMode` (enum), `resolveDarkTheme(themeMode, systemInDark): Boolean`, `ExtendedColors` (data class), `LocalAndroDRColors`, `MaterialTheme.androdrColors`, `settingsRepository.themeMode` / `setThemeMode(mode)`, `KEY_THEME_MODE` — all referenced consistently across tasks.
+- **No placeholders:** every step has either runnable code, an exact command, or a discrete edit instruction with the actual code shown.
+- **Out-of-order safety:** each task's "Files" / "Step 1" lists what it touches, so a worker resuming from any task has the context needed without reading earlier tasks.
+
+---
+
+**Plan complete and saved to `docs/superpowers/plans/2026-05-18-light-dark-theme.md`. Two execution options:**
+
+**1. Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration.
+
+**2. Inline Execution** — Execute tasks in this session using executing-plans, batch execution with checkpoints.
+
+**Which approach?**

--- a/docs/superpowers/plans/2026-05-18-light-dark-theme.md
+++ b/docs/superpowers/plans/2026-05-18-light-dark-theme.md
@@ -1377,13 +1377,13 @@ Add:
 import com.androdr.ui.theme.androdrColors
 ```
 
-Remove the now-dead import at line 61 (verified: no remaining usages of `severityColor` symbol in the file after this migration):
+Remove the dead import at line 61 — it is already unused at HEAD (zero `severityColor` call sites in this file; the import has been dead for at least one prior change). Removing it now closes a long-standing release-lint warning:
 
 ```kotlin
 import com.androdr.ui.common.severityColor   // delete this line
 ```
 
-Skipping the removal will produce a "Unused import" warning that may fail release lint (CLAUDE.md notes warnings are treated as errors in release builds).
+Skipping the removal will keep the "Unused import" warning that may fail release lint (CLAUDE.md notes warnings are treated as errors in release builds).
 
 - [ ] **Step 2: Migrate `PostScanGuidance` severity switch (lines 300-315)**
 

--- a/docs/superpowers/plans/2026-05-18-light-dark-theme.md
+++ b/docs/superpowers/plans/2026-05-18-light-dark-theme.md
@@ -4,7 +4,11 @@
 
 **Goal:** Make AndroDR's UI legible on every Android device by introducing a light color scheme that follows the OS setting, a user override (Auto/Light/Dark), a semantic-color layer, and migration of all hardcoded color literals. Fixes the tester-reported invisible-text bug on Honor MagicOS.
 
-**Architecture:** A new `ThemeMode` enum is persisted in `SettingsRepository` (DataStore). `AndroDRTheme` resolves it against `isSystemInDarkTheme()` and provides both a Material 3 `ColorScheme` and an app-specific `ExtendedColors` (severity hues, alert backgrounds) via `CompositionLocal`. The Activity theme drops hardcoded system-bar colors and `forceDarkAllowed` is disabled to stop OEM overrides. Five UI files migrate from hardcoded `Color(0xFF…)` literals to `MaterialTheme.androdrColors.*`, and a unit test guards against regression.
+**Architecture:** A new `ThemeMode` enum is persisted in `SettingsRepository` (DataStore). `AndroDRTheme` resolves it against `isSystemInDarkTheme()` and provides both a Material 3 `ColorScheme` and an app-specific `ExtendedColors` (severity hues, alert backgrounds) via `CompositionLocal`. The Activity theme drops hardcoded system-bar colors and `forceDarkAllowed` is disabled to stop OEM overrides. Nine UI files migrate from hardcoded `Color(0xFF…)` literals to `MaterialTheme.androdrColors.*`, and a unit test guards against regression.
+
+**Key idiom — `severityColor(level, colors)`:** The existing top-level `fun severityColor(level: String): Color` in `SeverityChip.kt` has many non-Composable callers (`AppScanScreen.kt`, `HistoryScreen.kt`, etc.). Rather than convert it to `@Composable` and cascade that requirement, we **add a `colors: ExtendedColors` parameter** so call sites pass the palette in. Composable callers read it from `MaterialTheme.androdrColors`; the function itself stays non-Composable.
+
+**Drift-guard idiom — `.copy(alpha = …)`:** The drift-guard test only catches raw `Color(0xFF…)` literals. Sub-percent tints like the `0.06f`/`0.08f`/`0.15f` washes in `EvidenceSheet` / `DashboardScreen` are migrated to `MaterialTheme.androdrColors.critical.copy(alpha = 0.08f)` (etc.) — those are NOT caught by the guard and preserve the original visual weight. The `*Container` fields in `ExtendedColors` are calibrated for the 20%-ish chip-background use case only.
 
 **Tech Stack:** Kotlin, Jetpack Compose, Material 3, Hilt, Jetpack DataStore (Preferences), AndroidX `WindowCompat`. JVM unit tests with JUnit 4.
 
@@ -18,22 +22,29 @@
 - `app/src/main/java/com/androdr/ui/theme/ThemeMode.kt` — `ThemeMode` enum + `resolveDarkTheme` pure helper.
 - `app/src/main/java/com/androdr/ui/theme/ExtendedColors.kt` — data class, `LocalAndroDRColors`, `DarkExtendedColors`, `LightExtendedColors`, `MaterialTheme.androdrColors` extension.
 - `app/src/test/java/com/androdr/ui/theme/ThemeModeResolutionTest.kt` — truth table for `resolveDarkTheme`.
-- `app/src/test/java/com/androdr/ui/theme/ExtendedColorsContrastTest.kt` — WCAG AA contrast assertions on both palette instances.
+- `app/src/test/java/com/androdr/ui/theme/ExtendedColorsContrastTest.kt` — WCAG AA contrast assertions on both palette instances (incl. light containers).
 - `app/src/test/java/com/androdr/ui/theme/HardcodedColorGuardTest.kt` — drift guard scanning `*.kt` outside `ui/theme/`.
 - `app/src/test/java/com/androdr/data/repo/SettingsRepositoryThemeModeTest.kt` — round-trip test for the new DataStore key.
 
-**Modify:**
+**Modify (theme + persistence):**
 - `app/src/main/java/com/androdr/ui/theme/Theme.kt` — add `LightColorScheme`, refactor `AndroDRTheme(themeMode = ...)`, wire `CompositionLocal`.
 - `app/src/main/java/com/androdr/data/repo/SettingsRepository.kt` — add `themeMode` Flow + `setThemeMode` + key constant.
 - `app/src/main/java/com/androdr/ui/settings/SettingsViewModel.kt` — expose `themeMode` StateFlow + `setThemeMode`.
 - `app/src/main/java/com/androdr/ui/settings/SettingsScreen.kt` — add "Appearance" section with 3-option picker.
-- `app/src/main/java/com/androdr/MainActivity.kt` — inject `SettingsRepository`, collect theme mode, pass into `AndroDRTheme`, drive system-bar colors from Compose.
-- `app/src/main/res/values/themes.xml` — drop hardcoded bar colors, add `android:forceDarkAllowed="false"`, switch parent to DayNight.
-- `app/src/main/java/com/androdr/ui/common/SeverityChip.kt` — migrate severity literals.
-- `app/src/main/java/com/androdr/ui/common/FindingCard.kt` — migrate severity literals.
-- `app/src/main/java/com/androdr/ui/common/EvidenceSheet.kt` — migrate severity literals.
-- `app/src/main/java/com/androdr/ui/timeline/TimelineEventCard.kt` — migrate severity literals.
-- `app/src/main/java/com/androdr/ui/network/DnsMonitorScreen.kt` — migrate severity literals.
+- `app/src/main/java/com/androdr/MainActivity.kt` — inject `SettingsRepository`, collect theme mode, pass into `AndroDRTheme`, drive system-bar colors from Compose, wrap content in `Surface`.
+- `app/src/main/res/values/themes.xml` — drop hardcoded bar colors, add `android:forceDarkAllowed="false"`. Keep platform parent (project has no AppCompat dependency).
+
+**Modify (color migration — 9 files):**
+- `ui/common/SeverityChip.kt` — also refactors `severityColor(level)` signature to `severityColor(level, colors)`.
+- `ui/apps/AppScanScreen.kt` — updates all `severityColor(level)` call sites to pass `colors`.
+- `ui/common/FindingCard.kt`
+- `ui/common/EvidenceSheet.kt`
+- `ui/timeline/TimelineEventCard.kt`
+- `ui/network/DnsMonitorScreen.kt`
+- `ui/history/HistoryScreen.kt` — both `severityColor` call sites AND 2 hardcoded literals.
+- `ui/device/DeviceAuditScreen.kt`
+- `ui/bugreport/BugReportScreen.kt`
+- `ui/dashboard/DashboardScreen.kt` — largest single file (15 literals incl. risk swatches and warning-tint card surfaces).
 
 ---
 
@@ -137,7 +148,6 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
-import java.io.File
 
 class SettingsRepositoryThemeModeTest {
 
@@ -145,18 +155,17 @@ class SettingsRepositoryThemeModeTest {
 
     private lateinit var dataStore: DataStore<Preferences>
     private lateinit var repo: SettingsRepository
-    private lateinit var prefsFile: File
 
     @Before
     fun setUp() {
-        prefsFile = tmp.newFile("test_prefs.preferences_pb")
-        dataStore = PreferenceDataStoreFactory.create(produceFile = { prefsFile })
+        val file = java.io.File(tmp.root, "test.preferences_pb")
+        dataStore = PreferenceDataStoreFactory.create(produceFile = { file })
         repo = SettingsRepository(dataStore)
     }
 
     @After
     fun tearDown() {
-        prefsFile.delete()
+        // TemporaryFolder rule handles cleanup
     }
 
     @Test
@@ -185,6 +194,8 @@ class SettingsRepositoryThemeModeTest {
 }
 ```
 
+Note: `tmp.root` is used (not `tmp.newFile(...)`) because `PreferenceDataStoreFactory.create` wants the file path; the factory creates the file lazily. `tmp.newFile()` pre-creates an empty file which can confuse the protobuf reader on first read.
+
 - [ ] **Step 2: Run test to verify it fails**
 
 Run: `./gradlew :app:testDebugUnitTest --tests "com.androdr.data.repo.SettingsRepositoryThemeModeTest"`
@@ -194,13 +205,13 @@ Expected: FAIL (unresolved reference `themeMode` / `setThemeMode`).
 
 In `app/src/main/java/com/androdr/data/repo/SettingsRepository.kt`:
 
-Add to the imports block (alphabetical):
+Add to the imports block (alphabetical, in the existing `com.androdr.…` cluster):
 
 ```kotlin
 import com.androdr.ui.theme.ThemeMode
 ```
 
-Add inside the class body, after the `domainIocBlockMode` block (around line 30):
+Add inside the class body **immediately after the `setDomainIocBlockMode` function** (the one that ends with `dataStore.edit { it[KEY_DOMAIN_IOC_BLOCK_MODE] = value }`) and **before the `customRuleUrls` declaration** (the `/** Custom SIGMA rule repo URLs ... */` block):
 
 ```kotlin
 val themeMode: Flow<ThemeMode> = dataStore.data
@@ -217,7 +228,7 @@ suspend fun setThemeMode(mode: ThemeMode) {
 }
 ```
 
-Add to the `companion object` (around line 102):
+Add inside the `companion object` block, **after `KEY_CUSTOM_RULE_URLS`** and before the closing brace:
 
 ```kotlin
 private val KEY_THEME_MODE = stringPreferencesKey("theme_mode")
@@ -258,9 +269,15 @@ import androidx.compose.ui.graphics.Color
 
 /**
  * App-specific semantic colors that Material 3's ColorScheme does not cover:
- * the four severity tiers and their tinted backgrounds. Two instances exist —
- * one for dark, one for light — and AndroDRTheme provides the right one via
+ * the four severity tiers and their chip-background tints. Two instances —
+ * one dark, one light. AndroDRTheme provides the right one via
  * LocalAndroDRColors. Access through MaterialTheme.androdrColors.
+ *
+ * Container values are calibrated for the ~20% chip-background use case.
+ * For sub-percent washes (alert card backgrounds, 6-15%), call sites should
+ * use the base hue with .copy(alpha = …) — e.g. critical.copy(alpha = 0.08f).
+ * Such call sites are NOT caught by HardcodedColorGuardTest (the guard only
+ * matches Color(0xFF…) literals).
  */
 data class ExtendedColors(
     val critical: Color,
@@ -274,24 +291,27 @@ data class ExtendedColors(
     val lowContainer: Color,
 )
 
+// Dark values preserve the existing hues so the dark UI is visually unchanged.
 val DarkExtendedColors = ExtendedColors(
     critical          = Color(0xFFCF6679),
     high              = Color(0xFFFF9800),
     medium            = Color(0xFFE6A800),
     low               = Color(0xFF64B5F6),
     neutral           = TealPrimary,
-    criticalContainer = Color(0x33CF6679),
+    criticalContainer = Color(0x33CF6679), // alpha 0x33 ≈ 0.20
     highContainer     = Color(0x33FF9800),
     mediumContainer   = Color(0x33E6A800),
     lowContainer      = Color(0x3364B5F6),
 )
 
+// Light values are darker, deeper shades chosen to satisfy WCAG AA UI contrast (≥ 3.0)
+// on background 0xFFFAFAFA. Verified by ExtendedColorsContrastTest.
 val LightExtendedColors = ExtendedColors(
     critical          = Color(0xFFB3261E),
     high              = Color(0xFFC25700),
     medium            = Color(0xFF8B6B00),
     low               = Color(0xFF1565C0),
-    neutral           = TealPrimaryVariant,
+    neutral           = Color(0xFF00695C),  // darker teal (TealPrimaryVariant 0xFF00A882 fails AA on white)
     criticalContainer = Color(0xFFFFDAD6),
     highContainer     = Color(0xFFFFDCC2),
     mediumContainer   = Color(0xFFF6E5B4),
@@ -311,7 +331,7 @@ val MaterialTheme.androdrColors: ExtendedColors
 - [ ] **Step 2: Verify it compiles**
 
 Run: `./gradlew :app:compileDebugKotlin`
-Expected: BUILD SUCCESSFUL. Compilation errors here mean either `TealPrimary` / `TealPrimaryVariant` aren't visible (they're top-level in `Theme.kt` already, in the same package, so this should just work) or a typo in an import.
+Expected: BUILD SUCCESSFUL.
 
 - [ ] **Step 3: Commit**
 
@@ -327,7 +347,9 @@ git commit -m "feat(theme): add ExtendedColors data class with dark+light severi
 **Files:**
 - Test: `app/src/test/java/com/androdr/ui/theme/ExtendedColorsContrastTest.kt`
 
-- [ ] **Step 1: Write the failing test**
+The light-palette values in Task 3 were pre-computed to pass the UI threshold (3.0) on `0xFFFAFAFA` background and on their matching containers. No iteration should be needed — if a check fails, the implementer should suspect a typo, not retune.
+
+- [ ] **Step 1: Write the test**
 
 Create `app/src/test/java/com/androdr/ui/theme/ExtendedColorsContrastTest.kt`:
 
@@ -338,8 +360,7 @@ import androidx.compose.ui.graphics.Color
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
-private const val WCAG_AA_LARGE_TEXT_AND_UI = 3.0
-private const val WCAG_AA_NORMAL_TEXT = 4.5
+private const val WCAG_AA_UI = 3.0  // UI components and large text; severity chips are UI.
 
 class ExtendedColorsContrastTest {
 
@@ -363,11 +384,20 @@ class ExtendedColorsContrastTest {
         assertAaUi("neutral",  LightExtendedColors.neutral,  bg)
     }
 
+    @Test
+    fun `light severity colors meet AA against their containers`() {
+        val light = LightExtendedColors
+        assertAaUi("critical/container", light.critical, light.criticalContainer)
+        assertAaUi("high/container",     light.high,     light.highContainer)
+        assertAaUi("medium/container",   light.medium,   light.mediumContainer)
+        assertAaUi("low/container",      light.low,      light.lowContainer)
+    }
+
     private fun assertAaUi(name: String, fg: Color, bg: Color) {
         val ratio = contrastRatio(fg, bg)
         assertTrue(
-            "$name (${fg.toHex()}) on (${bg.toHex()}) contrast $ratio < $WCAG_AA_LARGE_TEXT_AND_UI",
-            ratio >= WCAG_AA_LARGE_TEXT_AND_UI
+            "$name: fg=${fg.toHex()} bg=${bg.toHex()} contrast=${"%.2f".format(ratio)} < $WCAG_AA_UI",
+            ratio >= WCAG_AA_UI
         )
     }
 }
@@ -398,9 +428,9 @@ private fun Color.toHex(): String = String.format(
 - [ ] **Step 2: Run the test**
 
 Run: `./gradlew :app:testDebugUnitTest --tests "com.androdr.ui.theme.ExtendedColorsContrastTest"`
-Expected: PASS (2/2). If a specific color fails, the failure message tells you which one — adjust its value in `ExtendedColors.kt` and re-run until all pass.
+Expected: PASS (3/3). If a check fails, do NOT retune the palette — the values were pre-validated. A failure means a typo in `ExtendedColors.kt`; re-read the file against Task 3's hex values.
 
-Note: The threshold is the WCAG AA UI-component / large-text threshold (3.0). Severity chips and pill backgrounds are UI components, not body text. If you want body-text-strength contrast (4.5), bump the constant — but be aware that some hues (orange in particular) struggle to hit 4.5 on white without going brown.
+Dark containers are not tested directly: they are alpha-translucent over dark surface, so a chip's effective contrast is severity-text-on-near-black, which the first test already covers.
 
 - [ ] **Step 3: Commit**
 
@@ -426,7 +456,7 @@ Add to imports (alphabetical):
 import androidx.compose.material3.lightColorScheme
 ```
 
-Add immediately after the existing `private val DarkColorScheme = …` block (before the `@Composable fun AndroDRTheme` line, around line 53):
+Add immediately after the closing `)` of the existing `private val DarkColorScheme = darkColorScheme(...)` block and before the `@Composable fun AndroDRTheme` declaration:
 
 ```kotlin
 private val LightColorScheme = lightColorScheme(
@@ -490,7 +520,7 @@ import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.CompositionLocalProvider
 ```
 
-Replace the existing `AndroDRTheme` composable (lines 55-61 approximately) with:
+Replace the existing `@Composable fun AndroDRTheme` block (the entire current `AndroDRTheme(content: @Composable () -> Unit) { … }`) with:
 
 ```kotlin
 @Composable
@@ -511,10 +541,10 @@ fun AndroDRTheme(
 }
 ```
 
-- [ ] **Step 2: Verify it compiles and existing usages still build**
+- [ ] **Step 2: Verify it compiles**
 
 Run: `./gradlew :app:compileDebugKotlin`
-Expected: BUILD SUCCESSFUL. Existing call sites (`AndroDRTheme { … }`) keep working because `themeMode` has a default value.
+Expected: BUILD SUCCESSFUL. Existing callers (`AndroDRTheme { … }`) continue to work because `themeMode` has a default.
 
 - [ ] **Step 3: Commit**
 
@@ -534,13 +564,13 @@ git commit -m "feat(theme): wire AndroDRTheme to ThemeMode + provide ExtendedCol
 
 In `app/src/main/java/com/androdr/ui/settings/SettingsViewModel.kt`:
 
-Add to imports (alphabetical, after the existing `com.androdr.…` block):
+Add to imports (in the existing `com.androdr.…` cluster, alphabetical):
 
 ```kotlin
 import com.androdr.ui.theme.ThemeMode
 ```
 
-Add inside the class body, immediately after the existing `domainIocBlockMode` declaration (around line 67):
+Add inside the class body **immediately after the `domainIocBlockMode` `stateIn(...)` declaration** and **before the `customRuleUrls` declaration**:
 
 ```kotlin
 val themeMode = settingsRepository.themeMode
@@ -572,9 +602,7 @@ git commit -m "feat(settings-vm): expose themeMode StateFlow and setter"
 
 - [ ] **Step 1: Add imports**
 
-In `app/src/main/java/com/androdr/ui/settings/SettingsScreen.kt`:
-
-Add to imports (alphabetical):
+In `app/src/main/java/com/androdr/ui/settings/SettingsScreen.kt`, add to imports:
 
 ```kotlin
 import androidx.compose.material3.SegmentedButton
@@ -583,9 +611,11 @@ import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import com.androdr.ui.theme.ThemeMode
 ```
 
+(`MaterialTheme`, `Modifier`, `Text`, `HorizontalDivider`, `Column`, `Row`, `fillMaxWidth`, `padding`, `dp`, `collectAsStateWithLifecycle` are already imported in this file — do not re-add.)
+
 - [ ] **Step 2: Collect the state**
 
-Inside `fun SettingsScreen(...)`, after the existing `val customRuleUrls by …` line (around line 49), add:
+Inside `fun SettingsScreen(...)`, in the block of `val … by viewModel.X.collectAsStateWithLifecycle()` declarations near the top, add a line **immediately after `val customRuleUrls by viewModel.customRuleUrls.collectAsStateWithLifecycle()`**:
 
 ```kotlin
 val themeMode by viewModel.themeMode.collectAsStateWithLifecycle()
@@ -593,7 +623,7 @@ val themeMode by viewModel.themeMode.collectAsStateWithLifecycle()
 
 - [ ] **Step 3: Insert the Appearance section**
 
-Inside the `Column { … }` body, **immediately after** the headline `Text("Settings", …)` block (around line 125, before the `Text("DNS Blocklist", …)` line), insert:
+Inside the `Column { … }` body, **immediately after the closing brace of the headline `Text("Settings", …)` block** (the one with `style = MaterialTheme.typography.headlineMedium` and `color = MaterialTheme.colorScheme.primary`) and **before the `Text("DNS Blocklist", …)` block**, insert:
 
 ```kotlin
 Text(
@@ -615,7 +645,7 @@ HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
 
 - [ ] **Step 4: Add the picker composable**
 
-At the bottom of the file (after `UpdateStatusRow`, around line 429), add:
+At the bottom of the file (after the existing private `UpdateStatusRow` composable, as a new top-level declaration), add:
 
 ```kotlin
 @Composable
@@ -656,23 +686,24 @@ git commit -m "feat(settings-ui): add Appearance section with System/Light/Dark 
 
 ---
 
-## Task 9: Wire themeMode in MainActivity + drive system bars from Compose
+## Task 9: Wire themeMode in MainActivity + drive system bars + wrap Surface
 
 **Files:**
 - Modify: `app/src/main/java/com/androdr/MainActivity.kt`
 
 - [ ] **Step 1: Add imports**
 
-In `app/src/main/java/com/androdr/MainActivity.kt`:
-
-Add to imports (alphabetical):
+In `app/src/main/java/com/androdr/MainActivity.kt`, add to imports (alphabetical):
 
 ```kotlin
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
@@ -682,9 +713,9 @@ import com.androdr.ui.theme.ThemeMode
 import javax.inject.Inject
 ```
 
-- [ ] **Step 2: Inject SettingsRepository and collect themeMode**
+- [ ] **Step 2: Inject SettingsRepository and rewire onCreate**
 
-Replace the existing `MainActivity` class (lines 45-56) with:
+Replace the existing `MainActivity` class body (the `class MainActivity : ComponentActivity() { … }` block — only the class itself, not the top-level `AndroDRApp()` and `bottomNavDestinations` below it) with:
 
 ```kotlin
 @AndroidEntryPoint
@@ -694,13 +725,17 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: android.os.Bundle?) {
         super.onCreate(savedInstanceState)
-        WindowCompat.setDecorFitsSystemWindows(window, true)
         setContent {
             val themeMode by settingsRepository.themeMode
                 .collectAsStateWithLifecycle(initialValue = ThemeMode.AUTO)
             AndroDRTheme(themeMode = themeMode) {
                 SystemBarsEffect()
-                AndroDRApp()
+                Surface(
+                    modifier = Modifier.fillMaxSize(),
+                    color = MaterialTheme.colorScheme.background
+                ) {
+                    AndroDRApp()
+                }
             }
         }
     }
@@ -711,10 +746,10 @@ private fun SystemBarsEffect() {
     val view = LocalView.current
     val surface = MaterialTheme.colorScheme.surface
     val surfaceArgb = surface.toArgb()
-    // Drive icon brightness from the actual surface luminance — this is the only
-    // truthful signal when the user has forced LIGHT on a system-dark device (or
-    // vice versa). isSystemInDarkTheme() lies in that case.
-    val barsLookDark = surface.computeLuminance() < 0.5f
+    // Drive icon brightness from the actual surface luminance — this is the
+    // only truthful signal when the user has forced LIGHT on a system-dark
+    // device or vice versa. isSystemInDarkTheme() lies in that case.
+    val barsLookDark = surface.luminance() < 0.5f
     if (!view.isInEditMode) {
         SideEffect {
             val window = (view.context as android.app.Activity).window
@@ -727,17 +762,17 @@ private fun SystemBarsEffect() {
         }
     }
 }
-
-private fun Color.computeLuminance(): Float =
-    0.2126f * red + 0.7152f * green + 0.0722f * blue
 ```
 
-Note: `computeLuminance` is a local extension (named to avoid shadowing Compose's built-in `Color.luminance()` on some versions). The check uses `MaterialTheme.colorScheme.surface` directly — the only truthful signal when the user has forced LIGHT on a system-dark device or vice versa.
+Notes for the implementer:
+- `androidx.compose.ui.graphics.luminance` is the Compose built-in WCAG luminance helper; do not write a custom one.
+- We do NOT call `WindowCompat.setDecorFitsSystemWindows(window, true)` because that is the platform default — adding it is misleading.
+- The `Surface` wrap is required because Task 10 makes the Activity window background transparent; without it, dialogs and translucent areas would show through to whatever the OEM put underneath.
 
 - [ ] **Step 3: Build the debug APK**
 
 Run: `./gradlew assembleDebug`
-Expected: BUILD SUCCESSFUL. If `@Inject lateinit var` fails Hilt validation, confirm `SettingsRepository` is `@Singleton` (it already is in `data/repo/SettingsRepository.kt:20`) and that `MainActivity` already has `@AndroidEntryPoint` (it does).
+Expected: BUILD SUCCESSFUL. Hilt validation should accept `@Inject lateinit var settingsRepository: SettingsRepository` because `SettingsRepository` is already `@Singleton`.
 
 - [ ] **Step 4: Commit**
 
@@ -753,6 +788,8 @@ git commit -m "feat(main): inject SettingsRepository, drive theme + system bars 
 **Files:**
 - Modify: `app/src/main/res/values/themes.xml`
 
+The project has **no AppCompat dependency** (verified — `androidx.appcompat` not in `libs.versions.toml` or `app/build.gradle.kts`). Therefore we cannot use `Theme.AppCompat.DayNight.NoActionBar` as a parent. Keep the existing `android:Theme.Material.NoActionBar` platform parent — Compose owns all theming inside, so the XML parent only governs the brief pre-Compose window initialization.
+
 - [ ] **Step 1: Rewrite themes.xml**
 
 Replace the entire content of `app/src/main/res/values/themes.xml` with:
@@ -760,7 +797,7 @@ Replace the entire content of `app/src/main/res/values/themes.xml` with:
 ```xml
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <style name="Theme.AndroDR" parent="Theme.AppCompat.DayNight.NoActionBar">
+    <style name="Theme.AndroDR" parent="android:Theme.Material.NoActionBar">
         <item name="android:forceDarkAllowed" tools:targetApi="29">false</item>
         <item name="android:windowBackground">@android:color/transparent</item>
     </style>
@@ -768,93 +805,179 @@ Replace the entire content of `app/src/main/res/values/themes.xml` with:
 ```
 
 Changes vs. the previous version:
-- Parent switched to `Theme.AppCompat.DayNight.NoActionBar` so the Activity's base resources flip light/dark with the OS (Compose still owns the actual paint, but this keeps any non-Compose AppCompat widgets sane).
 - Hardcoded `statusBarColor` / `navigationBarColor` removed — `MainActivity.SystemBarsEffect` now sets these at runtime to track the Compose surface color.
-- `android:forceDarkAllowed="false"` added — blocks Honor MagicOS (and any other OEM force-dark / force-light) from overriding the app's intent. `tools:targetApi` suppresses lint on pre-API-29 where the attribute is ignored anyway.
-- `windowBackground` set to transparent so there is no flash of the Activity theme's default color before Compose draws.
+- `android:forceDarkAllowed="false"` added — blocks Honor MagicOS (and other OEM force-dark/force-light) from overriding the app's intent. `tools:targetApi="29"` is a lint hint; the attribute is no-op on older APIs.
+- `windowBackground` set to transparent so there is no flash of the platform default color before Compose draws. The new `Surface` wrap in Task 9 paints the actual background.
+- Parent kept as `android:Theme.Material.NoActionBar` (the existing one). We do NOT switch to AppCompat or DayNight — neither is available on the dependency graph.
 
 - [ ] **Step 2: Build the debug APK**
 
-Run: `./gradlew assembleDebug`
-Expected: BUILD SUCCESSFUL. If lint fails on `forceDarkAllowed` despite the `tools:targetApi`, add a baseline ignore or downgrade the lint rule — the attribute is genuinely safe on pre-29 (no-op).
+Run: `./gradlew assembleDebug && ./gradlew lintDebug`
+Expected: BUILD SUCCESSFUL for both. If lint flags `android:forceDarkAllowed`, the `tools:targetApi` should silence it; if not, the rule can be downgraded — the attribute is genuinely safe on pre-29 (no-op).
 
 - [ ] **Step 3: Commit**
 
 ```bash
 git add app/src/main/res/values/themes.xml
-git commit -m "fix(theme): drop hardcoded bar colors, disable forceDark, switch to DayNight parent"
+git commit -m "fix(theme): drop hardcoded bar colors, disable forceDark, keep platform parent"
 ```
 
 ---
 
-## Task 11: Migrate `SeverityChip.kt` to ExtendedColors
+## Task 11: Refactor `severityColor` + migrate `SeverityChip.kt`
 
 **Files:**
 - Modify: `app/src/main/java/com/androdr/ui/common/SeverityChip.kt`
 
-- [ ] **Step 1: Read the current file**
+The current file has two things:
+1. A `@Composable fun SeverityChip(level: String, active: Boolean = true)` with an inline `val severityColor = when …` (lines 11-34).
+2. A top-level non-Composable `fun severityColor(level: String): Color = when …` (lines 36-41) called from `AppScanScreen.kt` and `HistoryScreen.kt`.
 
-Open `app/src/main/java/com/androdr/ui/common/SeverityChip.kt` and identify every `Color(0xFF…)` literal. Expected (from initial grep): four severity colors at lines 14-17 (inside `severityColor()`), a grey at line 19, and a duplicate set at lines 37-40.
+We refactor the top-level function to take an `ExtendedColors` parameter so it stays non-Composable. Composable callers will pass `MaterialTheme.androdrColors`.
 
-- [ ] **Step 2: Replace literals with ExtendedColors lookups**
+- [ ] **Step 1: Replace the entire file body**
 
-Inside `SeverityChip.kt`:
+Replace `app/src/main/java/com/androdr/ui/common/SeverityChip.kt` with:
 
-- Add to imports:
-  ```kotlin
-  import androidx.compose.material3.MaterialTheme
-  import com.androdr.ui.theme.androdrColors
-  ```
-  (Remove `import androidx.compose.ui.graphics.Color` only if no `Color(...)` remains after migration. Keep it otherwise.)
+```kotlin
+package com.androdr.ui.common
 
-- For the `severityColor` function (around line 13):
-  ```kotlin
-  @Composable
-  private fun severityColor(level: String): Color {
-      val colors = MaterialTheme.androdrColors
-      return when (level.lowercase()) {
-          "critical" -> colors.critical
-          "high"     -> colors.high
-          "medium"   -> colors.medium
-          else       -> colors.neutral
-      }
-  }
-  ```
-  (Note: if the original used `else -> Color(0xFF00D4AA)` for "low" plus catch-all, prefer the explicit `"low" -> colors.low` branch and keep `else -> colors.neutral` separately. Inspect the actual file to keep the existing branch semantics — the rule is *one severity in, the matching ExtendedColors field out*.)
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SuggestionChip
+import androidx.compose.material3.SuggestionChipDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import com.androdr.ui.theme.ExtendedColors
+import com.androdr.ui.theme.androdrColors
 
-- For the disabled-grey `Color(0xFF888888)` at line 19:
-  ```kotlin
-  val color = if (active) severityColor(level) else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
-  ```
+@Composable
+fun SeverityChip(level: String, active: Boolean = true) {
+    val colors = MaterialTheme.androdrColors
+    val severityHue = severityColor(level, colors)
+    val color = if (active) severityHue else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
+    SuggestionChip(
+        onClick = {},
+        label = {
+            Text(
+                text = level.uppercase(),
+                style = MaterialTheme.typography.labelSmall,
+                fontWeight = FontWeight.Bold
+            )
+        },
+        colors = SuggestionChipDefaults.suggestionChipColors(
+            containerColor = color.copy(alpha = 0.2f),
+            labelColor = color
+        )
+    )
+}
 
-- For the duplicate switch at lines 37-40, mirror the same lookup pattern (likely another `severityColor`-style function — apply the same replacement).
+/**
+ * Non-Composable severity → color lookup. Takes the palette as a parameter so
+ * non-Composable callers (e.g. result-formatting helpers) can use it without
+ * having to become @Composable themselves. Composable callers should pass
+ * `MaterialTheme.androdrColors`.
+ */
+fun severityColor(level: String, colors: ExtendedColors): Color = when (level.lowercase()) {
+    "critical" -> colors.critical
+    "high"     -> colors.high
+    "medium"   -> colors.medium
+    "low"      -> colors.low
+    else       -> colors.neutral
+}
+```
 
-- [ ] **Step 3: Verify it compiles**
+Behavior preserved:
+- The default branch (`else`) returns `neutral`, which equals `TealPrimary` in dark and the darker teal in light — same as the original `0xFF00D4AA` default.
+- The disabled-state grey `Color(0xFF888888)` is replaced by `onSurface.copy(alpha = 0.38f)`, Material 3's standard disabled token; this works in both themes without a hardcoded grey.
+- The new function adds a `"low"` branch the original lacked — original returned the default (neutral) for any non-critical/high/medium input. Callers that previously passed `"low"` got the neutral teal; they will now get the `low` blue. **This is a deliberate fix**, not a regression — the old code lumped LOW findings into the neutral bucket.
+
+- [ ] **Step 2: Verify it compiles**
 
 Run: `./gradlew :app:compileDebugKotlin`
-Expected: BUILD SUCCESSFUL.
+Expected: COMPILATION ERROR in `AppScanScreen.kt` and `HistoryScreen.kt` because the new `severityColor(level, colors)` signature requires the second argument. **This is expected** — Task 12 and Task 17 fix the callers. Don't commit yet; proceed to Task 12.
 
-- [ ] **Step 4: Commit**
+- [ ] **Step 3: Do NOT commit yet**
 
-```bash
-git add app/src/main/java/com/androdr/ui/common/SeverityChip.kt
-git commit -m "refactor(ui): SeverityChip uses MaterialTheme.androdrColors"
-```
+The migration of `SeverityChip.kt` is intentionally entangled with its callers. Skip commit; the next task makes the compile pass.
 
 ---
 
-## Task 12: Migrate `FindingCard.kt` to ExtendedColors
+## Task 12: Update `AppScanScreen.kt` callers of `severityColor`
+
+**Files:**
+- Modify: `app/src/main/java/com/androdr/ui/apps/AppScanScreen.kt`
+
+The file has six calls to `severityColor(level)` (lines 170, 247, 325, 428, plus the wrapper `fun riskLevelColor(level: String): Color = severityColor(level)` at line 446). All four call sites in `@Composable` scope need `colors` passed in; the non-Composable `riskLevelColor` wrapper needs the same parameter.
+
+- [ ] **Step 1: Add import**
+
+Add to imports (alphabetical, in the existing `com.androdr.…` cluster):
+
+```kotlin
+import androidx.compose.material3.MaterialTheme
+import com.androdr.ui.theme.ExtendedColors
+import com.androdr.ui.theme.androdrColors
+```
+
+(`MaterialTheme` may already be imported — skip if so.)
+
+- [ ] **Step 2: Update each Composable-scope call**
+
+Each of the four `@Composable`-scope sites (around lines 170, 247, 325, 428) currently reads:
+
+```kotlin
+val color = severityColor(group.highestLevel)
+// or
+tint = severityColor(finding.level)
+// or
+val color = severityColor(level)
+```
+
+Replace each with the local-palette pattern. Pick a stable anchor for each site — at the top of the enclosing Composable, add:
+
+```kotlin
+val colors = MaterialTheme.androdrColors
+```
+
+Then change every `severityColor(X)` in that Composable to `severityColor(X, colors)`.
+
+- [ ] **Step 3: Update the `riskLevelColor` wrapper**
+
+The wrapper at line 446 (`fun riskLevelColor(level: String): Color = severityColor(level)`) needs the same parameter:
+
+```kotlin
+fun riskLevelColor(level: String, colors: ExtendedColors): Color = severityColor(level, colors)
+```
+
+Then update every caller of `riskLevelColor(...)` in the project (grep first):
+
+```bash
+grep -rn "riskLevelColor(" app/src/main/java --include="*.kt"
+```
+
+For each Composable-scope caller, pass `MaterialTheme.androdrColors`. If a non-Composable caller exists, it must already have access to an `ExtendedColors` instance (or be refactored to receive one). **Verify the grep output before proceeding** — if any caller cannot easily get an `ExtendedColors`, flag it and request guidance; don't paper over it.
+
+- [ ] **Step 4: Verify it compiles**
+
+Run: `./gradlew :app:compileDebugKotlin`
+Expected: still failing — `HistoryScreen.kt` callers still need fixing. That's Task 17. Don't commit yet.
+
+- [ ] **Step 5: Do NOT commit yet — wait for Task 17 to close the loop**
+
+---
+
+## Task 13: Migrate `FindingCard.kt` to ExtendedColors
 
 **Files:**
 - Modify: `app/src/main/java/com/androdr/ui/common/FindingCard.kt`
 
-- [ ] **Step 1: Locate the literals**
+Two hardcoded literals in the file:
+- `Color(0xFFCF6679).copy(alpha = 0.08f)` — card background when finding is triggered.
+- `Color(0xFFCF6679)` — icon tint when finding is triggered.
 
-Open `app/src/main/java/com/androdr/ui/common/FindingCard.kt`. Expected (from initial grep): `Color(0xFFCF6679).copy(alpha = 0.08f)` at line 42 (background), `Color(0xFFCF6679)` at line 54 (icon tint). The `MaterialTheme.colorScheme.primary` branch at line 54 stays as-is.
-
-- [ ] **Step 2: Replace**
-
-Add to imports:
+- [ ] **Step 1: Add import**
 
 ```kotlin
 import com.androdr.ui.theme.androdrColors
@@ -862,180 +985,239 @@ import com.androdr.ui.theme.androdrColors
 
 (`MaterialTheme` is already imported.)
 
-Change the card background pattern (around line 42):
+- [ ] **Step 2: Replace the background**
+
+Find the line `containerColor = if (finding.triggered) Color(0xFFCF6679).copy(alpha = 0.08f)` and change to:
 
 ```kotlin
-containerColor = if (finding.triggered) MaterialTheme.androdrColors.criticalContainer
+containerColor = if (finding.triggered) MaterialTheme.androdrColors.critical.copy(alpha = 0.08f)
                  else MaterialTheme.colorScheme.surfaceContainer
 ```
 
-Change the icon tint (around line 54):
+(Preserves the 8% wash — using `.criticalContainer` here would be ~3× too dark.)
+
+- [ ] **Step 3: Replace the icon tint**
+
+Find the line `tint = if (finding.triggered) Color(0xFFCF6679) else MaterialTheme.colorScheme.primary,` and change to:
 
 ```kotlin
 tint = if (finding.triggered) MaterialTheme.androdrColors.critical
-       else MaterialTheme.colorScheme.primary
+       else MaterialTheme.colorScheme.primary,
 ```
 
-- [ ] **Step 3: Verify it compiles**
+- [ ] **Step 4: Verify it compiles**
 
 Run: `./gradlew :app:compileDebugKotlin`
-Expected: BUILD SUCCESSFUL.
-
-- [ ] **Step 4: Commit**
-
-```bash
-git add app/src/main/java/com/androdr/ui/common/FindingCard.kt
-git commit -m "refactor(ui): FindingCard uses MaterialTheme.androdrColors"
-```
+Expected: still failing on `HistoryScreen.kt` etc. Continue without committing.
 
 ---
 
-## Task 13: Migrate `EvidenceSheet.kt` to ExtendedColors
+## Task 14: Migrate `EvidenceSheet.kt` to ExtendedColors
 
 **Files:**
 - Modify: `app/src/main/java/com/androdr/ui/common/EvidenceSheet.kt`
 
-- [ ] **Step 1: Locate the literals**
+Literals in the file (from initial grep): `Color(0xFFCF6679)` at lines 108, 158 (alpha 0.06), 205 (alpha 0.2), 206, 261; `Color(0xFFFF9800)` at lines 281 (alpha 0.15), 282.
 
-Open `app/src/main/java/com/androdr/ui/common/EvidenceSheet.kt`. Expected (from initial grep): `Color(0xFFCF6679)` at lines 108, 158 (alpha 0.06), 205 (container alpha 0.2), 206 (label), 261; `Color(0xFFFF9800)` at lines 281 (container alpha 0.15), 282 (label).
-
-- [ ] **Step 2: Replace**
-
-Add to imports:
+- [ ] **Step 1: Add import**
 
 ```kotlin
 import com.androdr.ui.theme.androdrColors
 ```
 
-Apply this mapping throughout the file:
+- [ ] **Step 2: Apply the mapping**
 
-| Old expression                                  | New expression                                     |
-|-------------------------------------------------|----------------------------------------------------|
-| `Color(0xFFCF6679)`                             | `MaterialTheme.androdrColors.critical`             |
-| `Color(0xFFCF6679).copy(alpha = 0.06f)` or `0.08f` | `MaterialTheme.androdrColors.criticalContainer` (container hex already encodes the right tint) |
-| `Color(0xFFCF6679).copy(alpha = 0.2f)`          | `MaterialTheme.androdrColors.criticalContainer`    |
-| `Color(0xFFFF9800)`                             | `MaterialTheme.androdrColors.high`                 |
-| `Color(0xFFFF9800).copy(alpha = 0.15f)`         | `MaterialTheme.androdrColors.highContainer`        |
+| Old expression                                  | New expression                                                            |
+|-------------------------------------------------|---------------------------------------------------------------------------|
+| `Color(0xFFCF6679)` (opaque, foreground use)    | `MaterialTheme.androdrColors.critical`                                    |
+| `Color(0xFFCF6679).copy(alpha = 0.06f)`         | `MaterialTheme.androdrColors.critical.copy(alpha = 0.06f)`                |
+| `Color(0xFFCF6679).copy(alpha = 0.2f)` (chip bg) | `MaterialTheme.androdrColors.criticalContainer` (already ~20% calibrated) |
+| `Color(0xFFFF9800)` (opaque, foreground use)    | `MaterialTheme.androdrColors.high`                                        |
+| `Color(0xFFFF9800).copy(alpha = 0.15f)`         | `MaterialTheme.androdrColors.high.copy(alpha = 0.15f)`                    |
 
-Walk the file top-to-bottom and apply each replacement at every site.
+The rule of thumb: low-alpha washes (≤ 0.15) keep the `.copy(alpha = …)` form on the base hue (drift guard doesn't catch this); only the ~20% chip-bg use becomes `.criticalContainer` / `.highContainer`.
 
 - [ ] **Step 3: Verify it compiles**
 
 Run: `./gradlew :app:compileDebugKotlin`
-Expected: BUILD SUCCESSFUL.
-
-- [ ] **Step 4: Commit**
-
-```bash
-git add app/src/main/java/com/androdr/ui/common/EvidenceSheet.kt
-git commit -m "refactor(ui): EvidenceSheet uses MaterialTheme.androdrColors"
-```
+Expected: still failing on other files. Don't commit yet.
 
 ---
 
-## Task 14: Migrate `TimelineEventCard.kt` to ExtendedColors
+## Task 15: Migrate `TimelineEventCard.kt` to ExtendedColors
 
 **Files:**
 - Modify: `app/src/main/java/com/androdr/ui/timeline/TimelineEventCard.kt`
 
-- [ ] **Step 1: Locate the literals**
+Literals (from initial grep): line 68 (`neutralColor = 0xFF00D4AA`), line 100 (CritRed tag), lines 206-209 (severity switch), lines 373-375 (correlation pattern colors).
 
-Open `app/src/main/java/com/androdr/ui/timeline/TimelineEventCard.kt`. Expected (from initial grep): line 68 (`neutralColor = 0xFF00D4AA`), line 100 (CritRed tag), lines 206-209 (severity switch CRITICAL/HIGH/MEDIUM/LOW), lines 373-375 (correlation pattern colors).
+The severity switch and correlation switch should mirror Task 11's pattern — non-Composable helpers that take `colors: ExtendedColors` as a parameter, called with `MaterialTheme.androdrColors`.
 
-- [ ] **Step 2: Replace**
-
-Add to imports:
+- [ ] **Step 1: Add imports**
 
 ```kotlin
-import androidx.compose.runtime.Composable
+import com.androdr.ui.theme.ExtendedColors
 import com.androdr.ui.theme.androdrColors
 ```
 
-(`MaterialTheme` and `Composable` may already be imported — skip if so.)
+- [ ] **Step 2: Replace `neutralColor` at line 68**
 
-For the `neutralColor` at line 68: it's inside a Composable, so swap to a Composable-context read. If the variable is declared at top-of-Composable, change:
+Inside the enclosing Composable, change `val neutralColor = Color(0xFF00D4AA)` to:
 
 ```kotlin
 val neutralColor = MaterialTheme.androdrColors.neutral
 ```
 
-For the tag chip at line 100 (`TagChip(event.campaignName, Color(0xFFCF6679))`): pull the color first then pass it:
+- [ ] **Step 3: Replace the CritRed tag at line 100**
+
+Pull the color from the local palette near the top of the enclosing Composable:
 
 ```kotlin
-val criticalColor = MaterialTheme.androdrColors.critical
+val colors = MaterialTheme.androdrColors
 …
-if (event.campaignName.isNotEmpty()) TagChip(event.campaignName, criticalColor)
+if (event.campaignName.isNotEmpty()) TagChip(event.campaignName, colors.critical)
 ```
 
-For the severity switch around lines 206-209 — convert the function to a `@Composable` (if not already) and replace:
+- [ ] **Step 4: Refactor the severity switch (lines 205-210)**
+
+If the current code is an inline `when` or a private helper, convert to a non-Composable helper:
 
 ```kotlin
-@Composable
-private fun severityToColor(severity: String): Color {
-    val colors = MaterialTheme.androdrColors
-    return when (severity.uppercase()) {
+private fun severityTier(severity: String, colors: ExtendedColors): Color =
+    when (severity.uppercase()) {
         "CRITICAL" -> colors.critical
         "HIGH"     -> colors.high
         "MEDIUM"   -> colors.medium
         "LOW"      -> colors.low
         else       -> colors.neutral
     }
-}
 ```
 
-For correlation pattern colors at lines 373-375:
+Call site passes `severityTier(severity, MaterialTheme.androdrColors)` (or the local `colors` from Step 3).
+
+The original code uses `0xFFFF8A65` (deep orange 300) for HIGH and `0xFFFFD54F` (amber 300) for MEDIUM; both are now collapsed into the single `colors.high` / `colors.medium` fields. This is intentional — having two separate orange shades for HIGH was unintentional drift between this file and `SeverityChip`.
+
+- [ ] **Step 5: Refactor the correlation pattern switch (lines 373-375)**
 
 ```kotlin
-@Composable
-private fun correlationPatternColor(pattern: CorrelationPattern): Color {
-    val colors = MaterialTheme.androdrColors
-    return when (pattern) {
-        CorrelationPattern.INSTALL_THEN_ADMIN       -> colors.critical
-        CorrelationPattern.MULTI_PERMISSION_BURST   -> colors.high
-        else                                        -> colors.neutral
+private fun correlationPatternColor(pattern: CorrelationPattern, colors: ExtendedColors): Color =
+    when (pattern) {
+        CorrelationPattern.INSTALL_THEN_ADMIN     -> colors.critical
+        CorrelationPattern.MULTI_PERMISSION_BURST -> colors.high
+        else                                      -> colors.neutral
     }
-}
 ```
 
-For the one-off `Color(0xFFFF8A65)` at line 207 (deep orange 300): replaced by `colors.high` in the severity switch above.
+Update the call site to pass `MaterialTheme.androdrColors`.
 
-- [ ] **Step 3: Verify it compiles**
+- [ ] **Step 6: Verify it compiles**
 
 Run: `./gradlew :app:compileDebugKotlin`
-Expected: BUILD SUCCESSFUL. If you converted a non-Composable function to `@Composable`, any caller that wasn't already inside a Composable scope must be moved into one. The whole timeline UI is Composable-only, so this should hold.
-
-- [ ] **Step 4: Commit**
-
-```bash
-git add app/src/main/java/com/androdr/ui/timeline/TimelineEventCard.kt
-git commit -m "refactor(ui): TimelineEventCard uses MaterialTheme.androdrColors"
-```
+Expected: still failing on remaining files. Don't commit yet.
 
 ---
 
-## Task 15: Migrate `DnsMonitorScreen.kt` to ExtendedColors
+## Task 16: Migrate `DnsMonitorScreen.kt` to ExtendedColors
 
 **Files:**
 - Modify: `app/src/main/java/com/androdr/ui/network/DnsMonitorScreen.kt`
 
-- [ ] **Step 1: Locate the literals**
+Literals at lines 258 (alpha 0.08), 273 (label), 302 (alpha 0.2), 305 (label).
 
-Open `app/src/main/java/com/androdr/ui/network/DnsMonitorScreen.kt`. Expected (from initial grep): lines 258 (container alpha 0.08), 273 (label), 302 (container alpha 0.2), 305 (label).
-
-- [ ] **Step 2: Replace**
-
-Add to imports:
+- [ ] **Step 1: Add import**
 
 ```kotlin
 import com.androdr.ui.theme.androdrColors
 ```
 
-Apply:
+- [ ] **Step 2: Apply the mapping**
 
-| Old expression                                  | New expression                                  |
-|-------------------------------------------------|-------------------------------------------------|
-| `Color(0xFFCF6679)`                             | `MaterialTheme.androdrColors.critical`          |
-| `Color(0xFFCF6679).copy(alpha = 0.08f)` / `0.2f` | `MaterialTheme.androdrColors.criticalContainer` |
+| Old expression                                  | New expression                                              |
+|-------------------------------------------------|-------------------------------------------------------------|
+| `Color(0xFFCF6679)`                             | `MaterialTheme.androdrColors.critical`                      |
+| `Color(0xFFCF6679).copy(alpha = 0.08f)`         | `MaterialTheme.androdrColors.critical.copy(alpha = 0.08f)`  |
+| `Color(0xFFCF6679).copy(alpha = 0.2f)` (chip bg) | `MaterialTheme.androdrColors.criticalContainer`             |
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `./gradlew :app:compileDebugKotlin`
+Expected: still failing on remaining files. Don't commit yet.
+
+---
+
+## Task 17: Migrate `HistoryScreen.kt` — both severityColor callers AND hardcoded literals
+
+**Files:**
+- Modify: `app/src/main/java/com/androdr/ui/history/HistoryScreen.kt`
+
+The file has two `severityColor(...)` calls (lines 252, 399) that now need `colors` passed AND two hardcoded `Color(0xFFCF6679)` literals (lines 561, 567).
+
+- [ ] **Step 1: Add import**
+
+```kotlin
+import com.androdr.ui.theme.androdrColors
+```
+
+(`MaterialTheme` may already be imported — skip if so.)
+
+- [ ] **Step 2: Update `severityColor` call sites**
+
+At each of the two `severityColor(...)` sites (lines 252 and 399), add a local palette pull at the top of the enclosing Composable:
+
+```kotlin
+val colors = MaterialTheme.androdrColors
+```
+
+Then change `severityColor(scan.overallRiskLevel.name)` → `severityColor(scan.overallRiskLevel.name, colors)`, and similarly for `severityColor(riskLevel.name)`.
+
+- [ ] **Step 3: Replace hardcoded literals**
+
+At lines 561 and 567, replace `Color(0xFFCF6679)` with `MaterialTheme.androdrColors.critical`.
+
+- [ ] **Step 4: Verify it compiles**
+
+Run: `./gradlew :app:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL if `AppScanScreen` (Task 12), `SeverityChip` (Task 11), and the migration tasks so far are all coherent. If still failing, the error message identifies the remaining caller — fix it before proceeding.
+
+- [ ] **Step 5: Commit Tasks 11-17 together**
+
+Tasks 11-17 form one coherent compile-passing unit. Commit them all now:
+
+```bash
+git add app/src/main/java/com/androdr/ui/common/SeverityChip.kt \
+        app/src/main/java/com/androdr/ui/apps/AppScanScreen.kt \
+        app/src/main/java/com/androdr/ui/common/FindingCard.kt \
+        app/src/main/java/com/androdr/ui/common/EvidenceSheet.kt \
+        app/src/main/java/com/androdr/ui/timeline/TimelineEventCard.kt \
+        app/src/main/java/com/androdr/ui/network/DnsMonitorScreen.kt \
+        app/src/main/java/com/androdr/ui/history/HistoryScreen.kt
+git commit -m "refactor(ui): migrate severity-coded UI to MaterialTheme.androdrColors
+
+severityColor(level) gains a colors: ExtendedColors parameter so it stays
+non-Composable and callers (Composable and otherwise) pass MaterialTheme
+.androdrColors. SeverityChip, FindingCard, EvidenceSheet, TimelineEventCard,
+DnsMonitorScreen, HistoryScreen, and AppScanScreen migrated to the new
+palette layer in one coherent compile unit."
+```
+
+---
+
+## Task 18: Migrate `DeviceAuditScreen.kt` to ExtendedColors
+
+**Files:**
+- Modify: `app/src/main/java/com/androdr/ui/device/DeviceAuditScreen.kt`
+
+Two hardcoded literals: `Color(0xFFCF6679)` at lines 88 and 126.
+
+- [ ] **Step 1: Add import**
+
+```kotlin
+import com.androdr.ui.theme.androdrColors
+```
+
+- [ ] **Step 2: Replace both literals**
+
+At lines 88 and 126, replace `Color(0xFFCF6679)` with `MaterialTheme.androdrColors.critical`.
 
 - [ ] **Step 3: Verify it compiles**
 
@@ -1045,16 +1227,161 @@ Expected: BUILD SUCCESSFUL.
 - [ ] **Step 4: Commit**
 
 ```bash
-git add app/src/main/java/com/androdr/ui/network/DnsMonitorScreen.kt
-git commit -m "refactor(ui): DnsMonitorScreen uses MaterialTheme.androdrColors"
+git add app/src/main/java/com/androdr/ui/device/DeviceAuditScreen.kt
+git commit -m "refactor(ui): DeviceAuditScreen uses MaterialTheme.androdrColors"
 ```
 
 ---
 
-## Task 16: Add the hardcoded-color drift guard test
+## Task 19: Migrate `BugReportScreen.kt` to ExtendedColors
+
+**Files:**
+- Modify: `app/src/main/java/com/androdr/ui/bugreport/BugReportScreen.kt`
+
+The file's severity switch at lines 491-495 maps levels to (icon, color) pairs:
+
+```kotlin
+"CRITICAL" -> Pair(Icons.Filled.Error, Color(0xFFCF6679))
+"HIGH"     -> Pair(Icons.Filled.Warning, Color(0xFFFF9800))
+"MEDIUM"   -> Pair(Icons.Filled.Warning, Color(0xFFE6A800))
+"ERROR"    -> Pair(Icons.Filled.Error, Color(0xFFCF6679))
+else       -> Pair(Icons.Filled.Info, Color(0xFF00D4AA))
+```
+
+- [ ] **Step 1: Add import**
+
+```kotlin
+import com.androdr.ui.theme.androdrColors
+```
+
+- [ ] **Step 2: Replace the switch**
+
+If the switch is inside a `@Composable`, pull the palette at the top:
+
+```kotlin
+val colors = MaterialTheme.androdrColors
+```
+
+Then replace the literals:
+
+```kotlin
+"CRITICAL" -> Pair(Icons.Filled.Error, colors.critical)
+"HIGH"     -> Pair(Icons.Filled.Warning, colors.high)
+"MEDIUM"   -> Pair(Icons.Filled.Warning, colors.medium)
+"ERROR"    -> Pair(Icons.Filled.Error, colors.critical)
+else       -> Pair(Icons.Filled.Info, colors.neutral)
+```
+
+If the switch lives in a non-Composable helper, convert it to take `colors: ExtendedColors` as the second parameter (same idiom as `severityColor`), and pass `MaterialTheme.androdrColors` from each call site.
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `./gradlew :app:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/src/main/java/com/androdr/ui/bugreport/BugReportScreen.kt
+git commit -m "refactor(ui): BugReportScreen uses MaterialTheme.androdrColors"
+```
+
+---
+
+## Task 20: Migrate `DashboardScreen.kt` to ExtendedColors
+
+**Files:**
+- Modify: `app/src/main/java/com/androdr/ui/dashboard/DashboardScreen.kt`
+
+The largest single migration — 15 literals across several semantic groups:
+- Lines 300-315: a severity switch (`critical/high/medium/default neutral`) using the *same* base hues as `SeverityChip`.
+- Lines 346-350: a *risk-level* switch using **different**, bolder hues:
+  - `0xFFFF1744` (bold red) for CRITICAL — "unmistakable danger"
+  - `0xFFFF6E40` (deep orange) for HIGH
+  - `0xFFFFD54F` (amber 300) for MEDIUM
+  - `0xFF00D4AA` (brand teal) for LOW
+- Lines 411, 422, 428: a single warning card — orange container + tint + label.
+- Lines 567, 578, 585: a second warning card — same orange triad.
+
+The two "risk-level" hues at 346-348 (`0xFFFF1744`, `0xFFFF6E40`, `0xFFFFD54F`) are visibly louder than the base severity hues. Two paths:
+
+**(a) Collapse both groups into the single `androdrColors.*` palette** (recommended). The "bolder" risk hues become regular `colors.critical`/`colors.high`/`colors.medium`. The Dashboard then renders consistently with every other surface. Lose the loud-red attention-grab; gain consistency. **This is the recommended choice** because the inconsistency was unintentional drift, not a designed call-out.
+
+**(b) Add a "loud" tier to `ExtendedColors`** (NOT recommended). Adds three new fields used by exactly one file. Maintenance overhead with no clear win.
+
+The plan proceeds with (a). If the dashboard's risk header *needs* a louder presentation for UX reasons, that's a follow-up design decision, not a migration concern.
+
+- [ ] **Step 1: Add import**
+
+```kotlin
+import com.androdr.ui.theme.androdrColors
+```
+
+- [ ] **Step 2: Migrate lines 300-315 (severity switch)**
+
+At the top of the enclosing Composable:
+
+```kotlin
+val colors = MaterialTheme.androdrColors
+```
+
+Replace each line in the switch:
+
+| Old                  | New              |
+|----------------------|------------------|
+| `Color(0xFFCF6679)`  | `colors.critical`|
+| `Color(0xFFFF9800)`  | `colors.high`    |
+| `Color(0xFFE6A800)`  | `colors.medium`  |
+| `Color(0xFF00D4AA)`  | `colors.neutral` |
+
+- [ ] **Step 3: Migrate lines 346-350 (risk-level switch)**
+
+Inside the enclosing Composable (palette already pulled in Step 2), replace each:
+
+| Old                                | New                              |
+|------------------------------------|----------------------------------|
+| `Color(0xFFFF1744)` (CRITICAL)     | `colors.critical`                |
+| `Color(0xFFFF6E40)` (HIGH)         | `colors.high`                    |
+| `Color(0xFFFFD54F)` (MEDIUM)       | `colors.medium`                  |
+| `Color(0xFF00D4AA)` (LOW)          | `colors.low`                     |
+| `Color(0xFF00D4AA)` (null branch)  | `colors.neutral`                 |
+
+Note the LOW branch was using the brand teal (`0xFF00D4AA`) in the original — now it correctly uses `colors.low` (blue). The null branch keeps the neutral teal. This is the same deliberate "LOW gets its own color" fix from Task 11.
+
+- [ ] **Step 4: Migrate the warning cards (lines 411-428 and 567-585)**
+
+Each card has three orange uses: container background (`0xFFFF9800).copy(alpha = 0.15f)`), icon tint, label color. Replace:
+
+| Old                                       | New                                                  |
+|-------------------------------------------|------------------------------------------------------|
+| `Color(0xFFFF9800).copy(alpha = 0.15f)`   | `colors.high.copy(alpha = 0.15f)` (keep wash form)   |
+| `Color(0xFFFF9800)`                       | `colors.high`                                        |
+
+- [ ] **Step 5: Verify it compiles**
+
+Run: `./gradlew :app:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/src/main/java/com/androdr/ui/dashboard/DashboardScreen.kt
+git commit -m "refactor(ui): DashboardScreen uses MaterialTheme.androdrColors
+
+Collapses the previously-divergent loud-risk hues (0xFFFF1744 etc.) into
+the standard severity palette; gains consistency, gives up the bespoke
+loud-red attention grab. If a louder risk-header presentation is wanted
+later, raise it as a UX decision (follow-up), not a palette regression."
+```
+
+---
+
+## Task 21: Add the hardcoded-color drift guard test
 
 **Files:**
 - Test: `app/src/test/java/com/androdr/ui/theme/HardcodedColorGuardTest.kt`
+
+This test runs LAST in the migration sequence so that when it first runs, all nine migration files (Tasks 11-20) are already done. Adding it before then would produce a noisy failure list of work-in-progress.
 
 - [ ] **Step 1: Write the test**
 
@@ -1069,8 +1396,11 @@ import java.io.File
 
 /**
  * Guards against re-introducing hardcoded Color(0xFF…) literals in UI code.
- * The only allowed locations for raw color values are inside ui/theme/.
+ * The only allowed location for raw color values is inside ui/theme/.
  * If you need a new semantic color, add it to ExtendedColors instead.
+ *
+ * Sub-percent washes — e.g. critical.copy(alpha = 0.08f) — are intentionally
+ * allowed and not matched by this regex.
  *
  * Suppress per-line with: // hardcoded-color-ok: <reason>
  */
@@ -1088,7 +1418,7 @@ class HardcodedColorGuardTest {
             .flatMap { file ->
                 file.readLines().mapIndexedNotNull { idx, line ->
                     if (pattern.containsMatchIn(line) && !line.contains(allowMarker)) {
-                        "${file.relativeTo(sourceRoot)}:${idx + 1}  $line"
+                        "${file.relativeTo(sourceRoot)}:${idx + 1}  ${line.trim()}"
                     } else null
                 }
             }
@@ -1104,13 +1434,18 @@ class HardcodedColorGuardTest {
     }
 
     private fun findSourceRoot(): File {
-        // Tests can run from either the repo root or the app module dir. Try both.
+        // Gradle JVM tests run with cwd = module dir (app/). IDE run configs sometimes
+        // use the repo root. Cover both.
         val candidates = listOf(
             File("src/main/java/com/androdr"),
-            File("app/src/main/java/com/androdr")
+            File("app/src/main/java/com/androdr"),
+            File("../app/src/main/java/com/androdr")
         )
         return candidates.firstOrNull { it.exists() }
-            ?: error("Could not locate source root from ${File(".").absolutePath}")
+            ?: error(
+                "Could not locate source root from ${File(".").absolutePath}. " +
+                    "Tried: ${candidates.map { it.path }}"
+            )
     }
 }
 ```
@@ -1118,7 +1453,7 @@ class HardcodedColorGuardTest {
 - [ ] **Step 2: Run the test**
 
 Run: `./gradlew :app:testDebugUnitTest --tests "com.androdr.ui.theme.HardcodedColorGuardTest"`
-Expected: PASS. If it FAILS, the failure message lists every remaining `Color(0xFF…)` literal — either migrate the listed sites to `ExtendedColors`, or add a `// hardcoded-color-ok: <reason>` marker on lines that genuinely belong outside the theme (uncommon — most likely the case is "I forgot to migrate one file").
+Expected: PASS. If it FAILS, the message lists every remaining `Color(0xFF…)` literal — go migrate it (or add `// hardcoded-color-ok: <reason>` if it genuinely belongs outside the theme; this should be rare).
 
 - [ ] **Step 3: Commit**
 
@@ -1129,37 +1464,38 @@ git commit -m "test(theme): guard against hardcoded Color(0xFF…) literals outs
 
 ---
 
-## Task 17: Add Compose previews for migrated severity-coded UI
+## Task 22: SeverityChip dark/light preview + final verification
 
 **Files:**
 - Modify: `app/src/main/java/com/androdr/ui/common/SeverityChip.kt`
-- Modify: `app/src/main/java/com/androdr/ui/common/FindingCard.kt`
-- Modify: `app/src/main/java/com/androdr/ui/common/EvidenceSheet.kt`
-- Modify: `app/src/main/java/com/androdr/ui/timeline/TimelineEventCard.kt`
 
-- [ ] **Step 1: Add a preview helper at the bottom of `SeverityChip.kt`**
+A single preview composable for `SeverityChip` proves the new palette renders correctly in both themes. Previews for `FindingCard` / `EvidenceSheet` / `TimelineEventCard` / dashboard cards are intentionally deferred — they require nontrivial fixture builders that aren't worth the scope inflation here. Track them as a UX-polish follow-up if desired; visual review of the running app on emulator (Step 4) covers them for now.
 
-Append to `app/src/main/java/com/androdr/ui/common/SeverityChip.kt`:
+- [ ] **Step 1: Append the preview to `SeverityChip.kt`**
+
+Add to `app/src/main/java/com/androdr/ui/common/SeverityChip.kt`:
 
 ```kotlin
-@androidx.compose.ui.tooling.preview.Preview(
-    name = "Severity chips — Dark",
-    uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES
-)
-@androidx.compose.ui.tooling.preview.Preview(
-    name = "Severity chips — Light",
-    uiMode = android.content.res.Configuration.UI_MODE_NIGHT_NO
-)
+import android.content.res.Configuration
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Surface
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.androdr.ui.theme.AndroDRTheme
+import com.androdr.ui.theme.ThemeMode
+
+@Preview(name = "Severity chips — Dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Preview(name = "Severity chips — Light", uiMode = Configuration.UI_MODE_NIGHT_NO)
 @Composable
 private fun SeverityChipPreview() {
-    com.androdr.ui.theme.AndroDRTheme(themeMode = com.androdr.ui.theme.ThemeMode.AUTO) {
-        androidx.compose.foundation.layout.Surface(
-            color = MaterialTheme.colorScheme.background
-        ) {
-            androidx.compose.foundation.layout.Row(
-                modifier = androidx.compose.ui.Modifier
-                    .padding(androidx.compose.ui.unit.dp.let { 16.dp }),
-                horizontalArrangement = androidx.compose.foundation.layout.Arrangement.spacedBy(8.dp)
+    AndroDRTheme(themeMode = ThemeMode.AUTO) {
+        Surface(color = MaterialTheme.colorScheme.background) {
+            Row(
+                modifier = Modifier.padding(16.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
             ) {
                 listOf("critical", "high", "medium", "low").forEach { level ->
                     SeverityChip(level = level)
@@ -1170,90 +1506,68 @@ private fun SeverityChipPreview() {
 }
 ```
 
-(Adjust the `SeverityChip(...)` call to match the file's actual public API — if it takes more parameters, supply sensible defaults. The point is one composable preview per severity, in both themes.)
-
-- [ ] **Step 2: Do the same for `FindingCard.kt`, `EvidenceSheet.kt`, `TimelineEventCard.kt`**
-
-For each file: add two `@Preview` annotations (Dark/Light) wrapping the public composable with mock data. The previews exist for the implementer and for visual review during PR — not for asserting in CI.
-
-If supplying mock data for `FindingCard` / `EvidenceSheet` / `TimelineEventCard` is more work than the value of the preview, **skip that specific preview** with a `// TODO(post-merge): add preview once Finding/Event factories are extracted` and mention it in the PR description. Don't block this task on building large fixture builders.
-
-- [ ] **Step 3: Verify Android Studio renders the previews**
+- [ ] **Step 2: Verify it compiles and renders**
 
 Run: `./gradlew :app:compileDebugKotlin`
-Expected: BUILD SUCCESSFUL. Open the migrated files in Android Studio and confirm the previews render in both Dark and Light modes without contrast issues.
+Expected: BUILD SUCCESSFUL. Open the file in Android Studio and confirm both preview panels render four severity chips with visibly distinct colors.
 
-- [ ] **Step 4: Commit**
-
-```bash
-git add app/src/main/java/com/androdr/ui/common/SeverityChip.kt \
-        app/src/main/java/com/androdr/ui/common/FindingCard.kt \
-        app/src/main/java/com/androdr/ui/common/EvidenceSheet.kt \
-        app/src/main/java/com/androdr/ui/timeline/TimelineEventCard.kt
-git commit -m "test(ui): add light+dark previews for migrated severity-coded composables"
-```
-
----
-
-## Task 18: Final verification — full test suite, lint, smoke
-
-**Files:** none modified.
-
-- [ ] **Step 1: Run the full unit test suite**
+- [ ] **Step 3: Run the full unit test suite**
 
 Run: `./gradlew :app:testDebugUnitTest`
-Expected: ALL TESTS PASS. If a pre-existing test breaks, investigate — but unrelated breakage is not part of this plan's scope. Theme-related failures should not occur if previous tasks passed.
+Expected: ALL TESTS PASS. Any pre-existing test failure unrelated to theme work is out of scope — flag in the PR description.
 
-- [ ] **Step 2: Run lint**
+- [ ] **Step 4: Build release + lint**
 
-Run: `./gradlew lintDebug`
-Expected: No NEW errors introduced. Warnings about `android:forceDarkAllowed` requiring API 29 should be suppressed by the `tools:targetApi` attribute added in Task 10. If a true error remains, fix at the source.
+Run: `./gradlew assembleRelease && ./gradlew lintDebug`
+Expected: BUILD SUCCESSFUL for both. R8 may strip the preview composable — that's fine (dev-only).
 
-- [ ] **Step 3: Build the release APK to confirm shrinker/proguard don't break**
+- [ ] **Step 5: Emulator smoke test**
 
-Run: `./gradlew assembleRelease`
-Expected: BUILD SUCCESSFUL. If R8 strips a Composable preview unexpectedly, that's fine — previews are dev-only. If R8 strips something real, add the necessary keep rule.
-
-- [ ] **Step 4: Smoke test on emulator**
-
-Run the existing script:
+Run the existing harness:
 ```bash
 ./scripts/smoke-test.sh
 ```
 Expected: APK installs, app launches, logcat is crash-free. Then manually:
-1. Open Settings on the emulator's system, toggle dark mode off → confirm AndroDR follows to light mode within seconds.
+1. Open the emulator's system Settings, toggle Dark mode off → confirm AndroDR follows to light within seconds.
 2. In AndroDR Settings → Appearance, switch to "Dark" → confirm app forces dark regardless of system.
 3. Switch to "Light" → confirm app forces light.
-4. Switch to "System" → confirm app re-follows the system setting.
-5. Open Dashboard, Apps, Network, Timeline screens in both modes — visually confirm severity chips and finding cards are legible.
+4. Switch to "System" → confirm app re-follows system.
+5. Visit Dashboard, Apps, Network, Timeline, History, Device, Bug Report screens in both modes — confirm severity chips, finding cards, evidence sheets, risk swatches, and warning cards are all legible.
 
-- [ ] **Step 5: Manual smoke on Honor device (if available)**
+- [ ] **Step 6: Honor device re-test (if available)**
 
-If the tester's Honor device is available, re-test the exact screen where text was reported invisible. Confirm legibility in both system-light and system-dark modes. Capture screenshots for the PR description.
+If the tester's Honor device is reachable, re-test the exact screen where text was reported invisible. Confirm legibility in both system-light and system-dark. Capture screenshots for the PR description.
 
 If no Honor device is available: explicitly note "Honor re-test pending — relies on tester verification post-merge" in the PR description. Do not claim the bug fixed without device confirmation.
 
-- [ ] **Step 6: No commit (verification only)**
+- [ ] **Step 7: Commit preview + close**
 
-This task produces no commits. Output goes into the PR description.
+```bash
+git add app/src/main/java/com/androdr/ui/common/SeverityChip.kt
+git commit -m "test(ui): add light+dark preview for SeverityChip"
+```
+
+This task produces no further commits; verification output goes into the PR description.
 
 ---
 
 ## Self-Review Notes
 
-Run through the plan once more before handoff:
+Plan has been through one full revision cycle after a two-reviewer plan-gate review. Verified post-revision:
 
-- **Spec coverage:** every spec section maps to at least one task — ThemeMode (T1), persistence (T2), ExtendedColors (T3), contrast test (T4), light scheme (T5), AndroDRTheme refactor (T6), Settings VM+UI (T7-T8), MainActivity wiring + system bars (T9), manifest hardening (T10), the 5 migration files (T11-T15), drift guard (T16), previews (T17), full verification (T18). Out-of-scope items (dynamic color, androdr-015 FP) remain out.
-- **Type consistency:** `ThemeMode` (enum), `resolveDarkTheme(themeMode, systemInDark): Boolean`, `ExtendedColors` (data class), `LocalAndroDRColors`, `MaterialTheme.androdrColors`, `settingsRepository.themeMode` / `setThemeMode(mode)`, `KEY_THEME_MODE` — all referenced consistently across tasks.
-- **No placeholders:** every step has either runnable code, an exact command, or a discrete edit instruction with the actual code shown.
-- **Out-of-order safety:** each task's "Files" / "Step 1" lists what it touches, so a worker resuming from any task has the context needed without reading earlier tasks.
+- **Spec coverage:** every spec section maps to at least one task. Migration covers all 9 files containing hardcoded `Color(0xFF…)` literals (verified by `grep -rn "Color(0x" app/src/main/java --include="*.kt" | grep -v "ui/theme/" | awk -F: '{print $1}' | sort -u`).
+- **`severityColor` cascade:** broken by keeping the function non-Composable and threading `ExtendedColors` through callers; Tasks 11-12-17 form one coherent compile-passing unit, committed together.
+- **Drift guard:** placed at Task 21 (after all migrations) so it passes the first time it runs; the regex only matches raw `Color(0xFF…)` literals so `.copy(alpha = …)` patterns are intentionally allowed.
+- **Type consistency:** `ThemeMode` (enum), `resolveDarkTheme(themeMode, systemInDark): Boolean`, `ExtendedColors` (data class), `LocalAndroDRColors`, `MaterialTheme.androdrColors`, `severityColor(level, colors)`, `riskLevelColor(level, colors)`, `settingsRepository.themeMode` / `setThemeMode(mode)`, `KEY_THEME_MODE` — all referenced consistently across tasks.
+- **No fragile anchors:** "around line N" replaced with stable code anchors ("immediately after the closing brace of X", "before declaration Y").
+- **Out of scope (still):** Material You dynamic color; `androdr-015` FP on Honor (separate track).
 
 ---
 
 **Plan complete and saved to `docs/superpowers/plans/2026-05-18-light-dark-theme.md`. Two execution options:**
 
-**1. Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration.
+**1. Subagent-Driven (recommended)** — fresh subagent per task, review between tasks. Tasks 11-17 should be dispatched as a single bundle (they don't compile independently); Tasks 18-20 can be parallel; Task 21 sequenced last.
 
-**2. Inline Execution** — Execute tasks in this session using executing-plans, batch execution with checkpoints.
+**2. Inline Execution** — execute tasks in this session using `superpowers:executing-plans`, batched with checkpoints.
 
 **Which approach?**

--- a/docs/superpowers/specs/2026-05-18-light-dark-theme-design.md
+++ b/docs/superpowers/specs/2026-05-18-light-dark-theme-design.md
@@ -1,0 +1,320 @@
+# Spec: Light/Dark theme with OS-following + semantic-color migration
+
+**Issue:** TBD (file before plan execution; covers the tester-reported invisible-text bug on Honor MagicOS).
+**Scope of this spec:** Introduce a light color scheme, an OS-following theme mode with user override (Auto / Light / Dark), a semantic-color layer for severity hues, and migrate all 55 hardcoded `Color(0xFF…)` literals outside `ui/theme/` to the new layer.
+**Out of scope:** Material You dynamic color (wallpaper-derived palette); the `androdr-015` false-positive bug on Honor (separate track).
+**Date:** 2026-05-18
+
+---
+
+## Why
+
+A tester running AndroDR on an Honor device reported text being invisible across multiple screens. Root-cause analysis points at two compounding factors:
+
+1. `ui/theme/Theme.kt` hardcodes a single dark color scheme. The app never reads `isSystemInDarkTheme()`, never exposes a user choice, and there is no light palette to fall back on.
+2. Honor MagicOS (Huawei's Android skin) aggressively applies system-wide "force light" / contrast overrides on apps that declare a dark theme. The result is a half-washed UI where the app's dark text-on-dark assumption collides with the OS's forced light background, producing the invisible-text symptom.
+
+The fix on its own — a working light scheme that the app switches to when the OS is in light mode — neutralizes the conflict. The accompanying semantic-color migration is the other half: 55 sites across the UI (severity chips, finding cards, evidence sheets, timeline events, DNS monitor) carry hardcoded colors tuned for a dark background. Without migration, severity chips remain illegible in light mode and the "fix" only half-works.
+
+This is a UX-blocking bug for any tester whose device is in light mode or whose OEM forces it, not a polish item.
+
+## Non-goals
+
+- **No Material You dynamic color.** Adds palette plumbing, dilutes the security/EDR brand identity on Android 12+ devices, and is not necessary to fix the reported bug. Revisit later if there is demand.
+- **No new theme variants beyond the two presets.** Just Dark and Light. No high-contrast, no AMOLED, no per-screen overrides.
+- **No fix for `androdr-015` ("Unrecognized System App") FP on Honor.** Same tester, different problem — `is_system_app && !is_known_oem_app` fires on Honor's MagicOS preloads because the known-good OEM database does not cover Honor. That gets its own spec.
+- **No design-system overhaul.** The existing teal/security identity stays. The light variant is a derivative of the same brand colors at darker shades for AA contrast on white.
+
+## Theme architecture
+
+### `ThemeMode` enum
+
+New file `app/src/main/java/com/androdr/ui/theme/ThemeMode.kt`:
+
+```kotlin
+enum class ThemeMode { AUTO, LIGHT, DARK }
+```
+
+Persisted in `SettingsRepository` as a string preference (`KEY_THEME_MODE`), default `AUTO`. AUTO means "follow `isSystemInDarkTheme()`".
+
+### `SettingsRepository` additions
+
+New flow + setter in `data/repo/SettingsRepository.kt`:
+
+```kotlin
+val themeMode: Flow<ThemeMode> = dataStore.data
+    .map { prefs ->
+        when (prefs[KEY_THEME_MODE]) {
+            "LIGHT" -> ThemeMode.LIGHT
+            "DARK"  -> ThemeMode.DARK
+            else    -> ThemeMode.AUTO
+        }
+    }
+
+suspend fun setThemeMode(mode: ThemeMode) {
+    dataStore.edit { it[KEY_THEME_MODE] = mode.name }
+}
+```
+
+Key constant: `private val KEY_THEME_MODE = stringPreferencesKey("theme_mode")`.
+
+### `AndroDRTheme` Composable
+
+Refactor `ui/theme/Theme.kt` so `AndroDRTheme` accepts a `themeMode: ThemeMode` (default AUTO for previews), resolves to `useDarkTheme: Boolean` via:
+
+```kotlin
+val useDarkTheme = when (themeMode) {
+    ThemeMode.LIGHT -> false
+    ThemeMode.DARK  -> true
+    ThemeMode.AUTO  -> isSystemInDarkTheme()
+}
+val colorScheme = if (useDarkTheme) DarkColorScheme else LightColorScheme
+val extended    = if (useDarkTheme) DarkExtendedColors else LightExtendedColors
+
+CompositionLocalProvider(LocalAndroDRColors provides extended) {
+    MaterialTheme(colorScheme = colorScheme, content = content)
+}
+```
+
+### `ExtendedColors` data class + CompositionLocal
+
+New file `ui/theme/ExtendedColors.kt`:
+
+```kotlin
+data class ExtendedColors(
+    val critical: Color,
+    val high: Color,
+    val medium: Color,
+    val low: Color,
+    val neutral: Color,
+    val criticalContainer: Color,   // 8-20% alpha-ish backgrounds for chips/cards
+    val highContainer: Color,
+    val mediumContainer: Color,
+    val lowContainer: Color,
+)
+
+val LocalAndroDRColors = staticCompositionLocalOf<ExtendedColors> {
+    error("AndroDRTheme must wrap the call site")
+}
+
+val MaterialTheme.androdrColors: ExtendedColors
+    @Composable
+    @ReadOnlyComposable
+    get() = LocalAndroDRColors.current
+```
+
+Two const instances, one for each scheme. The light variants are darker, deeper shades of the existing severity hues so AA contrast holds against `0xFFFAFAFA`.
+
+## Palettes
+
+### Dark scheme
+
+Unchanged. The existing `DarkColorScheme` in `Theme.kt` stays verbatim — no regressions for current users.
+
+### Light scheme
+
+New `lightColorScheme(…)` next to `DarkColorScheme`:
+
+```kotlin
+private val LightColorScheme = lightColorScheme(
+    primary             = TealPrimaryVariant,         // 0xFF00A882, darker teal, AA on white
+    onPrimary           = Color.White,
+    primaryContainer    = Color(0xFFB2FFF0),
+    onPrimaryContainer  = Color(0xFF003328),
+    secondary           = Color(0xFF006B62),
+    onSecondary         = Color.White,
+    secondaryContainer  = Color(0xFF70F2E6),
+    onSecondaryContainer= Color(0xFF00201D),
+    tertiary            = Color(0xFF00658E),
+    onTertiary          = Color.White,
+    tertiaryContainer   = Color(0xFFC5E7FF),
+    onTertiaryContainer = Color(0xFF001E2E),
+    error               = Color(0xFFB3261E),          // Material light error
+    onError             = Color.White,
+    errorContainer      = Color(0xFFFFDAD6),
+    onErrorContainer    = Color(0xFF410002),
+    background          = Color(0xFFFAFAFA),
+    onBackground        = Color(0xFF1A1A1A),
+    surface             = Color.White,
+    onSurface           = Color(0xFF1A1A1A),
+    surfaceVariant      = Color(0xFFEEEEEE),
+    onSurfaceVariant    = Color(0xFF4A4A4A),
+    outline             = Color(0xFF747878),
+    outlineVariant      = Color(0xFFC4C7C7),
+    surfaceContainer    = Color(0xFFF1F1F1),
+    surfaceContainerHigh= Color(0xFFEAEAEA),
+    surfaceContainerLow = Color(0xFFF6F6F6),
+)
+```
+
+Exact values may be tuned during implementation against the contrast-ratio test (see Testing). The contract is "AA pass for every fg/bg pair Compose can produce from this scheme".
+
+### `ExtendedColors` instances
+
+```kotlin
+val DarkExtendedColors = ExtendedColors(
+    critical          = Color(0xFFCF6679),   // existing dark severity hues, preserved
+    high              = Color(0xFFFF9800),
+    medium            = Color(0xFFE6A800),
+    low               = Color(0xFF64B5F6),
+    neutral           = TealPrimary,
+    criticalContainer = Color(0xFFCF6679).copy(alpha = 0.20f),
+    highContainer     = Color(0xFFFF9800).copy(alpha = 0.20f),
+    mediumContainer   = Color(0xFFE6A800).copy(alpha = 0.20f),
+    lowContainer      = Color(0xFF64B5F6).copy(alpha = 0.20f),
+)
+
+val LightExtendedColors = ExtendedColors(
+    critical          = Color(0xFFB3261E),   // darker red, AA on white
+    high              = Color(0xFFC25700),   // deep orange
+    medium            = Color(0xFF8B6B00),   // dark amber
+    low               = Color(0xFF1565C0),   // deep blue
+    neutral           = TealPrimaryVariant,
+    criticalContainer = Color(0xFFFFDAD6),   // pale red bg
+    highContainer     = Color(0xFFFFDCC2),
+    mediumContainer   = Color(0xFFF6E5B4),
+    lowContainer      = Color(0xFFD0E4FF),
+)
+```
+
+## Settings UI
+
+`SettingsScreen.kt` gains an "Appearance" section above the existing DNS / Custom rules sections.
+
+UI: a single 3-button segmented control (or radio group, whichever fits existing settings style) labelled **"Theme"** with buttons **System default / Light / Dark**. Default selection follows the persisted `themeMode`. Tap immediately calls `viewModel.setThemeMode(mode)`.
+
+`SettingsViewModel` exposes:
+
+```kotlin
+val themeMode: StateFlow<ThemeMode> = settingsRepository.themeMode
+    .stateIn(viewModelScope, SharingStarted.Eagerly, ThemeMode.AUTO)
+
+fun setThemeMode(mode: ThemeMode) {
+    viewModelScope.launch { settingsRepository.setThemeMode(mode) }
+}
+```
+
+`MainActivity` collects `settingsRepository.themeMode` as state and passes the value into `AndroDRTheme`. Theme switch is instant; no restart required.
+
+## OEM-override hardening (Honor MagicOS in particular)
+
+Confirmed current state of `app/src/main/res/values/themes.xml`:
+
+```xml
+<style name="Theme.AndroDR" parent="android:Theme.Material.NoActionBar">
+    <item name="android:statusBarColor">#1A1A2E</item>
+    <item name="android:navigationBarColor">#1A1A2E</item>
+</style>
+```
+
+This is a permanently-dark Activity theme with hardcoded system-bar colors that don't track Compose. Two of the three findings below are direct consequences.
+
+Three concrete changes:
+
+1. **`android:forceDarkAllowed="false"`** added to `Theme.AndroDR`. This blocks Honor's MagicOS force-light/force-dark from overriding Compose's choice. Compose owns the theme; the OS shouldn't.
+2. **Remove the hardcoded `statusBarColor` / `navigationBarColor`** from `Theme.AndroDR`. Replace with runtime updates in `MainActivity` (or a small `SystemBarsEffect` Composable) that read `MaterialTheme.colorScheme.surface` and call `WindowCompat.getInsetsController(...).isAppearanceLightStatusBars = !useDarkTheme` plus `window.statusBarColor = surface.toArgb()`. Bars then track theme switches instantly.
+3. **Parent theme switch.** `android:Theme.Material.NoActionBar` is a legacy platform theme that may apply implicit text colors. Switch to `Theme.AppCompat.DayNight.NoActionBar` (or `Theme.Material3.DayNight.NoActionBar` if Material 3 XML theme is already on the dependency graph). Audit confirms the Activity inherits no `android:textColorPrimary` overrides; if any are present, remove them so Compose's `onSurface` wins.
+
+## Migration of the 55 hardcoded color sites
+
+Mechanical replacement, file by file:
+
+| Old literal              | Used for                          | Replacement                                                                                |
+|--------------------------|-----------------------------------|--------------------------------------------------------------------------------------------|
+| `Color(0xFFCF6679)`      | critical severity / error chip    | `MaterialTheme.androdrColors.critical`                                                     |
+| `Color(0xFFFF9800)`      | high severity                     | `MaterialTheme.androdrColors.high`                                                         |
+| `Color(0xFFE6A800)` / `0xFFFFD54F` | medium severity         | `MaterialTheme.androdrColors.medium`                                                       |
+| `Color(0xFF64B5F6)`      | low severity                      | `MaterialTheme.androdrColors.low`                                                          |
+| `Color(0xFF00D4AA)`      | neutral severity / brand accent   | `MaterialTheme.androdrColors.neutral` (severity context) or `colorScheme.primary` (brand)  |
+| `Color(0xFFFF8A65)`      | one-off in TimelineEventCard      | `MaterialTheme.androdrColors.high` (same severity tier)                                    |
+| `Color(0xFF888888)`      | disabled-state grey               | `colorScheme.onSurface.copy(alpha = 0.38f)` (Material disabled token)                      |
+| `Color(0xFFCF6679).copy(alpha = N)` | alert backgrounds      | `MaterialTheme.androdrColors.criticalContainer` (drop alpha — light/dark variants already encode the visual weight) |
+
+Files confirmed from the codebase scan:
+
+- `ui/network/DnsMonitorScreen.kt`
+- `ui/timeline/TimelineEventCard.kt`
+- `ui/common/FindingCard.kt`
+- `ui/common/EvidenceSheet.kt`
+- `ui/common/SeverityChip.kt`
+
+Implementation should run a fresh `grep -rn "Color(0x" app/src/main/java --include="*.kt" | grep -v "ui/theme/"` to confirm no new sites were added since this spec was written; pick up any newcomers in the same pass.
+
+### Drift guard (durable part)
+
+Add a unit test in `app/src/test/java/com/androdr/ui/theme/HardcodedColorGuardTest.kt`:
+
+```kotlin
+class HardcodedColorGuardTest {
+    @Test
+    fun `no hardcoded Color(0xFF…) literals outside ui-theme package`() {
+        val offenders = File("src/main/java/com/androdr")
+            .walkTopDown()
+            .filter { it.extension == "kt" }
+            .filterNot { it.path.contains("/ui/theme/") }
+            .flatMap { f ->
+                f.readLines().mapIndexedNotNull { idx, line ->
+                    Regex("""Color\(0x[0-9A-Fa-f]{8}\)""").find(line)?.let { "${f.name}:${idx + 1}" }
+                }
+            }
+            .toList()
+        assertTrue(
+            "Hardcoded Color(0xFF…) literals found outside ui/theme/. Move to ExtendedColors:\n" +
+                offenders.joinToString("\n"),
+            offenders.isEmpty()
+        )
+    }
+}
+```
+
+Path resolution may need adjustment for the project's test working directory. The point is: if someone adds a hardcoded color in a future PR, CI breaks and tells them where.
+
+## Testing
+
+### Compose previews
+
+For each of `SeverityChip`, `FindingCard`, `EvidenceSheet`, `TimelineEventCard`, add `@Preview` entries with both `uiMode = UI_MODE_NIGHT_YES` and `UI_MODE_NIGHT_NO`. Visual regression catches obvious contrast failures during code review.
+
+### Contrast unit test
+
+Helper:
+
+```kotlin
+fun contrastRatio(fg: Color, bg: Color): Double { /* WCAG luminance math */ }
+```
+
+Test asserts: for both `LightExtendedColors` and `DarkExtendedColors`, every severity color against its scheme's `background` and `surface` meets WCAG AA (≥ 4.5 for normal text, ≥ 3.0 for large/UI components). Same for the `*Container` colors against `onSurface`.
+
+### Settings round-trip
+
+`SettingsRepositoryTest` (extend existing or add) verifies `setThemeMode(LIGHT)` then `themeMode.first()` returns `LIGHT`; same for `DARK` and `AUTO`; unknown stored value falls back to `AUTO`.
+
+### `AndroDRTheme` resolution
+
+Unit test with a fake `isSystemInDarkTheme` value confirms the truth table:
+
+| themeMode | isSystemDark | useDark expected |
+|-----------|--------------|------------------|
+| AUTO      | true         | true             |
+| AUTO      | false        | false            |
+| LIGHT     | true         | false            |
+| LIGHT     | false        | false            |
+| DARK      | true         | true             |
+| DARK      | false        | true             |
+
+### Manual smoke
+
+- Emulator: install, toggle system dark mode, confirm app follows. Toggle picker through all three modes.
+- Physical device, if Honor unit available: re-test the screen the tester originally flagged. Confirm text is legible in both modes and that MagicOS no longer washes the UI.
+
+## Risks
+
+- **Light palette tuning is iterative.** First-pass color values almost certainly won't all pass AA. Implementation should run the contrast test as it goes and adjust.
+- **The drift-guard test may produce noise on legitimate uses of `Color(0xFF…)`** (e.g., debug overlays, screenshot tests). Add an opt-out comment marker (`// hardcoded-color-ok: <reason>`) the test recognizes if needed.
+- **`forceDarkAllowed="false"` is a manifest change.** Confirm no regression on stock Android devices where Compose theming already handles everything correctly.
+
+## Rollout
+
+Single PR targeting `main` per project convention. All work behind one branch (`fix/light-dark-theme-honor-contrast` or similar). No feature flag; this is a fix.
+
+Filed-issue link gets added to the spec header and PR body once the issue is created.


### PR DESCRIPTION
## Summary

- Adds a light Material 3 color scheme + OS-following theme mode with user override (Auto/Light/Dark) persisted in DataStore.
- Introduces `MaterialTheme.androdrColors` (severity hues + alert backgrounds) via `CompositionLocal`; migrates 10 UI files away from 55 hardcoded `Color(0xFF…)` literals.
- Drops hardcoded status/nav bar colors from `themes.xml`, adds `android:forceDarkAllowed="false"`, and drives bar colors from the active Compose surface via `MainActivity.SystemBarsEffect` — blocks the Honor MagicOS force-light override that was producing invisible text.

## Visual changes (deliberate)

- **LOW severity is now blue, not brand teal.** Affects severity chips, finding cards, dashboard risk swatches, timeline backgrounds. The previous code lumped LOW into the neutral teal bucket; the new palette gives LOW its own blue.
- **Dashboard CRITICAL / HIGH / MEDIUM risk swatches lose the "loud" presentation** (`0xFFFF1744` siren red → `androdrColors.critical`, etc.). If a louder dashboard banner is wanted, file separately as a UX decision.
- **TimelineEventCard severity-row washes shift slightly** on HIGH (deep orange 300 → deeper orange) and MEDIUM (amber 300 → darker amber).
- **SeverityChip disabled state** changes from a fixed `0xFF888888` grey to `colorScheme.onSurface.copy(alpha = 0.38f)` so it adapts to the active theme.

## Test plan

- [x] `./gradlew :app:testDebugUnitTest` — 532 tests pass (incl. 4 new test classes: `ThemeModeResolutionTest`, `SettingsRepositoryThemeModeTest`, `ExtendedColorsContrastTest` (WCAG AA verified on both palettes + light containers), `HardcodedColorGuardTest`).
- [x] `./gradlew assembleRelease` + `./gradlew lintDebug` — both pass; no new errors.
- [x] Interactive emulator (`Medium_Phone_API_36.1`): cycled Settings → Appearance → System/Light/Dark, walked Dashboard + Apps + Network + Timeline screens in both modes.
- [ ] Honor MagicOS re-test by tester — pending; relies on the original reporter to verify the invisible-text bug is resolved post-merge.

## Spec + plan

- Spec: `docs/superpowers/specs/2026-05-18-light-dark-theme-design.md`
- Plan: `docs/superpowers/plans/2026-05-18-light-dark-theme.md` (executed in 22 tasks via Subagent-Driven Development with per-task two-stage review)

## Follow-ups (not in scope)

- `MainActivity.SystemBarsEffect` uses `window.statusBarColor` / `navigationBarColor`, deprecated on API 35+. Works on compile SDK 34 (this project); future migration to edge-to-edge `WindowInsets` worth filing.
- Material You dynamic color from wallpaper.
- `androdr-015` "Unrecognized System App" FP on Honor MagicOS preloads — separate track.

Closes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)