### PR TITLE
fix(ci): path-filter classified every PR as code (PR #202 regression)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,13 @@ jobs:
   # YAML-only and Python-only PRs. secret-scan + submodule-check always run
   # (cheap, catch accidents). ci-success treats `skipped` as a pass.
   # No untrusted input is interpolated into run: scripts in any job below.
+  #
+  # IMPORTANT: dorny/paths-filter@v3 evaluates each pattern in a filter under
+  # "any matches" semantics. A `!pattern` entry is therefore a separate
+  # positive matcher meaning "file does NOT match pattern" — it does NOT
+  # subtract from earlier positive matches the way .gitignore does. Keep
+  # `code` (and any future filter) as a positive allowlist; do not add `!`
+  # patterns here. See PR #202's regression for the bug this caused.
   changes:
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -39,15 +46,30 @@ jobs:
             python:
               - 'scripts/**'
             code:
-              - 'app/src/**'
-              - '!app/src/main/res/raw/sigma_*.yml'
-              - '!app/src/main/res/raw/known_oem_prefixes.yml'
+              # Kotlin / Java sources across all source sets
+              - 'app/src/**/*.kt'
+              - 'app/src/**/*.java'
+              # Android XML (manifests, layouts, values, drawable XML, keep.xml)
+              - 'app/src/**/*.xml'
+              # Non-rule resources under res/raw (rule files match `rules` above)
+              - 'app/src/main/res/raw/*.json'
+              - 'app/src/main/res/raw/*.txt'
+              - 'app/src/main/res/raw/known_spyware_artifacts.yml'
+              # Test fixtures and resource bundles
+              - 'app/src/test/resources/**'
+              - 'app/src/androidTest/resources/**'
+              # Build configuration
               - 'app/build.gradle.kts'
+              - 'app/proguard-rules.pro'
               - 'build.gradle.kts'
               - 'settings.gradle.kts'
               - 'gradle/**'
               - 'gradle.properties'
+              - 'gradlew'
+              - 'gradlew.bat'
+              # Submodule pointer (rule-schema cross-check tests)
               - 'third-party/android-sigma-rules'
+              # CI workflows
               - '.github/workflows/**'
   build-and-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

The `code` path filter in the `changes` job — added in #202 to skip irrelevant work on YAML/Python-only PRs — was using \`!pattern\` negation entries intending to exclude rule files from the code bucket:

\`\`\`yaml
code:
  - 'app/src/**'
  - '!app/src/main/res/raw/sigma_*.yml'
  - '!app/src/main/res/raw/known_oem_prefixes.yml'
  ...
\`\`\`

\`dorny/paths-filter@v3\` evaluates each pattern in a filter under \"any matches\" semantics (via picomatch). A \`!pattern\` entry is therefore a *separate positive matcher* meaning \"file does NOT match pattern\" — it does **not** subtract from earlier positive matches the way \`.gitignore\` does.

Net effect: every file path that wasn't one of those two specific YAMLs was getting classified as \`code=true\`. The filter was a no-op for everything except its self-test cases (sigma-only and python-only PRs).

Surfaced on **PR #204** (harness-only, touched 19 files all under \`test-adversary/\`) which still triggered the full Kotlin pipeline: build-and-test 4m36s, lint-and-detekt 3m39s, instrumented 5m10s, apk-analyze 29s — ~13 GHA minutes wasted.

## Fix

Replaces the negation-based filter with a **positive allowlist**. Verified locally with the same picomatch library dorny uses, against 25 representative file paths:

| Path | Old | New |
|---|---|---|
| \`test-adversary/run.sh\` | code (BUG) | (none) |
| \`docs/ARCHITECTURE.md\` / \`README.md\` / \`CLAUDE.md\` | code (BUG) | (none) |
| \`app/src/main/res/raw/sigma_*.yml\` | code (BUG) | rules |
| \`app/src/main/res/raw/known_oem_prefixes.yml\` | code (BUG) | rules |
| \`scripts/render_privacy.py\` | code (BUG) | python |
| \`app/src/main/java/com/androdr/Foo.kt\` | code | code |
| \`app/src/main/res/raw/known_bad_packages.json\` | code (BUG) | code |
| \`app/src/main/res/raw/keep.xml\` | code | code |
| \`app/build.gradle.kts\` / \`gradle/**\` / \`gradlew\` | code | code |

Also adds a WARNING comment so future contributors don't reintroduce \`!\` negations under gitignore intuition.

## Test plan

- [x] Local picomatch verification across 25 representative paths covering all four classification outcomes (none / rules / python / code)
- [x] YAML still parses (\`python3 -c \"import yaml; yaml.safe_load(open(...))\"\`)
- [x] Reviewer-flagged \`gradlew\` / \`gradlew.bat\` coverage added defensively
- [ ] Natural integration test: this PR itself is workflow-only — should classify as \`code\` (since \`.github/workflows/**\` is intentionally in the code bucket so workflow changes get smoke-tested through the full pipeline). The follow-up natural test is whichever harness/docs-only PR lands after this one.

## Follow-ups

- Workflow-only PRs (like this one) still trigger \`lint-and-detekt\` and \`instrumented\` via the \`code\` bucket. Defensible — workflow changes deserve a full smoke test — but if optimization is desired later, split workflow YAML into its own \`workflow\` bucket and gate just \`build-and-test\` / \`apk-analyze\` on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)