### PR TITLE
fix(detekt): suppress 4 false-positive findings unblocking CI

### DIFF
--- a/app/src/main/java/com/androdr/MainActivity.kt
+++ b/app/src/main/java/com/androdr/MainActivity.kt
@@ -58,6 +58,7 @@ import javax.inject.Inject
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
 
+    @Suppress("LateinitUsage") // Hilt field injection requires lateinit on @AndroidEntryPoint activities.
     @Inject lateinit var settingsRepository: SettingsRepository
 
     override fun onCreate(savedInstanceState: android.os.Bundle?) {

--- a/app/src/main/java/com/androdr/ui/bugreport/BugReportViewModel.kt
+++ b/app/src/main/java/com/androdr/ui/bugreport/BugReportViewModel.kt
@@ -90,6 +90,7 @@ class BugReportViewModel @Inject constructor(
      * Analyzes the bug report zip at the given [uri].
      * Updates [isAnalyzing], [findings], and [timeline] reactively.
      */
+    @Suppress("TooGenericExceptionCaught") // Bug-report analysis surfaces any IO/parse error to the user.
     fun analyzeUri(uri: Uri) {
         viewModelScope.launch {
             _isAnalyzing.value = true

--- a/app/src/main/java/com/androdr/ui/common/SeverityChip.kt
+++ b/app/src/main/java/com/androdr/ui/common/SeverityChip.kt
@@ -55,6 +55,7 @@ fun severityColor(level: String, colors: ExtendedColors): Color = when (level.lo
     else       -> colors.neutral
 }
 
+@Suppress("UnusedPrivateMember") // Compose @Preview functions are invoked by the IDE preview tool, not by code.
 @Preview(name = "Severity chips — Dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Preview(name = "Severity chips — Light", uiMode = Configuration.UI_MODE_NIGHT_NO)
 @Composable

--- a/app/src/test/java/com/androdr/ui/theme/ExtendedColorsContrastTest.kt
+++ b/app/src/test/java/com/androdr/ui/theme/ExtendedColorsContrastTest.kt
@@ -64,6 +64,7 @@ private fun relativeLuminance(c: Color): Double {
 }
 
 private fun Color.toHex(): String = String.format(
+    java.util.Locale.ROOT,
     "#%02X%02X%02X",
     (red * 255).toInt(), (green * 255).toInt(), (blue * 255).toInt()
 )


### PR DESCRIPTION
## Summary

Unblocks the `lint-and-detekt` job on `main` that has been failing since #192. Adds targeted `@Suppress` annotations to four detekt false-positives — three I introduced in #194 (theme PR), one pre-existing on `BugReportViewModel.analyzeUri`.

## Findings + rationale

| File | Rule | Why suppress |
|---|---|---|
| `BugReportViewModel.kt:107` | `TooGenericExceptionCaught` | Bug-report analysis must surface any IO/parse error to the user — the broad catch is intentional. (Pre-existing on `main`.) |
| `MainActivity.kt:61` | `LateinitUsage` | Hilt field injection on `@AndroidEntryPoint` activities requires `lateinit`. Cannot be removed. |
| `ExtendedColorsContrastTest.kt:66` | `ImplicitDefaultLocale` | Hex color formatting is locale-invariant; now uses `Locale.ROOT` explicitly. |
| `SeverityChip.kt:58` | `UnusedPrivateMember` | Compose `@Preview` functions are invoked by the IDE preview tool, not by code. |

No behavior change.

## Test plan

- [x] `./gradlew detekt lintDebug :app:testDebugUnitTest` — all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)