### PR TITLE
fix(rules): broker-SDK descriptions — replace dev-prose with end-user prose

### DIFF
--- a/app/src/main/res/raw/sigma_androdr_079_data_broker_outlogic.yml
+++ b/app/src/main/res/raw/sigma_androdr_079_data_broker_outlogic.yml
@@ -3,16 +3,11 @@ id: androdr-079
 status: production
 category: incident
 description: >
-    Detects the Outlogic (formerly X-Mode Social) location-data broker SDK
-    embedded inside an installed app. X-Mode was banned from the Play Store
-    in December 2020 after Vice/Motherboard reporting tied it to US military
-    and federal LE buyers. The vendor was acquired by Digital Envoy in
-    August 2021 and rebranded as Outlogic. The FTC finalized a settlement
-    in April 2024 prohibiting sale of sensitive location data. The match
-    set is the two unambiguous io.xmode.* class prefixes documented by
-    Exodus Privacy tracker #354 and the ExpressVPN 'Xoth' investigation;
-    the io.mysdk.* prefix is intentionally excluded because it is shared
-    with SignalFrame/WirelessRegistry and would cause false positives.
+    This app contains the Outlogic (formerly X-Mode) data-broker SDK.
+    X-Mode was banned from the Play Store in December 2020 after
+    reporting tied its location feed to US military and federal
+    law-enforcement buyers; the FTC settled with successor Outlogic in
+    April 2024 over the sale of sensitive location data.
 author: AndroDR (AI-generated)
 date: 2026/05/18
 references:

--- a/app/src/main/res/raw/sigma_androdr_080_data_broker_venntel.yml
+++ b/app/src/main/res/raw/sigma_androdr_080_data_broker_venntel.yml
@@ -3,12 +3,10 @@ id: androdr-080
 status: production
 category: incident
 description: >
-    Detects the legacy Gravy GOLD SDK (published under TimeRAZOR Inc.,
-    later branded Venntel) embedded inside an installed app. Venntel
-    resold the resulting location feed to ICE, CBP, DEA, and US military
-    customers per Senator Wyden's investigations and the FTC complaint
-    (December 2024). Match set is the two confirmed class prefixes from
-    the vendor's own Javadoc and an independent third-party mirror.
+    This app contains the legacy Gravy GOLD / Venntel data-broker SDK.
+    Venntel resold the location feed to ICE, CBP, DEA, and US military
+    customers per Senator Wyden's investigations and the December 2024
+    FTC complaint.
 author: AndroDR (AI-generated)
 date: 2026/05/18
 references:

--- a/app/src/main/res/raw/sigma_androdr_081_data_broker_predicio.yml
+++ b/app/src/main/res/raw/sigma_androdr_081_data_broker_predicio.yml
@@ -3,12 +3,11 @@ id: androdr-081
 status: production
 category: incident
 description: >
-    Detects the Predicio 'Telescope' SDK embedded inside an installed app.
-    Predicio was removed from Google Play and Apple's App Store in
-    February 2021 after Vice/Motherboard reporting (Joseph Cox) exposed
-    that the Salaat First Muslim prayer app exfiltrated user location to
-    predic.io endpoints. The SDK is functionally defunct but historical
-    versions may persist on devices that have not been re-published.
+    This app contains the Predicio 'Telescope' data-broker SDK. Predicio
+    was removed from Google Play and the App Store in February 2021
+    after reporting exposed that the Salaat First Muslim prayer app
+    exfiltrated user location to broker servers. The SDK is defunct, but
+    historical versions persist in apps that have not been re-published.
 author: AndroDR (AI-generated)
 date: 2026/05/18
 references:

--- a/app/src/main/res/raw/sigma_androdr_082_data_broker_cuebiq.yml
+++ b/app/src/main/res/raw/sigma_androdr_082_data_broker_cuebiq.yml
@@ -3,15 +3,12 @@ id: androdr-082
 status: production
 category: incident
 description: >
-    Detects the Cuebiq location-data broker SDK embedded inside an
-    installed app. Cuebiq-sourced data was used in the New York Times
-    'Privacy Project' (December 2019) to re-identify named individuals,
+    This app contains the Cuebiq location-data broker SDK. Cuebiq-sourced
+    data was used by the December 2019 New York Times 'Privacy Project'
+    to re-identify named individuals from supposedly-anonymous datasets,
     including a US Secret Service agent traveling with the President.
-    Cuebiq announced an SDK sunset in 2021 but a permissive variant
-    remained available; historical versions persist in apps that have
-    not been re-published. Match set is the two canonical class anchors
-    from Exodus Privacy tracker #57 and the glorifiedgrep OSS static
-    analysis tool.
+    Cuebiq announced an SDK sunset in 2021, but historical versions
+    persist in apps that have not been re-published.
 author: AndroDR (AI-generated)
 date: 2026/05/18
 references:

--- a/app/src/main/res/raw/sigma_androdr_083_broker_sdk_with_location_permission.yml
+++ b/app/src/main/res/raw/sigma_androdr_083_broker_sdk_with_location_permission.yml
@@ -3,22 +3,12 @@ id: androdr-083
 status: experimental
 category: incident
 description: >
-    Detects an installed app that BOTH embeds one of the documented
-    data-broker SDKs (Outlogic, Venntel, Predicio, Cuebiq) AND holds
-    ACCESS_FINE_LOCATION. This is the threat model from the DW
-    Documentary "Dangerous apps — In the web of data brokers":
-    ordinary apps (weather, classifieds, dating, games) embed a
-    location-broker SDK and request location permission, enabling the
-    broker pipeline to sell precise-movement data to LE and military
-    buyers. Higher signal than either anchor alone because the AND
-    models the full pipeline.
-
-    Note on permission matching: AndroDR's AppScanner emits the
-    `permissions` field as short names (the surveillance-permission
-    subset, with `android.permission.` stripped — see AppScanner.kt
-    line 275). ACCESS_BACKGROUND_LOCATION is not tracked in that
-    subset; matching on ACCESS_FINE_LOCATION suffices because Android
-    11+ requires FINE to be granted as a prerequisite for BACKGROUND.
+    This app combines a documented data-broker SDK (Outlogic, Venntel,
+    Predicio, or Cuebiq) with permission to access your precise location.
+    The two signals together indicate an active broker pipeline —
+    ordinary-looking apps (weather, classifieds, dating, games) embed
+    these SDKs to monetize precise-movement data, which has historically
+    been sold to law-enforcement and military buyers.
 author: AndroDR (AI-generated)
 date: 2026/05/18
 references:


### PR DESCRIPTION
## Summary

Found while testing the just-merged broker-SDK detection (#197) on an emulator: the finding card body renders the rule's raw `description:` field, which for the 5 broker rules contained developer-facing prose — file:line references, all-caps code constants, and rule-author meta-prose ("Match set is the two canonical class anchors..."). End users have no context for any of that.

Rewrote the 5 broker rules' descriptions to be victim-voice and user-facing while keeping the threat context that makes the finding actionable.

## Rules touched

- androdr-079 — Outlogic / X-Mode
- androdr-080 — Venntel / Gravy GOLD
- androdr-081 — Predicio / Telescope
- androdr-082 — Cuebiq
- androdr-083 — combination (broker SDK + location)

No detection logic changes, no schema changes, no UI code changes.

## Test plan

- [x] `./gradlew :app:testDebugUnitTest` — passes locally.
- [ ] On-device re-test: re-trigger the broker-SDK detection on the emulator fixture, verify the finding card body is now readable end-user prose.

## Mirror

Companion upstream rule-repo PR: https://github.com/android-sigma-rules/rules/pull/27

Submodule pointer is intentionally NOT bumped in this PR (same pattern as #199) — the remote-fetch path uses the URL directly; pointer bump is a follow-up after upstream merges.

Closes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)