### PR TITLE
fix(report): derive Flag chips from rule implies_flags (#205)

### DIFF
--- a/app/src/main/java/com/androdr/reporting/ReportFormatter.kt
+++ b/app/src/main/java/com/androdr/reporting/ReportFormatter.kt
@@ -478,8 +478,9 @@ object ReportFormatter {
         val appName = highest.matchContext["app_name"]?.toString()?.takeIf { it.isNotEmpty() }
             ?: displayNames[pkg]
             ?: pkg
-        val isKnownMalware = findings.any { it.ruleId.startsWith("androdr-00") }
-        val isSideloaded = findings.any { it.ruleId == "androdr-010" }
+        val subjectFlags = findings.flatMap { it.impliesFlags }.toSet()
+        val isKnownMalware = "known_malware" in subjectFlags
+        val isSideloaded = "sideloaded" in subjectFlags
 
         val flags = buildList {
             if (isKnownMalware) add("[!] Known Malware")

--- a/app/src/main/java/com/androdr/scanner/ScanOrchestrator.kt
+++ b/app/src/main/java/com/androdr/scanner/ScanOrchestrator.kt
@@ -303,7 +303,7 @@ class ScanOrchestrator @Inject constructor(
             it.category == FindingCategory.APP_RISK && it.matchContext["is_sideloaded"] == "true"
         }
         val malwareCount = allFindings.count {
-            it.level == "critical" && it.ruleId in KNOWN_MALWARE_RULE_IDS
+            it.level == "critical" && "known_malware" in it.impliesFlags
         }
 
         Log.i(TAG, "Scan complete — SIGMA: ${allFindings.size} findings from " +
@@ -481,7 +481,7 @@ class ScanOrchestrator @Inject constructor(
             bugReportFindings = emptyList(),
             riskySideloadCount = 0,
             knownMalwareCount = result.findings.count {
-                it.level == "critical" && it.ruleId in KNOWN_MALWARE_RULE_IDS
+                it.level == "critical" && "known_malware" in it.impliesFlags
             },
             scannerErrors = bugReportScannerErrors
         )
@@ -600,9 +600,6 @@ class ScanOrchestrator @Inject constructor(
          * the progress bar fills to 100%.
          */
         private const val SCANNER_COUNT = 8
-
-        /** Rule IDs that represent confirmed malware matches (IOC database hits). */
-        private val KNOWN_MALWARE_RULE_IDS = setOf("androdr-001", "androdr-002")
 
         /**
          * Maximum age of the cached app telemetry that [analyzeBugReport]

--- a/app/src/main/java/com/androdr/sigma/SigmaRule.kt
+++ b/app/src/main/java/com/androdr/sigma/SigmaRule.kt
@@ -16,7 +16,12 @@ data class SigmaRule(
     val remediation: List<String>,
     val display: SigmaDisplay = SigmaDisplay(),
     val enabled: Boolean = true,
-    val reportSafeState: Boolean = false
+    val reportSafeState: Boolean = false,
+    // Orthogonal subject-level properties the detection structurally guarantees.
+    // Schema-defined enum (see third-party/android-sigma-rules/validation/rule-schema.json):
+    // "sideloaded", "known_malware". Renderers aggregate the union across all
+    // findings for the same subject to surface as Flag chips.
+    val impliesFlags: List<String> = emptyList()
 )
 
 data class SigmaDetection(

--- a/app/src/main/java/com/androdr/sigma/SigmaRuleEvaluator.kt
+++ b/app/src/main/java/com/androdr/sigma/SigmaRuleEvaluator.kt
@@ -33,7 +33,11 @@ data class Finding(
     val guidance: String = "",
     val triggered: Boolean = true,
     val evidence: Evidence = Evidence.None,
-    val matchContext: Map<String, String> = emptyMap()
+    val matchContext: Map<String, String> = emptyMap(),
+    // Propagated from the rule. Subject-level properties the detection
+    // guarantees (e.g. "sideloaded", "known_malware"). The presentation
+    // layer aggregates the union across same-subject findings.
+    val impliesFlags: List<String> = emptyList()
 )
 
 /**
@@ -155,7 +159,8 @@ object SigmaRuleEvaluator {
             triggered = triggered,
             evidence = evidenceResult?.evidence ?: Evidence.None,
             matchContext = record.filterValues { it !is List<*> && it !is Map<*, *> }
-                .mapValues { (_, v) -> v?.toString() ?: "" }
+                .mapValues { (_, v) -> v?.toString() ?: "" },
+            impliesFlags = rule.impliesFlags
         )
     }
 

--- a/app/src/main/java/com/androdr/sigma/SigmaRuleParser.kt
+++ b/app/src/main/java/com/androdr/sigma/SigmaRuleParser.kt
@@ -186,7 +186,8 @@ object SigmaRuleParser {
                 remediation = (doc["remediation"] as? List<*>)?.map { it.toString() } ?: emptyList(),
                 display = parseDisplay(doc["display"] as? Map<*, *>),
                 enabled = enabled,
-                reportSafeState = reportSafeState
+                reportSafeState = reportSafeState,
+                impliesFlags = (doc["implies_flags"] as? List<*>)?.map { it.toString() } ?: emptyList()
             )
         } catch (e: SigmaRuleParseException) {
             throw e

--- a/app/src/main/res/raw/sigma_androdr_001_package_ioc.yml
+++ b/app/src/main/res/raw/sigma_androdr_001_package_ioc.yml
@@ -25,3 +25,5 @@ display:
     guidance: "UNINSTALL IMMEDIATELY -- matches known malware signatures"
 remediation:
     - "Uninstall this app immediately."
+implies_flags:
+    - known_malware

--- a/app/src/main/res/raw/sigma_androdr_002_cert_hash_ioc.yml
+++ b/app/src/main/res/raw/sigma_androdr_002_cert_hash_ioc.yml
@@ -31,3 +31,5 @@ display:
     guidance: "UNINSTALL IMMEDIATELY -- signed by a known threat developer"
 remediation:
     - "This app is signed by a known threat developer. Uninstall it even if the name looks legitimate."
+implies_flags:
+    - known_malware

--- a/app/src/main/res/raw/sigma_androdr_004_apk_hash_ioc.yml
+++ b/app/src/main/res/raw/sigma_androdr_004_apk_hash_ioc.yml
@@ -25,3 +25,5 @@ display:
     guidance: "UNINSTALL IMMEDIATELY -- file hash matches known malware sample"
 remediation:
     - "This app's file hash matches a known malware sample. Uninstall it immediately: go to Settings > Apps > find the app > Uninstall."
+implies_flags:
+    - known_malware

--- a/app/src/main/res/raw/sigma_androdr_010_sideloaded_app.yml
+++ b/app/src/main/res/raw/sigma_androdr_010_sideloaded_app.yml
@@ -27,3 +27,5 @@ display:
     guidance: "REVIEW -- sideloaded app with elevated permissions; verify intentional"
 remediation:
     - "This app was not installed from a trusted app store. Verify you intended to install it."
+implies_flags:
+    - sideloaded

--- a/app/src/main/res/raw/sigma_androdr_011_surveillance_permissions.yml
+++ b/app/src/main/res/raw/sigma_androdr_011_surveillance_permissions.yml
@@ -31,3 +31,5 @@ display:
     guidance: "REVIEW -- app has extensive surveillance capabilities"
 remediation:
     - "This app has extensive surveillance capabilities. If you did not install it intentionally, uninstall it."
+implies_flags:
+    - sideloaded

--- a/app/src/main/res/raw/sigma_androdr_012_accessibility_abuse.yml
+++ b/app/src/main/res/raw/sigma_androdr_012_accessibility_abuse.yml
@@ -27,3 +27,5 @@ display:
     guidance: "UNINSTALL -- accessibility service abuse indicates stalkerware"
 remediation:
     - "This app can read your screen content. Go to Settings > Accessibility and disable its service before uninstalling."
+implies_flags:
+    - sideloaded

--- a/app/src/main/res/raw/sigma_androdr_013_device_admin_abuse.yml
+++ b/app/src/main/res/raw/sigma_androdr_013_device_admin_abuse.yml
@@ -27,3 +27,5 @@ display:
     guidance: "UNINSTALL -- device admin abuse indicates stalkerware; revoke admin first"
 remediation:
     - "Go to Settings > Security > Device Admin Apps and remove this app first, then uninstall."
+implies_flags:
+    - sideloaded

--- a/app/src/main/res/raw/sigma_androdr_014_app_impersonation.yml
+++ b/app/src/main/res/raw/sigma_androdr_014_app_impersonation.yml
@@ -25,3 +25,5 @@ display:
     guidance: "UNINSTALL -- impersonates a legitimate app; likely malicious"
 remediation:
     - "This app impersonates a well-known app but was not installed from a trusted store."
+implies_flags:
+    - sideloaded

--- a/app/src/main/res/raw/sigma_androdr_016_system_name_disguise.yml
+++ b/app/src/main/res/raw/sigma_androdr_016_system_name_disguise.yml
@@ -34,3 +34,5 @@ falsepositives:
 remediation:
     - "This app's name impersonates a system component but was installed from an untrusted source."
     - "Uninstall it unless you specifically installed it."
+implies_flags:
+    - sideloaded

--- a/app/src/main/res/raw/sigma_androdr_017_accessibility_surveillance_combo.yml
+++ b/app/src/main/res/raw/sigma_androdr_017_accessibility_surveillance_combo.yml
@@ -31,3 +31,5 @@ display:
 remediation:
     - "This app combines screen reading with surveillance permissions."
     - "Disable its accessibility service in Settings, then uninstall."
+implies_flags:
+    - sideloaded

--- a/app/src/main/res/raw/sigma_androdr_067_notification_listener.yml
+++ b/app/src/main/res/raw/sigma_androdr_067_notification_listener.yml
@@ -29,3 +29,5 @@ remediation:
     - "This sideloaded app can read all your notifications, including banking codes and 2FA messages."
     - "Go to Settings > Apps > Special access > Notification access and revoke this app's access."
     - "If you did not install this app intentionally, uninstall it immediately."
+implies_flags:
+    - sideloaded

--- a/app/src/main/res/raw/sigma_androdr_068_hidden_launcher.yml
+++ b/app/src/main/res/raw/sigma_androdr_068_hidden_launcher.yml
@@ -33,3 +33,5 @@ remediation:
     - "This app is installed but hidden from your home screen -- you cannot see or open it normally."
     - "Go to Settings > Apps > See all apps to find it, then tap Uninstall."
     - "Hidden apps are a common sign of stalkerware or monitoring software."
+implies_flags:
+    - sideloaded

--- a/app/src/main/res/raw/sigma_androdr_069_overlay_permission.yml
+++ b/app/src/main/res/raw/sigma_androdr_069_overlay_permission.yml
@@ -32,3 +32,5 @@ display:
     evidence_type: none
 remediation:
     - "This sideloaded app can draw over other apps, which is used by banking trojans to steal passwords. Go to Settings > Apps > Special access > Display over other apps and revoke its permission, then uninstall the app."
+implies_flags:
+    - sideloaded

--- a/app/src/main/res/raw/sigma_androdr_077_popular_app_impersonation.yml
+++ b/app/src/main/res/raw/sigma_androdr_077_popular_app_impersonation.yml
@@ -45,3 +45,5 @@ display:
     evidence_type: none
 remediation:
     - "This sideloaded app uses a package name that imitates a well-known app. It is likely a fake or trojanized version. Uninstall it from Settings > Apps and install the legitimate version from Google Play Store."
+implies_flags:
+    - sideloaded

--- a/app/src/main/res/raw/sigma_androdr_078_meiya_pico_forensics.yml
+++ b/app/src/main/res/raw/sigma_androdr_078_meiya_pico_forensics.yml
@@ -44,3 +44,5 @@ remediation:
     - "Massistant is a mobile forensic client used by Chinese law enforcement to extract data from seized devices."
     - "If you did not install this app yourself, your device may have been accessed without your knowledge. Seek advice from a digital security trainer or a relevant civil-society organization."
     - "Uninstall the app: Settings > Apps > find 'APKToolPlus' or 'Massistant' > Uninstall."
+implies_flags:
+    - known_malware

--- a/app/src/test/java/com/androdr/reporting/ReportFormatterTest.kt
+++ b/app/src/test/java/com/androdr/reporting/ReportFormatterTest.kt
@@ -3,6 +3,7 @@ package com.androdr.reporting
 import com.androdr.data.model.ScanResult
 import com.androdr.sigma.Finding
 import com.androdr.sigma.FindingCategory
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -32,17 +33,37 @@ class ReportFormatterTest {
         category = FindingCategory.APP_RISK,
         triggered = true,
         guidance = "UNINSTALL IMMEDIATELY -- matches known malware signatures",
-        matchContext = mapOf("package_name" to "com.evil.spy", "app_name" to "EvilSpy")
+        matchContext = mapOf("package_name" to "com.evil.spy", "app_name" to "EvilSpy"),
+        impliesFlags = listOf("known_malware")
     )
 
     private val sideloadFinding = Finding(
         ruleId = "androdr-010",
-        title = "Sideloaded App",
+        title = "Sideloaded Application",
         level = "high",
         category = FindingCategory.APP_RISK,
         triggered = true,
         guidance = "REVIEW -- sideloaded app with elevated permissions; verify intentional",
-        matchContext = mapOf("package_name" to "com.unknown.app")
+        matchContext = mapOf(
+            "package_name" to "com.unknown.app",
+            "is_sideloaded" to "true"
+        ),
+        impliesFlags = listOf("sideloaded")
+    )
+
+    private val impersonationFinding = Finding(
+        ruleId = "androdr-014",
+        title = "App Impersonation",
+        level = "high",
+        category = FindingCategory.APP_RISK,
+        triggered = true,
+        guidance = "UNINSTALL -- impersonates a legitimate app; likely malicious",
+        matchContext = mapOf(
+            "package_name" to "org.telegram.messenger",
+            "app_name" to "Telegram",
+            "is_sideloaded" to "true"
+        ),
+        impliesFlags = listOf("sideloaded")
     )
 
     private val deviceFinding = Finding(
@@ -178,5 +199,66 @@ class ReportFormatterTest {
     fun `format version line is present`() {
         val text = ReportFormatter.formatScanReport(cleanScan, emptyList(), emptyList(), versionName = "test")
         assertTrue(text.contains("Format    : v${ReportExporter.EXPORT_FORMAT_VERSION}"))
+    }
+
+    // -- Flag aggregation tests (issue #205) ----------------------------------
+
+    @Test
+    fun `impersonation finding alone renders Sideloaded flag via impliesFlags`() {
+        // Issue #205: FakeTelegram (org.telegram.messenger spoof) fires
+        // androdr-014 but NOT androdr-010, because the sideload rule's
+        // filter_known_good suppresses it for known-popular package names.
+        // The Sideloaded flag must still surface from the impersonation
+        // rule's own implies_flags declaration.
+        val scan = buildScan(appRisks = listOf(impersonationFinding))
+        val text = ReportFormatter.formatScanReport(scan, emptyList(), emptyList(), versionName = "test")
+        assertTrue("Flags line should appear", text.contains("Flags   :"))
+        assertTrue("Sideloaded flag must render", text.contains("Flags   : Sideloaded"))
+    }
+
+    @Test
+    fun `sideload and impersonation findings both fire — Sideloaded flag not duplicated`() {
+        val both = listOf(sideloadFinding, impersonationFinding.copy(
+            matchContext = impersonationFinding.matchContext + ("package_name" to "com.unknown.app")
+        ))
+        val scan = buildScan(appRisks = both)
+        val text = ReportFormatter.formatScanReport(scan, emptyList(), emptyList(), versionName = "test")
+        val flagsLine = text.lineSequence().first { it.trimStart().startsWith("Flags   :") }
+        assertEquals("Flags   : Sideloaded", flagsLine.trim())
+    }
+
+    @Test
+    fun `known malware finding renders Known Malware flag via impliesFlags`() {
+        val scan = buildScan(appRisks = listOf(malwareFinding), knownMalwareCount = 1)
+        val text = ReportFormatter.formatScanReport(scan, emptyList(), emptyList(), versionName = "test")
+        assertTrue("Known Malware flag must render",
+            text.contains("Flags   : [!] Known Malware"))
+    }
+
+    @Test
+    fun `malware plus sideload renders both flags`() {
+        val both = listOf(malwareFinding.copy(
+            matchContext = mapOf("package_name" to "com.unknown.app")
+        ), sideloadFinding)
+        val scan = buildScan(appRisks = both, knownMalwareCount = 1, riskySideloadCount = 1)
+        val text = ReportFormatter.formatScanReport(scan, emptyList(), emptyList(), versionName = "test")
+        assertTrue("Both flags must render",
+            text.contains("Flags   : [!] Known Malware / Sideloaded"))
+    }
+
+    @Test
+    fun `finding with no impliesFlags produces no Flags line`() {
+        val orphan = Finding(
+            ruleId = "androdr-999",
+            title = "Some Other Finding",
+            level = "medium",
+            category = FindingCategory.APP_RISK,
+            triggered = true,
+            matchContext = mapOf("package_name" to "com.orphan.app")
+            // impliesFlags defaults to empty
+        )
+        val scan = buildScan(appRisks = listOf(orphan))
+        val text = ReportFormatter.formatScanReport(scan, emptyList(), emptyList(), versionName = "test")
+        assertFalse("No Flags line expected when no implies_flags", text.contains("Flags   :"))
     }
 }

--- a/app/src/test/java/com/androdr/sigma/BundledRulesSchemaCrossCheckTest.kt
+++ b/app/src/test/java/com/androdr/sigma/BundledRulesSchemaCrossCheckTest.kt
@@ -188,74 +188,74 @@ class BundledRulesSchemaCrossCheckTest {
     @Test
     fun `rules declaring implies_flags sideloaded structurally guarantee it`() {
         val yamlLoader = Load(
-            LoadSettings.builder()
-                .setMaxAliasesForCollections(10)
-                .setAllowDuplicateKeys(false)
-                .build()
+            LoadSettings.builder().setMaxAliasesForCollections(10).setAllowDuplicateKeys(false).build()
         )
-
-        val violations = mutableListOf<String>()
-
-        detectionAndAtomRuleFiles().forEach { file ->
+        val violations = detectionAndAtomRuleFiles().mapNotNull { file ->
             @Suppress("UNCHECKED_CAST")
-            val doc = yamlLoader.loadFromString(file.readText()) as? Map<String, Any?> ?: return@forEach
-            val implies = (doc["implies_flags"] as? List<*>)?.map { it.toString() } ?: return@forEach
-            if ("sideloaded" !in implies) return@forEach
-
-            @Suppress("UNCHECKED_CAST")
-            val detection = doc["detection"] as? Map<String, Any?> ?: return@forEach
-            val condition = (detection["condition"] as? String) ?: ""
-
-            // Tripwire: bail out if condition uses parens — tokenizer below
-            // assumes flat conditions and can silently misclassify negation
-            // inside parens.
-            if ("(" in condition || ")" in condition) {
-                violations += "${file.name}: condition contains parentheses, " +
-                    "which this structural gate does not parse correctly. " +
-                    "Either refactor the rule's condition to a flat form " +
-                    "or extend the test with a proper boolean-expression parser."
-                return@forEach
-            }
-
-            // Tokenize: split on whitespace, lowercased, group block refs by polarity.
-            val tokens = condition.lowercase().split(Regex("\\s+")).filter { it.isNotEmpty() }
-            val positiveRefs = mutableSetOf<String>()
-            val negativeRefs = mutableSetOf<String>()
-            var negate = false
-            for (tok in tokens) {
-                when (tok) {
-                    "and", "or" -> negate = false
-                    "not" -> negate = true
-                    else -> {
-                        if (negate) negativeRefs.add(tok) else positiveRefs.add(tok)
-                        negate = false
-                    }
-                }
-            }
-
-            val sideloadEvidence = positiveRefs.any { name ->
-                @Suppress("UNCHECKED_CAST")
-                val block = detection[name] as? Map<String, Any?> ?: return@any false
-                (block["from_trusted_store"] == false) || (block["is_sideloaded"] == true)
-            } || negativeRefs.any { name ->
-                @Suppress("UNCHECKED_CAST")
-                val block = detection[name] as? Map<String, Any?> ?: return@any false
-                (block["from_trusted_store"] == true) || (block["is_sideloaded"] == false)
-            }
-
-            if (!sideloadEvidence) {
-                violations += "${file.name}: declares `implies_flags: [sideloaded]` but no detection clause " +
-                    "establishes it. Need either a positive block with `from_trusted_store: false` / " +
-                    "`is_sideloaded: true`, or a negated block (`not <name>` in condition) with " +
-                    "`from_trusted_store: true` / `is_sideloaded: false`."
-            }
+            val doc = yamlLoader.loadFromString(file.readText()) as? Map<String, Any?>
+                ?: return@mapNotNull null
+            val implies = (doc["implies_flags"] as? List<*>)?.map { it.toString() } ?: return@mapNotNull null
+            if ("sideloaded" !in implies) return@mapNotNull null
+            sideloadedStructuralViolation(file.name, doc)
         }
-
         if (violations.isNotEmpty()) {
             fail(
                 "implies_flags structural-guarantee gate FAILED for ${violations.size} rule(s):\n" +
                     violations.joinToString("\n") { "  - $it" }
             )
         }
+    }
+
+    private fun sideloadedStructuralViolation(fileName: String, doc: Map<String, Any?>): String? {
+        @Suppress("UNCHECKED_CAST")
+        val detection = doc["detection"] as? Map<String, Any?> ?: return null
+        val condition = (detection["condition"] as? String) ?: ""
+
+        // Tripwire: parens not supported by flat-condition tokenizer below.
+        if ("(" in condition || ")" in condition) {
+            return "$fileName: condition contains parentheses, which this structural " +
+                "gate does not parse correctly. Refactor to a flat condition or " +
+                "extend the test with a proper boolean-expression parser."
+        }
+
+        val (positive, negative) = tokenizeFlatCondition(condition)
+        val sideloadEvidence = positive.any { name -> blockEstablishesSideload(detection, name, negated = false) } ||
+            negative.any { name -> blockEstablishesSideload(detection, name, negated = true) }
+        return if (sideloadEvidence) null
+        else "$fileName: declares `implies_flags: [sideloaded]` but no detection clause " +
+            "establishes it. Need either a positive block with `from_trusted_store: false` / " +
+            "`is_sideloaded: true`, or a negated block (`not <name>` in condition) with " +
+            "`from_trusted_store: true` / `is_sideloaded: false`."
+    }
+
+    /** Split a flat SIGMA condition string into (positively-referenced, negatively-referenced) block names. */
+    private fun tokenizeFlatCondition(condition: String): Pair<Set<String>, Set<String>> {
+        val tokens = condition.lowercase().split(Regex("\\s+")).filter { it.isNotEmpty() }
+        val pos = mutableSetOf<String>()
+        val neg = mutableSetOf<String>()
+        var negate = false
+        for (tok in tokens) when (tok) {
+            "and", "or" -> negate = false
+            "not" -> negate = true
+            else -> { if (negate) neg.add(tok) else pos.add(tok); negate = false }
+        }
+        return pos to neg
+    }
+
+    /**
+     * True iff the named detection block, considered with its polarity in the condition,
+     * establishes the sideloaded property:
+     *   positive: block has `from_trusted_store: false` or `is_sideloaded: true`
+     *   negated:  block has `from_trusted_store: true` or `is_sideloaded: false`
+     */
+    private fun blockEstablishesSideload(
+        detection: Map<String, Any?>, name: String, negated: Boolean
+    ): Boolean {
+        @Suppress("UNCHECKED_CAST")
+        val block = detection[name] as? Map<String, Any?> ?: return false
+        val trustedExpected = if (negated) true else false
+        val sideloadedExpected = if (negated) false else true
+        return (block["from_trusted_store"] == trustedExpected) ||
+            (block["is_sideloaded"] == sideloadedExpected)
     }
 }

--- a/app/src/test/java/com/androdr/sigma/BundledRulesSchemaCrossCheckTest.kt
+++ b/app/src/test/java/com/androdr/sigma/BundledRulesSchemaCrossCheckTest.kt
@@ -154,4 +154,108 @@ class BundledRulesSchemaCrossCheckTest {
             )
         }
     }
+
+    /**
+     * Defense in depth: a rule's `implies_flags: [sideloaded]` only carries the
+     * intended guarantee if the rule's detection actually conditions on the app
+     * being sideloaded. Two structural patterns satisfy this:
+     *
+     *   1. A block referenced positively in `condition` declares
+     *      `from_trusted_store: false` or `is_sideloaded: true`
+     *
+     *   2. A block referenced negatively (`not <name>`) in `condition` declares
+     *      `from_trusted_store: true` or `is_sideloaded: false`
+     *      (the negation makes the property hold)
+     *
+     * Without this gate, a rule author could add the annotation to a rule that
+     * fires on Play Store apps and the Flag would silently lie.
+     *
+     * Asymmetry note: there is no parallel gate for `implies_flags: [known_malware]`.
+     * That annotation is semantic ("this rule's detection corpus is a curated
+     * malware database") and doesn't have a single structural signature — IOC
+     * lookups (`|ioc_lookup`) and exact-literal package-name matches (e.g. -078)
+     * are both valid. Adding a known_malware gate without false negatives would
+     * require a more sophisticated heuristic; deferred.
+     *
+     * Tokenizer scope: the condition parser below handles flat conditions
+     * (`a and not b and not c`, `a or b`). It does NOT correctly handle
+     * parenthesized negation like `not (filter_a or filter_b)` — after paren
+     * stripping the inner `or` would reset the negation state. The bundled
+     * corpus has no such conditions today; the loop at the end asserts this
+     * so a future rule introducing parens trips the test rather than silently
+     * mis-classifying.
+     */
+    @Test
+    fun `rules declaring implies_flags sideloaded structurally guarantee it`() {
+        val yamlLoader = Load(
+            LoadSettings.builder()
+                .setMaxAliasesForCollections(10)
+                .setAllowDuplicateKeys(false)
+                .build()
+        )
+
+        val violations = mutableListOf<String>()
+
+        detectionAndAtomRuleFiles().forEach { file ->
+            @Suppress("UNCHECKED_CAST")
+            val doc = yamlLoader.loadFromString(file.readText()) as? Map<String, Any?> ?: return@forEach
+            val implies = (doc["implies_flags"] as? List<*>)?.map { it.toString() } ?: return@forEach
+            if ("sideloaded" !in implies) return@forEach
+
+            @Suppress("UNCHECKED_CAST")
+            val detection = doc["detection"] as? Map<String, Any?> ?: return@forEach
+            val condition = (detection["condition"] as? String) ?: ""
+
+            // Tripwire: bail out if condition uses parens — tokenizer below
+            // assumes flat conditions and can silently misclassify negation
+            // inside parens.
+            if ("(" in condition || ")" in condition) {
+                violations += "${file.name}: condition contains parentheses, " +
+                    "which this structural gate does not parse correctly. " +
+                    "Either refactor the rule's condition to a flat form " +
+                    "or extend the test with a proper boolean-expression parser."
+                return@forEach
+            }
+
+            // Tokenize: split on whitespace, lowercased, group block refs by polarity.
+            val tokens = condition.lowercase().split(Regex("\\s+")).filter { it.isNotEmpty() }
+            val positiveRefs = mutableSetOf<String>()
+            val negativeRefs = mutableSetOf<String>()
+            var negate = false
+            for (tok in tokens) {
+                when (tok) {
+                    "and", "or" -> negate = false
+                    "not" -> negate = true
+                    else -> {
+                        if (negate) negativeRefs.add(tok) else positiveRefs.add(tok)
+                        negate = false
+                    }
+                }
+            }
+
+            val sideloadEvidence = positiveRefs.any { name ->
+                @Suppress("UNCHECKED_CAST")
+                val block = detection[name] as? Map<String, Any?> ?: return@any false
+                (block["from_trusted_store"] == false) || (block["is_sideloaded"] == true)
+            } || negativeRefs.any { name ->
+                @Suppress("UNCHECKED_CAST")
+                val block = detection[name] as? Map<String, Any?> ?: return@any false
+                (block["from_trusted_store"] == true) || (block["is_sideloaded"] == false)
+            }
+
+            if (!sideloadEvidence) {
+                violations += "${file.name}: declares `implies_flags: [sideloaded]` but no detection clause " +
+                    "establishes it. Need either a positive block with `from_trusted_store: false` / " +
+                    "`is_sideloaded: true`, or a negated block (`not <name>` in condition) with " +
+                    "`from_trusted_store: true` / `is_sideloaded: false`."
+            }
+        }
+
+        if (violations.isNotEmpty()) {
+            fail(
+                "implies_flags structural-guarantee gate FAILED for ${violations.size} rule(s):\n" +
+                    violations.joinToString("\n") { "  - $it" }
+            )
+        }
+    }
 }

--- a/app/src/test/java/com/androdr/sigma/SigmaRuleParserTest.kt
+++ b/app/src/test/java/com/androdr/sigma/SigmaRuleParserTest.kt
@@ -233,4 +233,49 @@ class SigmaRuleParserTest {
         assertEquals("attack.t1036", rule.tags[0])
         assertEquals(1, rule.falsepositives.size)
     }
+
+    @Test
+    fun `parses implies_flags as a list of strings`() {
+        val yaml = """
+            title: Implies sideloaded
+            id: test-005
+            category: incident
+            logsource:
+                product: androdr
+                service: app_scanner
+            detection:
+                selection:
+                    is_sideloaded: true
+                condition: selection
+            level: medium
+            implies_flags:
+                - sideloaded
+                - known_malware
+        """.trimIndent()
+
+        val rule = SigmaRuleParser.parse(yaml)
+        assertNotNull(rule)
+        assertEquals(listOf("sideloaded", "known_malware"), rule!!.impliesFlags)
+    }
+
+    @Test
+    fun `implies_flags defaults to empty list when absent`() {
+        val yaml = """
+            title: No implications declared
+            id: test-006
+            category: incident
+            logsource:
+                product: androdr
+                service: app_scanner
+            detection:
+                selection:
+                    is_sideloaded: true
+                condition: selection
+            level: medium
+        """.trimIndent()
+
+        val rule = SigmaRuleParser.parse(yaml)
+        assertNotNull(rule)
+        assertTrue(rule!!.impliesFlags.isEmpty())
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #205 — App-Impersonation findings on package-name spoofs (e.g. FakeTelegram on `org.telegram.messenger`) no longer hide the Sideloaded flag.

The formatter previously encoded "is this app sideloaded?" as "did rule `androdr-010` fire?". For known-popular package names, `androdr-010`'s `filter_known_good` correctly suppresses the rule (to avoid nagging on legitimate F-Droid installs) — but that suppression also hid the sideload signal on impersonator findings where the only rule that fires is `androdr-014` (App Impersonation).

The same rule-ID-as-semantic-fact smell existed for the `[!] Known Malware` flag (`startsWith("androdr-00")`), and disagreed with `ScanOrchestrator.kt`'s parallel `KNOWN_MALWARE_RULE_IDS = setOf("androdr-001", "androdr-002")` — two definitions, different rule sets.

## Approach

Each rule declares the subject-level properties its detection structurally guarantees via a new top-level `implies_flags` YAML field. The formatter aggregates `findings.flatMap { it.impliesFlags }.toSet()` instead of inspecting rule IDs.

Schema PR (merged): https://github.com/android-sigma-rules/rules/pull/28

## This PR (consumer side)

| File | Change |
|---|---|
| `SigmaRule.kt` | +`impliesFlags: List<String> = emptyList()` |
| `SigmaRuleParser.kt` | parse `implies_flags` YAML |
| `SigmaRuleEvaluator.kt` | Finding carries `impliesFlags`; `buildFinding` propagates `rule.impliesFlags` |
| `ReportFormatter.kt:482-487` | derive Flag chips from `findings.flatMap { it.impliesFlags }.toSet()` |
| `ScanOrchestrator.kt` | `malwareCount` derived from impliesFlags; `KNOWN_MALWARE_RULE_IDS` constant deleted |
| 15 bundled rule YAMLs | annotated (see below) |
| Tests | +5 ReportFormatterTest, +2 SigmaRuleParserTest, +1 BundledRulesSchemaCrossCheckTest structural gate |

### Bundled rule annotations

- `[sideloaded]` — `androdr-010, -011, -012, -013, -014, -016, -017, -067, -068, -069, -077`
- `[known_malware]` — `androdr-001, -002, -004, -078`

Not annotated (intentional): DNS rules `-003`/`-005` (no app subject per schema policy); `-015` (system-app, not sideloaded); `-083` (broker SDKs ship in legitimate Play Store apps too — selection doesn't structurally guarantee sideload).

## Behavior change to call out

`knownMalwareCount` (the "X known malware" report-summary line) now counts `androdr-004` (APK hash IOC) and `androdr-078` (Massistant forensics tool) in addition to `-001`/`-002`. Both are strictly more correct than the previous 2-rule definition — they are confirmed-known-malicious matches by construction. The old `ReportFormatter.kt:481` `startsWith("androdr-00")` heuristic and the old `KNOWN_MALWARE_RULE_IDS = setOf("androdr-001", "androdr-002")` already disagreed; this unifies them.

## Defense in depth

`BundledRulesSchemaCrossCheckTest.rules declaring implies_flags sideloaded structurally guarantee it` is a new gate: any rule declaring `implies_flags: [sideloaded]` must have either a positive selection block with `from_trusted_store: false` / `is_sideloaded: true`, or a negated filter clause (`not <name>` in condition where the named block has `from_trusted_store: true` / `is_sideloaded: false`). Catches the false-positive failure mode where a rule author adds the annotation to a rule that fires on Play Store apps and the chip silently lies.

The condition tokenizer is intentionally flat-only; a paren tripwire (`if "(" in condition`) fails the test fast if a future rule introduces parenthesized negation, rather than silently misclassifying.

## Test plan

- [x] `./gradlew testDebugUnitTest lintDebug :app:detekt` — green
- [x] On-device verification on `Medium_Phone_API_36.1` (API 36): surveillance-permissions fixture installed via `pm install -i com.androdr.debug`. Three sideloaded-implying rules fire (`-010 -011 -068`); `Flags : Sideloaded` chip renders once (dedup via `toSet()`).
- [x] Two-reviewer cycle (code-reviewer + architecture-review) — addressed asymmetric-gate comment, paren-tripwire, unchecked cast.
- [x] Submodule schema PR merged before this PR was opened.

## Follow-up

#209 — teach the `/update-rules-author` skill about `implies_flags` so future AI-generated rules carry the annotation by default. Without this, new rules pass schema validation but silently miss the Flag rendering.

Closes #205

🤖 Generated with [Claude Code](https://claude.com/claude-code)