### PR TITLE
feat(rules): androdr-084 actively-exploited-CVE rule + 52 threat-intel IOCs

### DIFF
--- a/app/src/main/java/com/androdr/sigma/SigmaRuleEngine.kt
+++ b/app/src/main/java/com/androdr/sigma/SigmaRuleEngine.kt
@@ -351,6 +351,7 @@ class SigmaRuleEngine @Inject constructor(
             R.raw.sigma_androdr_081_data_broker_predicio,
             R.raw.sigma_androdr_082_data_broker_cuebiq,
             R.raw.sigma_androdr_083_broker_sdk_with_location_permission,
+            R.raw.sigma_androdr_084_actively_exploited_cve,
             // Atom rules — pass-through matchers for raw timeline event categories.
             // Referenced by sprint-75 correlation rules (Task 9); tagged
             // level: informational so they are filtered out of the user-facing

--- a/app/src/main/res/raw/sigma_androdr_084_actively_exploited_cve.yml
+++ b/app/src/main/res/raw/sigma_androdr_084_actively_exploited_cve.yml
@@ -1,0 +1,36 @@
+title: Device vulnerable to an actively exploited CVE
+id: androdr-084
+status: experimental
+description: >
+    Device security patch level leaves it exposed to a CVE that Google
+    flagged as under 'limited, targeted exploitation' in the wild
+    (e.g. CVE-2025-48595, June 2026 Android Security Bulletin — a
+    no-interaction Framework privilege-escalation integer overflow).
+    Actively exploited bugs are the highest-priority posture gap because
+    weaponized exploit code already exists.
+author: AndroDR AI Pipeline
+date: 2026/06/01
+tags:
+    - attack.t1404
+logsource:
+    product: androdr
+    service: device_auditor
+detection:
+    selection:
+        unpatched_cve_id|contains:
+            - "CVE-2025-48595"
+    condition: selection
+level: medium
+category: device_posture
+report_safe_state: true
+display:
+    category: device_posture
+    icon: shield_alert
+    triggered_title: "{count} actively exploited CVEs unpatched"
+    safe_title: "No actively exploited CVEs"
+    evidence_type: cve_list
+    summary_template: "This device is missing patches for {count} CVE(s) under active exploitation in the wild"
+falsepositives:
+    - "Carrier or OEM patch-level reporting lag may briefly show a CVE as unpatched after the fix has actually shipped."
+remediation:
+    - "Go to Settings > Software Update > Download and Install immediately. Also check Play Store > Settings > About > Google Play system update. This vulnerability is being actively exploited by attackers right now."


### PR DESCRIPTION
## Summary
Output of the `update-rules-e2e` pipeline (HitL-approved). Adds one bundled SIGMA rule and bumps the `android-sigma-rules` submodule (→ `e9ce9e3`, [rules#30](https://github.com/android-sigma-rules/rules/pull/30)) which carries the rule mirror + 52 threat-intel IOC entries.

### Rule `androdr-084` — Device vulnerable to an actively exploited CVE
- New `res/raw/sigma_androdr_084_actively_exploited_cve.yml` + registration in `SigmaRuleEngine.kt`.
- `device_auditor` / `level: medium` (the `device_posture` severity cap — `high` is silently clamped by `SeverityCapPolicy` and rejected by `AllRulesHaveCategoryTest`) / `report_safe_state: true`.
- Fires when the device's unpatched actively-exploited CVE set contains **CVE-2025-48595** (June 2026 ASB — no-interaction Framework EoP under limited targeted exploitation). Same `unpatched_cve_id|contains` mechanism as campaign rules 048–052; the CVE arrives via the live CISA-KEV/OSV refresh (not the cold-start snapshot — consistent with siblings).

### IOCs (in the submodule bump, +52, all additive)
40 apk_hash + 8 c2_domain + 4 package_name across BTMOB, TrickMo, Astrinox, Massiv, SaferRat, RecruitRat, PixRevolution, AndroRAT, Antidot (MALWARE) and 3 Asin (SPYWARE). They reach devices via `IocUpdateWorker` pulling rules-repo `main`; `res/raw` is cold-start only.

## Validation
- `./gradlew testDebugUnitTest` → **550 tests, 0 failures** (incl. `GateFourFixtureTest`, `BundledRulesManifestCompletenessTest`, `BundledRules/IocDataSchemaCrossCheckTest`, `AllRulesHaveCategoryTest`).
- `validate-rule.py`, `validate-ioc-data.py` (×3), strict complementarity → PASS.
- Two-reviewer cycle: detection reviewer PASS_WITH_NOTES, quality reviewer PASS.

## Real-device verification
Installed on a physical **Galaxy Z Fold2 (Android 13, patch 2024-08-01)**. Loads 57 bundled rules incl. 084 (zero parse errors); after a scan, **androdr-084 fires correctly** in Device Flags with the right title, evidence count ("19 CVEs"), and remediation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)