### PR TITLE
feat(scan): run a full threat-intel refresh before a manual scan

### DIFF
--- a/app/src/main/java/com/androdr/ioc/IntelRefresher.kt
+++ b/app/src/main/java/com/androdr/ioc/IntelRefresher.kt
@@ -1,0 +1,130 @@
+package com.androdr.ioc
+
+import android.util.Log
+import com.androdr.data.repo.CveRepository
+import com.androdr.sigma.SigmaRuleEngine
+import com.androdr.sigma.SigmaRuleFeed
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Runs the full threat-intel refresh sequence shared by the periodic
+ * [IocUpdateWorker] (every 12h) and the manual pre-scan refresh in
+ * DashboardViewModel.
+ *
+ * Each step is independently fault-tolerant: a single feed failure is logged,
+ * not propagated, so a partial outage still updates the feeds that succeeded.
+ * This class deliberately does NOT prune old data — pruning stays in the
+ * periodic worker so it isn't run on every user-initiated scan.
+ */
+@Singleton
+@Suppress("LongParameterList") // All parameters are Hilt-injected dependencies
+class IntelRefresher @Inject constructor(
+    private val indicatorUpdater: IndicatorUpdater,
+    private val knownAppUpdater: KnownAppUpdater,
+    private val publicRepoIocFeed: PublicRepoIocFeed,
+    private val knownAppResolver: KnownAppResolver,
+    private val oemPrefixResolver: OemPrefixResolver,
+    private val sigmaRuleFeed: SigmaRuleFeed,
+    private val sigmaRuleEngine: SigmaRuleEngine,
+    private val cveRepository: CveRepository
+) {
+
+    private val refreshMutex = Mutex()
+
+    @Volatile
+    private var lastRefreshAt = 0L
+
+    /**
+     * Refreshes every threat-intel feed (bulk IOC feeds, the curated public
+     * rule-repo IOCs, OEM prefixes, SIGMA rules, and CVEs). Returns the IOC
+     * entry count reported by the bulk feed updaters. Safe to call from any
+     * coroutine context.
+     *
+     * Single-flighted via [refreshMutex]: at most one refresh runs at a time.
+     * A caller that arrives while another refresh is in flight **waits** for it
+     * (so e.g. a manual pre-scan refresh blocks the scan until fresh intel has
+     * landed) rather than racing ahead with stale data.
+     *
+     * @param skipIfRefreshedWithinMs once the lock is acquired, if a refresh
+     * completed less than this long ago, skip the work and return 0 — the data
+     * is already fresh, so there's no point re-downloading the same ~6–8 MB.
+     * This is what makes the "wait for the in-flight refresh, then don't redo
+     * it" path cheap. Pass 0 to always refresh.
+     */
+    suspend fun refreshAll(skipIfRefreshedWithinMs: Long = 0L): Int = refreshMutex.withLock {
+        val now = System.currentTimeMillis()
+        if (skipIfRefreshedWithinMs > 0L && lastRefreshAt != 0L &&
+            now - lastRefreshAt < skipIfRefreshedWithinMs
+        ) {
+            Log.i(TAG, "Intel refreshed ${(now - lastRefreshAt) / 1000}s ago — reusing, skipping refresh")
+            return@withLock 0
+        }
+        val fetched = runBulkUpdaters()
+        refreshPublicRepoIoc()
+        refreshOemPrefixes()
+        refreshSigmaRules()
+        refreshCveDatabase()
+        lastRefreshAt = System.currentTimeMillis()
+        fetched
+    }
+
+    private suspend fun runBulkUpdaters(): Int = coroutineScope {
+        val indicators = async { indicatorUpdater.update() }
+        val knownApps = async { knownAppUpdater.update() }
+        indicators.await() + knownApps.await()
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    private suspend fun refreshPublicRepoIoc() {
+        try {
+            val count = publicRepoIocFeed.update()
+            if (count > 0) {
+                Log.i(TAG, "Public repo IOC feed: $count entries loaded")
+                knownAppResolver.refreshCache()
+            }
+        } catch (e: Exception) {
+            Log.w(TAG, "Public repo IOC feed failed (non-fatal): ${e.message}")
+        }
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    private suspend fun refreshOemPrefixes() {
+        try {
+            oemPrefixResolver.refresh()
+        } catch (e: Exception) {
+            Log.w(TAG, "OEM prefix refresh failed (non-fatal): ${e.message}")
+        }
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    private suspend fun refreshSigmaRules() {
+        try {
+            val remoteRules = sigmaRuleFeed.fetch()
+            if (remoteRules.isNotEmpty()) {
+                sigmaRuleEngine.setRemoteRules(remoteRules)
+                Log.i(TAG, "SIGMA rules refreshed: ${remoteRules.size} remote rules loaded")
+            }
+        } catch (e: Exception) {
+            Log.w(TAG, "SIGMA rule refresh failed: ${e.message}")
+        }
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    private suspend fun refreshCveDatabase() {
+        try {
+            cveRepository.refresh()
+            Log.i(TAG, "CVE database refreshed: ${cveRepository.getActivelyExploitedCount()} Android CVEs")
+        } catch (e: Exception) {
+            Log.w(TAG, "CVE database refresh failed (non-fatal): ${e.message}")
+        }
+    }
+
+    companion object {
+        private const val TAG = "IntelRefresher"
+    }
+}

--- a/app/src/main/java/com/androdr/ioc/IocUpdateWorker.kt
+++ b/app/src/main/java/com/androdr/ioc/IocUpdateWorker.kt
@@ -8,26 +8,15 @@ import androidx.work.WorkerParameters
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import com.androdr.data.db.ForensicTimelineEventDao
-import com.androdr.data.repo.CveRepository
 import com.androdr.data.repo.ScanRepository
 import com.androdr.sigma.SigmaRuleEngine
-import com.androdr.sigma.SigmaRuleFeed
-import kotlinx.coroutines.async
-import kotlinx.coroutines.coroutineScope
 
 @HiltWorker
-@Suppress("LongParameterList") // All parameters are Hilt-injected dependencies
 class IocUpdateWorker @AssistedInject constructor(
     @Assisted context: Context,
     @Assisted params: WorkerParameters,
-    private val indicatorUpdater: IndicatorUpdater,
-    private val knownAppUpdater: KnownAppUpdater,
-    private val publicRepoIocFeed: PublicRepoIocFeed,
-    private val knownAppResolver: KnownAppResolver,
-    private val oemPrefixResolver: OemPrefixResolver,
-    private val sigmaRuleFeed: SigmaRuleFeed,
+    private val intelRefresher: IntelRefresher,
     private val sigmaRuleEngine: SigmaRuleEngine,
-    private val cveRepository: CveRepository,
     private val scanRepository: ScanRepository,
     private val forensicTimelineEventDao: ForensicTimelineEventDao
 ) : CoroutineWorker(context, params) {
@@ -35,11 +24,7 @@ class IocUpdateWorker @AssistedInject constructor(
     @Suppress("TooGenericExceptionCaught")
     override suspend fun doWork(): Result {
         return try {
-            val fetched = runAllUpdaters()
-            refreshPublicRepoIoc()
-            refreshOemPrefixes()
-            refreshSigmaRules()
-            refreshCveDatabase()
+            val fetched = intelRefresher.refreshAll(skipIfRefreshedWithinMs = RECENT_REFRESH_SKIP_MS)
             val thirtyDaysAgo = System.currentTimeMillis() - (30L * 24 * 60 * 60 * 1000)
             scanRepository.pruneOldDnsEvents(thirtyDaysAgo)
             forensicTimelineEventDao.deleteOlderThan(thirtyDaysAgo)
@@ -51,59 +36,16 @@ class IocUpdateWorker @AssistedInject constructor(
         }
     }
 
-    private suspend fun runAllUpdaters(): Int = coroutineScope {
-        val indicators = async { indicatorUpdater.update() }
-        val knownApps = async { knownAppUpdater.update() }
-        indicators.await() + knownApps.await()
-    }
-
-    @Suppress("TooGenericExceptionCaught")
-    private suspend fun refreshSigmaRules() {
-        try {
-            val remoteRules = sigmaRuleFeed.fetch()
-            if (remoteRules.isNotEmpty()) {
-                sigmaRuleEngine.setRemoteRules(remoteRules)
-                Log.i(TAG, "SIGMA rules refreshed: ${remoteRules.size} remote rules loaded")
-            }
-        } catch (e: Exception) {
-            Log.w(TAG, "SIGMA rule refresh failed: ${e.message}")
-        }
-    }
-
-    @Suppress("TooGenericExceptionCaught")
-    private suspend fun refreshCveDatabase() {
-        try {
-            cveRepository.refresh()
-            Log.i(TAG, "CVE database refreshed: ${cveRepository.getActivelyExploitedCount()} Android CVEs")
-        } catch (e: Exception) {
-            Log.w(TAG, "CVE database refresh failed (non-fatal): ${e.message}")
-        }
-    }
-
-    @Suppress("TooGenericExceptionCaught")
-    private suspend fun refreshPublicRepoIoc() {
-        try {
-            val count = publicRepoIocFeed.update()
-            if (count > 0) {
-                Log.i(TAG, "Public repo IOC feed: $count entries loaded")
-                knownAppResolver.refreshCache()
-            }
-        } catch (e: Exception) {
-            Log.w(TAG, "Public repo IOC feed failed (non-fatal): ${e.message}")
-        }
-    }
-
-    @Suppress("TooGenericExceptionCaught")
-    private suspend fun refreshOemPrefixes() {
-        try {
-            oemPrefixResolver.refresh()
-        } catch (e: Exception) {
-            Log.w(TAG, "OEM prefix refresh failed (non-fatal): ${e.message}")
-        }
-    }
-
     companion object {
         private const val TAG = "IocUpdateWorker"
         const val WORK_NAME = "ioc_periodic_update"
+
+        /**
+         * If a refresh (e.g. a manual pre-scan one) completed within this
+         * window, the periodic worker reuses it instead of re-downloading.
+         * The worker's real cadence is 12h, so this only ever suppresses a
+         * redundant back-to-back refresh.
+         */
+        private const val RECENT_REFRESH_SKIP_MS = 5L * 60 * 1000 // 5 minutes
     }
 }

--- a/app/src/main/java/com/androdr/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/com/androdr/ui/dashboard/DashboardScreen.kt
@@ -70,6 +70,7 @@ fun DashboardScreen(
 ) {
     val latestScan by viewModel.latestScan.collectAsStateWithLifecycle()
     val isScanning by viewModel.isScanning.collectAsStateWithLifecycle()
+    val isUpdatingIntel by viewModel.isUpdatingIntel.collectAsStateWithLifecycle()
     val scanProgress by viewModel.scanProgress.collectAsStateWithLifecycle()
     val scanDiff by viewModel.scanDiff.collectAsStateWithLifecycle()
     val matchedDnsCount by viewModel.matchedDnsCount.collectAsStateWithLifecycle()
@@ -185,7 +186,7 @@ fun DashboardScreen(
             // making forward progress. The old UX was a single spinning button
             // which gave no indication of stages or progress.
             if (isScanning) {
-                ScanProgressCard(progress = scanProgress)
+                ScanProgressCard(progress = scanProgress, isUpdatingIntel = isUpdatingIntel)
             } else {
                 Button(
                     onClick = { viewModel.runScan() },
@@ -496,16 +497,17 @@ private fun UsageAccessBanner(onOpenSettings: () -> Unit) {
  */
 @Suppress("LongMethod") // Compose UI function with sectioned rendering
 @Composable
-private fun ScanProgressCard(progress: ScanProgress) {
+private fun ScanProgressCard(progress: ScanProgress, isUpdatingIntel: Boolean = false) {
     val running = progress as? ScanProgress.Running
-    val stageText = when (running?.phase) {
-        ScanProgress.Running.Phase.COLLECTING_TELEMETRY ->
+    val stageText = when {
+        isUpdatingIntel -> stringResource(R.string.updating_intel)
+        running?.phase == ScanProgress.Running.Phase.COLLECTING_TELEMETRY ->
             stringResource(R.string.scan_phase_collecting)
-        ScanProgress.Running.Phase.EVALUATING_RULES ->
+        running?.phase == ScanProgress.Running.Phase.EVALUATING_RULES ->
             stringResource(R.string.scan_phase_evaluating)
-        ScanProgress.Running.Phase.SAVING_RESULTS ->
+        running?.phase == ScanProgress.Running.Phase.SAVING_RESULTS ->
             stringResource(R.string.scan_phase_saving)
-        null -> stringResource(R.string.scanning)
+        else -> stringResource(R.string.scanning)
     }
 
     Card(

--- a/app/src/main/java/com/androdr/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/com/androdr/ui/dashboard/DashboardViewModel.kt
@@ -7,8 +7,8 @@ import com.androdr.data.db.IndicatorDao
 import com.androdr.data.model.ScanResult
 import com.androdr.data.repo.ScanRepository
 import com.androdr.data.repo.ScanRepository.Companion.preferRuntimeScan
+import com.androdr.ioc.IntelRefresher
 import com.androdr.ioc.IocDatabase
-import com.androdr.ioc.IndicatorUpdater
 import com.androdr.scanner.ScanOrchestrator
 import com.androdr.scanner.ScanProgress
 import com.androdr.ui.permissions.UsageStatsPermission
@@ -32,7 +32,7 @@ class DashboardViewModel @Inject constructor(
     private val repository: ScanRepository,
     private val indicatorDao: IndicatorDao,
     private val iocDatabase: IocDatabase,
-    private val indicatorUpdater: IndicatorUpdater,
+    private val intelRefresher: IntelRefresher,
     @ApplicationContext private val context: Context
 ) : ViewModel() {
 
@@ -43,6 +43,15 @@ class DashboardViewModel @Inject constructor(
 
     private val _isScanning = MutableStateFlow(false)
     val isScanning: StateFlow<Boolean> = _isScanning.asStateFlow()
+
+    /**
+     * True while a scan is blocked on the pre-scan threat-intel refresh. Lets
+     * the Dashboard show "Updating threat intel…" instead of a generic
+     * "Scanning…" with a non-advancing bar during the (potentially ~30s)
+     * network refresh, so the scan doesn't look hung.
+     */
+    private val _isUpdatingIntel = MutableStateFlow(false)
+    val isUpdatingIntel: StateFlow<Boolean> = _isUpdatingIntel.asStateFlow()
 
     /**
      * Live scan progress published by the orchestrator. The Dashboard UI
@@ -106,10 +115,15 @@ class DashboardViewModel @Inject constructor(
             _isScanning.value = true
             try {
                 val isStale = _iocLastUpdated.value == null ||
-                    System.currentTimeMillis() - (_iocLastUpdated.value ?: 0L) > 24 * 60 * 60 * 1000L
+                    System.currentTimeMillis() - (_iocLastUpdated.value ?: 0L) > PRE_SCAN_REFRESH_THROTTLE_MS
                 val hasOnlyBundled = _iocEntryCount.value <= bundledCount
                 if (isStale || hasOnlyBundled) {
-                    doUpdate()
+                    _isUpdatingIntel.value = true
+                    try {
+                        doUpdate()
+                    } finally {
+                        _isUpdatingIntel.value = false
+                    }
                 }
                 orchestrator.runFullScan()
             } finally {
@@ -121,7 +135,7 @@ class DashboardViewModel @Inject constructor(
     @Suppress("TooGenericExceptionCaught")
     private suspend fun doUpdate() {
         try {
-            indicatorUpdater.update()
+            intelRefresher.refreshAll(skipIfRefreshedWithinMs = PRE_SCAN_REFRESH_THROTTLE_MS)
             refreshIocState()
             // Only warn if DB is still empty after update attempt (not just zero new entries)
             if (_iocEntryCount.value <= bundledCount) {
@@ -134,6 +148,16 @@ class DashboardViewModel @Inject constructor(
 
     private suspend fun refreshIocState() {
         _iocEntryCount.value = indicatorDao.count() + bundledCount
-        _iocLastUpdated.value = indicatorDao.lastFetchTime("stalkerware_indicators")
+        _iocLastUpdated.value = indicatorDao.lastFetchTimeGlobal()
+    }
+
+    companion object {
+        /**
+         * A manual scan refreshes threat intel first, but only if the last
+         * refresh is older than this. Prevents back-to-back full syncs
+         * (~6–8 MB each) on rapid re-scans while still giving a deliberate
+         * scan fresh intel. The background worker refreshes every 12h anyway.
+         */
+        private const val PRE_SCAN_REFRESH_THROTTLE_MS = 60L * 60 * 1000 // 1 hour
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,6 +10,7 @@
     <!-- Dashboard -->
     <string name="run_scan">Run Scan</string>
     <string name="scanning">Scanning…</string>
+    <string name="updating_intel">Updating threat intel…</string>
 
     <!-- Usage Access permission banner — shown when forensic timeline data is unavailable -->
     <string name="usage_access_banner_title">Enable Usage Access</string>


### PR DESCRIPTION
## Summary
A manual scan now freshens **all** threat intel before scanning, fixing two latent bugs in the existing pre-scan update:
1. It only called `indicatorUpdater.update()` — missing the curated public-repo IOCs, SIGMA rules, and CVEs.
2. Its 24h staleness gate effectively never fired (the background worker refreshes every 12h), so manual scans ran on stale intel.

## Changes
- **Shared `IntelRefresher`** (`@Singleton`): the periodic `IocUpdateWorker` and the pre-scan path now run *identical* refresh logic — no drift. Pruning stays worker-only.
- **Throttle fix**: `runScan()` now refreshes if intel is older than `PRE_SCAN_REFRESH_THROTTLE_MS` (1h), anchored on `IndicatorDao.lastFetchTimeGlobal()` (a single feed failing no longer wedges the throttle).
- **Single-flight refresh**: a caller arriving during an in-flight refresh **waits** for it (scan gets fresh data) then **reuses** it (`skipIfRefreshedWithinMs`) instead of re-downloading ~6–8 MB. Fixes a worker/pre-scan double-download race.
- **UX**: Dashboard shows "Updating threat intel…" during the pre-scan refresh so the scan doesn't look hung behind a non-advancing bar.

Per discussion: full refresh on any network, 1h throttle (no metered-network special-casing).

## Review & verification
- Two independent reviewers + a focused concurrency re-review of the mutex semantics — all clean.
- **On-device (SM-F916B, Android 13/API 33):** confirmed via logcat that the pre-scan full refresh runs first (450 public-repo IOCs + 24 SIGMA rules + 87 CVEs), the scan completes *after* fresh intel lands, the worker/pre-scan race no longer double-downloads (`reusing, skipping refresh`), and "Updating threat intel…" renders.
- `:app:testDebugUnitTest` passes; `compileDebugKotlin` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)