### PR TITLE
fix: suppress detekt TooGenericExceptionCaught in BugReportViewModel

### DIFF
--- a/app/src/main/java/com/androdr/ui/bugreport/BugReportViewModel.kt
+++ b/app/src/main/java/com/androdr/ui/bugreport/BugReportViewModel.kt
@@ -90,6 +90,8 @@ class BugReportViewModel @Inject constructor(
      * Analyzes the bug report zip at the given [uri].
      * Updates [isAnalyzing], [findings], and [timeline] reactively.
      */
+    // Orchestrator throws many exception types (IO, zip, parse); UI shows the raw message.
+    @Suppress("TooGenericExceptionCaught")
     fun analyzeUri(uri: Uri) {
         viewModelScope.launch {
             _isAnalyzing.value = true


### PR DESCRIPTION
## Summary
Adds `@Suppress("TooGenericExceptionCaught")` to `BugReportViewModel.analyzeUri()` to unblock CI's `lint-and-detekt` gate. Same pattern as existing suppressions in `SettingsViewModel` (lines 132, 246, 305) and `TimelineViewModel` (line 353).

## Context
CI's `lint-and-detekt` job has been failing on every merged PR since #189 because of this pre-existing finding at `BugReportViewModel.kt:107`. The catch-all `catch (e: Exception)` is intentional — `orchestrator.analyzeBugReport(uri)` throws many distinct types (`IOException`, `ZipException`, `IllegalArgumentException`, parse errors from various subsystems) and the UI just needs to show the raw message to the user.

Until CI was being admin-bypassed (per the earlier "CI out of budget" pattern), this was tolerable. Now that CI is enforced, it has to be fixed before any other PR can merge cleanly.

## Test plan
- [x] `./gradlew :app:detekt` — green locally.
- [x] No behavior change (suppression annotation only).
- [ ] Other in-flight branches (#168 follow-up + theme PR) rebase onto this once merged, unblocking their CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)