### PR TITLE
fix(test-adversary): regression-mode report race + broaden sideload patterns

### DIFF
--- a/test-adversary/fixtures/expected/andrmonitor_stalkerware.patterns
+++ b/test-adversary/fixtures/expected/andrmonitor_stalkerware.patterns
@@ -1,2 +1,2 @@
 Surveillance Permissions
-not installed from a trusted app store
+Sideloaded Application

--- a/test-adversary/fixtures/expected/anubis_banker.patterns
+++ b/test-adversary/fixtures/expected/anubis_banker.patterns
@@ -1,1 +1,1 @@
-not installed from a trusted app store
+Sideloaded Application

--- a/test-adversary/fixtures/expected/brata_rat.patterns
+++ b/test-adversary/fixtures/expected/brata_rat.patterns
@@ -1,1 +1,1 @@
-not installed from a trusted app store
+Sideloaded Application

--- a/test-adversary/fixtures/expected/cerberus_banker.patterns
+++ b/test-adversary/fixtures/expected/cerberus_banker.patterns
@@ -1,1 +1,1 @@
-not installed from a trusted app store
+Sideloaded Application

--- a/test-adversary/fixtures/expected/cocospy_stalkerware.patterns
+++ b/test-adversary/fixtures/expected/cocospy_stalkerware.patterns
@@ -1,2 +1,2 @@
 Surveillance Permissions
-not installed from a trusted app store
+Sideloaded Application

--- a/test-adversary/fixtures/expected/ermac_stealer.patterns
+++ b/test-adversary/fixtures/expected/ermac_stealer.patterns
@@ -1,1 +1,1 @@
-not installed from a trusted app store
+Sideloaded Application

--- a/test-adversary/fixtures/expected/eyezy_stalkerware.patterns
+++ b/test-adversary/fixtures/expected/eyezy_stalkerware.patterns
@@ -1,2 +1,2 @@
 Surveillance Permissions
-not installed from a trusted app store
+Sideloaded Application

--- a/test-adversary/fixtures/expected/godfather_banker.patterns
+++ b/test-adversary/fixtures/expected/godfather_banker.patterns
@@ -1,1 +1,1 @@
-not installed from a trusted app store
+Sideloaded Application

--- a/test-adversary/fixtures/expected/hookbot_rat.patterns
+++ b/test-adversary/fixtures/expected/hookbot_rat.patterns
@@ -1,1 +1,1 @@
-not installed from a trusted app store
+Sideloaded Application

--- a/test-adversary/fixtures/expected/hydra_dropper.patterns
+++ b/test-adversary/fixtures/expected/hydra_dropper.patterns
@@ -1,1 +1,1 @@
-not installed from a trusted app store
+Sideloaded Application

--- a/test-adversary/fixtures/expected/mspy_stalkerware.patterns
+++ b/test-adversary/fixtures/expected/mspy_stalkerware.patterns
@@ -1,2 +1,2 @@
 Surveillance Permissions
-not installed from a trusted app store
+Sideloaded Application

--- a/test-adversary/fixtures/expected/sharkbot_banker.patterns
+++ b/test-adversary/fixtures/expected/sharkbot_banker.patterns
@@ -1,1 +1,1 @@
-not installed from a trusted app store
+Sideloaded Application

--- a/test-adversary/fixtures/expected/spynote_rat.patterns
+++ b/test-adversary/fixtures/expected/spynote_rat.patterns
@@ -1,1 +1,1 @@
-not installed from a trusted app store
+Sideloaded Application

--- a/test-adversary/fixtures/expected/surveillance_permissions.patterns
+++ b/test-adversary/fixtures/expected/surveillance_permissions.patterns
@@ -1,2 +1,2 @@
 Surveillance Permissions
-not installed from a trusted app store
+Sideloaded Application

--- a/test-adversary/fixtures/expected/thetruthspy_stalkerware.patterns
+++ b/test-adversary/fixtures/expected/thetruthspy_stalkerware.patterns
@@ -1,2 +1,2 @@
 Surveillance Permissions
-not installed from a trusted app store
+Sideloaded Application

--- a/test-adversary/fixtures/expected/tispy_stalkerware.patterns
+++ b/test-adversary/fixtures/expected/tispy_stalkerware.patterns
@@ -1,2 +1,2 @@
 Surveillance Permissions
-not installed from a trusted app store
+Sideloaded Application

--- a/test-adversary/fixtures/expected/vultur_rat.patterns
+++ b/test-adversary/fixtures/expected/vultur_rat.patterns
@@ -1,1 +1,1 @@
-not installed from a trusted app store
+Sideloaded Application

--- a/test-adversary/manifest.yml
+++ b/test-adversary/manifest.yml
@@ -44,7 +44,7 @@ scenarios:
     tags: [android, cerberus, banker]
     attack: [T1429, T1636]
     expected_patterns:
-      - "not installed from a trusted app store"
+      - "Sideloaded Application"
 
   - id: spynote_rat
     track: 1
@@ -57,7 +57,7 @@ scenarios:
     tags: [android, spynote, rat]
     attack: [T1429, T1430, T1512]
     expected_patterns:
-      - "not installed from a trusted app store"
+      - "Sideloaded Application"
 
   - id: anubis_banker
     track: 1
@@ -70,7 +70,7 @@ scenarios:
     tags: [android, Anubis, banker, sms-stealer]
     attack: [T1429, T1636]
     expected_patterns:
-      - "not installed from a trusted app store"
+      - "Sideloaded Application"
 
   - id: brata_rat
     track: 1
@@ -83,7 +83,7 @@ scenarios:
     tags: [android, BRATA, banker, trojan]
     attack: [T1429, T1636]
     expected_patterns:
-      - "not installed from a trusted app store"
+      - "Sideloaded Application"
 
   - id: hydra_dropper
     track: 1
@@ -96,7 +96,7 @@ scenarios:
     tags: [android, Hydra, banker]
     attack: [T1429, T1636]
     expected_patterns:
-      - "not installed from a trusted app store"
+      - "Sideloaded Application"
 
   - id: vultur_rat
     track: 1
@@ -109,7 +109,7 @@ scenarios:
     tags: [android, Vultur, trojan]
     attack: [T1429, T1512, T1636]
     expected_patterns:
-      - "not installed from a trusted app store"
+      - "Sideloaded Application"
 
   - id: sharkbot_banker
     track: 1
@@ -122,7 +122,7 @@ scenarios:
     sha256: "ab62a82d7752a52bc81001c7fc990037b45040f68e98769492f877815375876d"
     tags: [android, SharkBot, banker]
     expected_patterns:
-      - "not installed from a trusted app store"
+      - "Sideloaded Application"
 
   - id: ermac_stealer
     track: 1
@@ -135,7 +135,7 @@ scenarios:
     sha256: "ab62a82d7752a52bc81001c7fc990037b45040f68e98769492f877815375876d"
     tags: [android, Ermac, stealer]
     expected_patterns:
-      - "not installed from a trusted app store"
+      - "Sideloaded Application"
 
   - id: godfather_banker
     track: 1
@@ -148,7 +148,7 @@ scenarios:
     sha256: "ab62a82d7752a52bc81001c7fc990037b45040f68e98769492f877815375876d"
     tags: [android, GodFather, banker]
     expected_patterns:
-      - "not installed from a trusted app store"
+      - "Sideloaded Application"
 
   - id: hookbot_rat
     track: 1
@@ -161,7 +161,7 @@ scenarios:
     sha256: "ab62a82d7752a52bc81001c7fc990037b45040f68e98769492f877815375876d"
     tags: [android, Hook, rat]
     expected_patterns:
-      - "not installed from a trusted app store"
+      - "Sideloaded Application"
 
   # ── Track 2: Stalkerware ───────────────────────────────────────────────
   - id: thetruthspy_stalkerware
@@ -176,7 +176,7 @@ scenarios:
     attack: [T1429, T1430, T1512, T1636]
     expected_patterns:
       - "surveillance capabilities"
-      - "not installed from a trusted app store"
+      - "Sideloaded Application"
 
   - id: andrmonitor_stalkerware
     track: 2
@@ -190,7 +190,7 @@ scenarios:
     attack: [T1429, T1430, T1512, T1636]
     expected_patterns:
       - "surveillance capabilities"
-      - "not installed from a trusted app store"
+      - "Sideloaded Application"
 
   - id: tispy_stalkerware
     track: 2
@@ -204,7 +204,7 @@ scenarios:
     attack: [T1429, T1430, T1512, T1636]
     expected_patterns:
       - "surveillance capabilities"
-      - "not installed from a trusted app store"
+      - "Sideloaded Application"
 
   - id: cocospy_stalkerware
     track: 2
@@ -218,7 +218,7 @@ scenarios:
     tags: [android, Cocospy, stalkerware]
     expected_patterns:
       - "Surveillance Permissions"
-      - "not installed from a trusted app store"
+      - "Sideloaded Application"
 
   - id: mspy_stalkerware
     track: 2
@@ -232,7 +232,7 @@ scenarios:
     tags: [android, mSpy, stalkerware]
     expected_patterns:
       - "Surveillance Permissions"
-      - "not installed from a trusted app store"
+      - "Sideloaded Application"
 
   - id: eyezy_stalkerware
     track: 2
@@ -246,7 +246,7 @@ scenarios:
     tags: [android, Eyezy, stalkerware]
     expected_patterns:
       - "Surveillance Permissions"
-      - "not installed from a trusted app store"
+      - "Sideloaded Application"
 
   # ── Track 3: Mercenary spyware simulation ──────────────────────────────
   - id: mercenary_package_name
@@ -313,7 +313,7 @@ scenarios:
     attack: [T1429, T1430, T1512, T1636]
     expected_patterns:
       - "surveillance capabilities"
-      - "not installed from a trusted app store"
+      - "Sideloaded Application"
 
   - id: mercenary_file_artifacts
     track: 3
@@ -477,7 +477,7 @@ scenarios:
     source: adb_inject
     inject:
       - type: trigger_update
-        adb_cmd: "shell am broadcast -a com.androdr.ACTION_SCAN -p com.androdr.debug"
+        adb_cmd: "shell am broadcast -a com.androdr.ACTION_SCAN -n com.androdr.debug/com.androdr.debug.ScanBroadcastReceiver"
     attack: [T1404]
     expected_patterns:
       # After a scan, the report header shows patch level

--- a/test-adversary/run.sh
+++ b/test-adversary/run.sh
@@ -358,7 +358,11 @@ run_scenario() {
 
     # Step 6: TRIGGER SCAN
     echo "  Triggering scan..."
-    $ADB shell am broadcast -a com.androdr.ACTION_SCAN -p com.androdr.debug >/dev/null 2>&1
+    # Delete the previous report first; otherwise the poll loop below sees a
+    # stale file from the initial threat-DB update or a prior scenario and pulls
+    # the wrong scan output. Load mode does the same on its single-scan path.
+    $ADB shell rm -f /sdcard/Android/data/com.androdr.debug/files/androdr_last_report.txt 2>/dev/null || true
+    $ADB shell am broadcast -a com.androdr.ACTION_SCAN -n com.androdr.debug/com.androdr.debug.ScanBroadcastReceiver </dev/null >/dev/null 2>&1
     # Poll for report file instead of fixed sleep
     local waited=0
     while [ $waited -lt 60 ]; do


### PR DESCRIPTION
## Summary

Two bugs in the adversary simulation test harness surfaced while running fresh MalwareBazaar samples (2026-05). Both made real, higher-severity detections look like misses.

- **Race in regression mode** — `run.sh:run_scenario` triggered the scan broadcast and then polled `[ -f androdr_last_report.txt ]` to detect completion, but never deleted the stale file first. The initial threat-DB-update broadcast at script start creates a report, and every prior scenario leaves one behind. The poll therefore broke immediately on a stale file and pulled the wrong scan output. Load mode already did `rm` before its single-scan path; regression mode now mirrors it.
- **Sideload `.patterns` too narrow** — `.patterns` files matched the action-text string `not installed from a trusted app store`, which AndroDR only emits when the generic sideload finding fires *alone*. When a stronger reason fires (Malicious Certificate IOC, App Impersonation), the action text is replaced and the test misses despite a higher-severity detection. Switched to `Sideloaded Application` — the literal `triggered_title` of rule `androdr-010`, rendered into the `Reasons :` line whenever the sideload rule fires, regardless of what else fires alongside.

Also aligns regression-mode broadcast with load mode (`-n` receiver form, `</dev/null` stdin, `rm -f`) and updates `cve_settings_display`'s `adb_cmd` for the same consistency. Manifest's decorative `expected_patterns:` field updated to match (harness reads `.patterns` files only; the manifest field is doc-only).

## Verification

Re-ran the harness against 7 fresh MalwareBazaar samples uploaded 2026-05-11 to 2026-05-24 (Anatsa, FakeTelegram, NGate, AntiDot, NFC banker, Konfety, PNB India banker).

- **Pre-fix:** 4 PASS / 4 FAIL (race + narrow patterns)
- **Post-fix:** 6 PASS / 1 family-specific FAIL

The 1 outlier (FakeTelegram, `org.telegram.messenger` package-name spoof) is a separate product issue — App-Impersonation rule **replaces** rather than **augments** the Sideload reason. Out of scope for this PR; will file a follow-up.

## Test plan

- [x] `bash -n test-adversary/run.sh` — syntax clean
- [x] `python3 -c \"import yaml; yaml.safe_load(open('test-adversary/manifest.yml'))\"` — manifest parses
- [x] End-to-end harness run on emulator-5554 (Medium_Phone_API_36.1 / API 36) against 7 fresh real-world Android malware samples — 6/7 PASS; the 1 FAIL is documented and out of scope
- [x] Pre-fix run reproduced the bug (4/8 PASS, mixed race + pattern misses)

## Follow-up to file

- AndroDR App-Impersonation rule (androdr-014 / androdr-077) should not suppress the parent Sideload finding when both fire — downstream reporting and pattern matching assume Sideload's reason is always present for sideloaded apps. Real product bug, not a harness issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)