### PR TITLE
fix(data): cover partner pre-installs in OEM allowlist (HONOR FP fix)

### DIFF
--- a/app/src/main/res/raw/known_oem_prefixes.yml
+++ b/app/src/main/res/raw/known_oem_prefixes.yml
@@ -22,6 +22,7 @@ unconditional:
     - "com.qualcomm."
     - "com.qti."
     - "vendor.qti."
+    - "org.codeaurora."   # Code Aurora Forum — Qualcomm-aligned open-source baseband/IMS namespace (e.g., org.codeaurora.ims)
     - "com.mediatek."
     - "com.mtk."
     - "com.unisoc."
@@ -40,6 +41,38 @@ unconditional:
   custom_rom_prefixes:
     - "org.lineageos."
     - "com.cyanogenmod."
+
+  # Partner pre-installs — cross-OEM packages bundled by manufacturers as
+  # part of commercial partnerships. Each ships as system: true on the OEM
+  # image but its package namespace belongs to the partner, not the OEM,
+  # so it falls through OEM-conditional blocks and trips androdr-015
+  # (Unrecognized System App, LOW) as a false positive.
+  #
+  # Treated as unconditional because the signed package is identical
+  # across every OEM that ships it (Microsoft, Meta, the SwiftKey APK on
+  # Play are the same APK whether preloaded on HONOR, Samsung, OPPO, etc.).
+  #
+  # Entry-shape rules:
+  #   * Trailing dot ("com.X.") only when the partner namespace has no
+  #     publicly-distributable apps an attacker could spoof under it.
+  #   * Exact-match (no trailing dot) where the partner also publishes
+  #     user-installable apps under com.<partner>.* that we do NOT want
+  #     implicitly trusted (e.g., com.facebook.katana / com.microsoft.emmx /
+  #     com.touchtype.* sibling APKs an attacker could publish).
+  #
+  # NOT-added intentionally:
+  #   * com.aura.*  — IronSource AppCloud sponsored-app installer (different
+  #     vendor than the Aura identity-protection brand). The project's own
+  #     known_good_apps.json catalogs 5+ com.aura.oobe.* / com.aura.jet.*
+  #     packages as "App from <carrier>. Installs apps on oobe and is made
+  #     by advertising company 'ironSource'." Existing exclusion comment at
+  #     conditional/us_carrier_tmobile (below) is the standing project
+  #     stance. Detection of these as Unrecognized System App is intended.
+  partner_preinstall_prefixes:
+    - "com.touchtype.swiftkey"    # SwiftKey (Microsoft-owned, exact-match — TouchType Ltd. namespace isn't reserved on Play, so a trailing-dot prefix would create a spoofing surface)
+    - "com.microsoft.appmanager"  # Microsoft Phone Link / Link to Windows (exact-match; trailing dot covered via Kotlin startsWith semantics for variants like com.microsoft.appmanager.cn)
+    - "com.facebook.appmanager"   # Facebook OEM stub appmanager — preinstalled on most non-Google OEM images
+    - "com.facebook.services"     # Facebook OEM stub services
 
   # Trusted app store installer package names. These are compared against
   # installer identity, not against arbitrary package names, so they are

--- a/app/src/test/java/com/androdr/ioc/OemPrefixCoverageRegressionTest.kt
+++ b/app/src/test/java/com/androdr/ioc/OemPrefixCoverageRegressionTest.kt
@@ -82,6 +82,13 @@ class OemPrefixCoverageRegressionTest {
             DeviceIdentity("fairphone", "fairphone") to "com.fairphone.activator",
             // Wiko
             DeviceIdentity("wiko", "wiko") to "com.wiko.services",
+            // Code Aurora Forum — Qualcomm-aligned baseband/IMS (unconditional via chipset_prefixes)
+            DeviceIdentity("honor", "honor") to "org.codeaurora.ims",
+            // Partner pre-installs — unconditional, must match on every device
+            DeviceIdentity("honor", "honor") to "com.touchtype.swiftkey",
+            DeviceIdentity("samsung", "samsung") to "com.microsoft.appmanager",
+            DeviceIdentity("xiaomi", "redmi") to "com.facebook.appmanager",
+            DeviceIdentity("oneplus", "oneplus") to "com.facebook.services",
         )
 
         val failures = cases.filterNot { (device, pkg) ->
@@ -92,6 +99,40 @@ class OemPrefixCoverageRegressionTest {
             "Lost OEM coverage for ${failures.size} case(s):\n" +
                 failures.joinToString("\n") { (d, p) -> "  - $p on $d" },
             failures.isEmpty(),
+        )
+    }
+
+    @Test
+    fun `partner pre-install allowlist does NOT over-trust user-installable sibling packages`() {
+        // Negative coverage lock — these must NOT match an OEM prefix because they're
+        // user-installable apps in the same namespace as a partner preinstall. If
+        // someone widens com.touchtype.swiftkey to com.touchtype. or com.microsoft.appmanager
+        // to com.microsoft., this test fails and points to the over-trust.
+        val nonOemCases: List<Pair<DeviceIdentity, String>> = listOf(
+            // Microsoft user-installable apps under com.microsoft.* — must NOT match
+            DeviceIdentity("honor", "honor") to "com.microsoft.emmx",       // Edge
+            DeviceIdentity("honor", "honor") to "com.microsoft.teams",
+            DeviceIdentity("honor", "honor") to "com.microsoft.office.word",
+            // Facebook user apps under com.facebook.* — must NOT match
+            DeviceIdentity("honor", "honor") to "com.facebook.katana",      // Facebook
+            DeviceIdentity("honor", "honor") to "com.facebook.orca",        // Messenger
+            DeviceIdentity("honor", "honor") to "com.facebook.lite",        // Facebook Lite
+            // IronSource AppCloud (com.aura.*) — intentionally NOT in the allowlist
+            // because known_good_apps.json catalogs these as sponsored-app bloatware.
+            // Flagging as Unrecognized System App is the intended behavior.
+            DeviceIdentity("honor", "honor") to "com.aura.oobe.honor",
+            DeviceIdentity("samsung", "samsung") to "com.aura.oobe.samsung.gl",
+            DeviceIdentity("motorola", "motorola") to "com.aura.oobe.motorola",
+        )
+
+        val falseTrust = nonOemCases.filter { (device, pkg) ->
+            resolver.isOemPrefix(pkg, device)
+        }
+
+        assertTrue(
+            "Over-trust regression for ${falseTrust.size} case(s) — these should NOT be OEM:\n" +
+                falseTrust.joinToString("\n") { (d, p) -> "  - $p on $d" },
+            falseTrust.isEmpty(),
         )
     }
 }

--- a/app/src/test/resources/raw/known_oem_prefixes.yml
+++ b/app/src/test/resources/raw/known_oem_prefixes.yml
@@ -22,6 +22,7 @@ unconditional:
     - "com.qualcomm."
     - "com.qti."
     - "vendor.qti."
+    - "org.codeaurora."   # Code Aurora Forum — Qualcomm-aligned open-source baseband/IMS namespace (e.g., org.codeaurora.ims)
     - "com.mediatek."
     - "com.mtk."
     - "com.unisoc."
@@ -40,6 +41,38 @@ unconditional:
   custom_rom_prefixes:
     - "org.lineageos."
     - "com.cyanogenmod."
+
+  # Partner pre-installs — cross-OEM packages bundled by manufacturers as
+  # part of commercial partnerships. Each ships as system: true on the OEM
+  # image but its package namespace belongs to the partner, not the OEM,
+  # so it falls through OEM-conditional blocks and trips androdr-015
+  # (Unrecognized System App, LOW) as a false positive.
+  #
+  # Treated as unconditional because the signed package is identical
+  # across every OEM that ships it (Microsoft, Meta, the SwiftKey APK on
+  # Play are the same APK whether preloaded on HONOR, Samsung, OPPO, etc.).
+  #
+  # Entry-shape rules:
+  #   * Trailing dot ("com.X.") only when the partner namespace has no
+  #     publicly-distributable apps an attacker could spoof under it.
+  #   * Exact-match (no trailing dot) where the partner also publishes
+  #     user-installable apps under com.<partner>.* that we do NOT want
+  #     implicitly trusted (e.g., com.facebook.katana / com.microsoft.emmx /
+  #     com.touchtype.* sibling APKs an attacker could publish).
+  #
+  # NOT-added intentionally:
+  #   * com.aura.*  — IronSource AppCloud sponsored-app installer (different
+  #     vendor than the Aura identity-protection brand). The project's own
+  #     known_good_apps.json catalogs 5+ com.aura.oobe.* / com.aura.jet.*
+  #     packages as "App from <carrier>. Installs apps on oobe and is made
+  #     by advertising company 'ironSource'." Existing exclusion comment at
+  #     conditional/us_carrier_tmobile (below) is the standing project
+  #     stance. Detection of these as Unrecognized System App is intended.
+  partner_preinstall_prefixes:
+    - "com.touchtype.swiftkey"    # SwiftKey (Microsoft-owned, exact-match — TouchType Ltd. namespace isn't reserved on Play, so a trailing-dot prefix would create a spoofing surface)
+    - "com.microsoft.appmanager"  # Microsoft Phone Link / Link to Windows (exact-match; trailing dot covered via Kotlin startsWith semantics for variants like com.microsoft.appmanager.cn)
+    - "com.facebook.appmanager"   # Facebook OEM stub appmanager — preinstalled on most non-Google OEM images
+    - "com.facebook.services"     # Facebook OEM stub services
 
   # Trusted app store installer package names. These are compared against
   # installer identity, not against arbitrary package names, so they are


### PR DESCRIPTION
## Summary
User reported `androdr-015 Firmware Implant: HIGH` on HONOR PGT-N19 (v0.9.0.557). Diagnosis: the `is_known_oem_app` check missed several cross-OEM partner-preinstalled system apps. PR #199 (today) added `com.hihonor./com.magic.` for HONOR's own packages but didn't cover the partners that ship as `system: true` on the same image.

The Firmware Implant title + HIGH severity in the user's screenshot is a stale finding from before #147's downgrade — current rule is `Unrecognized System App: LOW`. New scans will render correctly.

## Adds
- New `partner_preinstall_prefixes` section under `unconditional:`:
  - `com.touchtype.swiftkey` — Microsoft SwiftKey (exact match — see below)
  - `com.microsoft.appmanager` — Microsoft Phone Link
  - `com.facebook.appmanager` — Facebook OEM stub
  - `com.facebook.services` — Facebook OEM stub
- `org.codeaurora.` added to existing `chipset_prefixes` (Qualcomm-aligned)

`OemPrefixResolver.kt` already auto-picks-up any list under `unconditional:`. No Kotlin change.

## NOT-added intentionally — `com.aura.*`
The first draft of this PR added `com.aura.` but reviewer flagged it as silencing a **true positive**. The project's own `known_good_apps.json` catalogs 5+ `com.aura.oobe.*` / `com.aura.jet.*` packages as carrier OOBE bloatware "made by advertising company 'ironSource'" (AppCloud sponsored-app installer). The existing exclusion comment at `conditional/us_carrier_tmobile` was already the standing project stance — `com.aura.oobe.honor` should remain flagged as Unrecognized System App. Negative test cases lock this in.

## Why `com.touchtype.swiftkey` is exact-match (no trailing dot)
TouchType Ltd. namespace isn't reserved on Play. A trailing-dot prefix would let an attacker publish `com.touchtype.attacker.*` and silence androdr-010/-015/-016/-068. Exact match is intentional.

## Tests
- `OemPrefixCoverageRegressionTest`: +5 positive cases for new prefixes.
- **New negative test** `partner pre-install allowlist does NOT over-trust user-installable sibling packages`:
  - `com.microsoft.emmx/teams/office.word` — NOT trusted
  - `com.facebook.katana/orca/lite` — NOT trusted
  - `com.aura.oobe.{honor,samsung.gl,motorola}` — NOT trusted (intentional)
- `./gradlew testDebugUnitTest lintDebug :app:detekt`: green.

## Found via
Two-reviewer cycle on a single-commit data fix. Harsh-quality reviewer caught both the `com.aura.` over-trust and the `com.touchtype.` spoofing surface; both addressed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)