### PR TITLE
fix(skills): repair update-rules skill family per full audit

### DIFF
--- a/.claude/commands/update-rules-author.md
+++ b/.claude/commands/update-rules-author.md
@@ -17,7 +17,7 @@ You receive:
 
 ## CRITICAL: IOC Data vs Rules — Know the Difference
 
-**IOC data** (package names, cert hashes, domains, IPs) should be added to `ioc-data/` YAML files in the public rules repo — NOT expressed as individual SIGMA rules. The generic IOC lookup rules (androdr-001, 002, 003) already catch ALL entries in those databases. Creating a per-family rule for each malware family is wasteful and duplicates what IOC lookups do.
+**IOC data** (package names, cert hashes, domains, file hashes, IPs) should be added to `ioc-data/` YAML files in the public rules repo — NOT expressed as individual SIGMA rules. The generic IOC lookup rules (androdr-001 package names, 002 cert hashes, 003 domains, 004 APK hashes) already catch ALL entries in those databases. Creating a per-family rule for each malware family is wasteful and duplicates what IOC lookups do.
 
 **SIGMA rules** are for behavioral/TTP patterns that IOC lookups CANNOT express — permission combinations, accessibility+surveillance combos, system name impersonation, device posture checks.
 
@@ -120,6 +120,16 @@ Use ONLY these modifiers. Any other modifier name will be rejected by the parser
 | Sideloaded app with suspicious permissions, outdated patch (CVSS 7.0-8.9) | `medium` |
 | Informational signal, low-confidence IOC, minor CVE (CVSS < 7.0) | `low` |
 
+### Device-posture severity cap (MANDATORY)
+
+Findings from `device_posture`-category rules are **clamped to `medium` at
+runtime** by `SeverityCapPolicy` (`app/src/main/java/com/androdr/sigma/SeverityCapPolicy.kt`),
+regardless of the declared `level:`. Declaring `high` or `critical` on a
+device-posture rule (CVE / patch-level / device-flag checks, typically
+`device_auditor` service) is dead text — the engine downgrades it.
+**Declare at most `medium` for device-posture rules.** The `high`/`critical`
+rows in the table above apply only to incident-category rules.
+
 ## Decision Flagging
 
 > **Authoritative format:** `third-party/android-sigma-rules/validation/decisions-schema.json`.
@@ -206,7 +216,11 @@ decisions:
 - NEVER extrapolate patterns (e.g., "similar package names would be...")
 - NEVER fill in missing fields with guesses
 - NEVER use category values: TEST, FIXTURE, SIMULATION, DEBUG
-- NEVER use familyName containing: test, fixture, simulation, sample, example
+- `category` MUST be one of the enum in `validation/ioc-entry-schema.json`:
+  `STALKERWARE`, `SPYWARE`, `MALWARE`, `NATION_STATE_SPYWARE`,
+  `FORENSIC_TOOL`, `MONITORING`, `DATA_BROKER_SDK`. There is **no `TROJAN`
+  category** — label banking trojans and RATs as `MALWARE`.
+- NEVER use a `family` value containing: test, fixture, simulation, sample, example (and there is no `familyName` field — the schema rejects unknown keys)
 - If a SIR has only IPs and AndroDR doesn't monitor raw IP connections, flag as skip
 
 ### Mandatory `source` field
@@ -223,9 +237,14 @@ entries:
     source: "stalkerware-indicators"   # ← MANDATORY
 ```
 
-Allowed sources: `stalkerware-indicators`, `malwarebazaar`, `threatfox`,
+Allowed sources (authoritative list: `validation/allowed-sources.json`):
+`stalkerware-indicators`, `malwarebazaar`, `threatfox`,
 `amnesty-investigations`, `citizenlab-indicators`, `mvt-indicators`,
-`virustotal`, `android-security-bulletin`, `zimperium-ioc`
+`virustotal`, `android-security-bulletin`, `zimperium-ioc`,
+`threat_research`
+
+Use `threat_research` for entries derived from research/discover SIRs
+(web-sourced intel where `source.feed` is `"threat_research"`).
 
 Entries without a valid `source` will be REJECTED by the validation gate.
 
@@ -254,7 +273,7 @@ Return a JSON object:
       "type": "package_name",
       "indicator": "com.example.malware",
       "family": "MalwareName",
-      "category": "TROJAN",
+      "category": "MALWARE",
       "severity": "CRITICAL",
       "description": "...",
       "source": "malwarebazaar",

--- a/.claude/commands/update-rules-ingest-abusech.md
+++ b/.claude/commands/update-rules-ingest-abusech.md
@@ -16,17 +16,20 @@ You receive:
 
 - `MALWAREBAZAAR_API_KEY` — single abuse.ch Auth-Key covering both ThreatFox and MalwareBazaar. **Both endpoints return HTTP 401 without it.**
 
-**Fail fast if unset.** Before any WebFetch call, verify the env var is available. If it is missing or empty, abort the run immediately with an explicit error (`"MALWAREBAZAAR_API_KEY env var not set — abusech ingester cannot authenticate"`) and return `{"sirs": [], "updated_cursors": {}, "error": "..."}`. Do NOT silently return empty SIRs — that looks like "no new threats" and masks the auth failure from the orchestrator.
+**Fail fast if unset.** Before any API call, verify the env var is available (`test -n "$MALWAREBAZAAR_API_KEY"`). If it is missing or empty, abort the run immediately with an explicit error (`"MALWAREBAZAAR_API_KEY env var not set — abusech ingester cannot authenticate"`) and return `{"sirs": [], "updated_cursors": {}, "error": "..."}`. Do NOT silently return empty SIRs — that looks like "no new threats" and masks the auth failure from the orchestrator.
 
-Every WebFetch call below must include the header `Auth-Key: $MALWAREBAZAAR_API_KEY`.
+**Use Bash + curl for every API call below — NOT WebFetch.** WebFetch can only do GET requests and cannot set custom headers; both abuse.ch endpoints require a POST with the header `Auth-Key: $MALWAREBAZAAR_API_KEY`.
 
 ## Process
 
 ### ThreatFox
 
-1. Use WebFetch to POST to `https://threatfox-api.abuse.ch/api/v1/` with body:
-   ```json
-   {"query": "taginfo", "tag": "Android", "limit": 100}
+1. POST to the ThreatFox API via curl:
+   ```bash
+   curl -s -X POST https://threatfox-api.abuse.ch/api/v1/ \
+     -H "Auth-Key: $MALWAREBAZAAR_API_KEY" \
+     -H "Content-Type: application/json" \
+     -d '{"query": "taginfo", "tag": "Android", "limit": 100}'
    ```
 2. Parse the JSON response. Each IOC has: `id`, `ioc`, `ioc_type`, `threat_type`, `malware`, `tags`, `first_seen_utc`, `reference`
 3. Filter to IOCs with `first_seen_utc` after `last_seen_timestamp` (or take all if null)
@@ -45,9 +48,11 @@ Every WebFetch call below must include the header `Auth-Key: $MALWAREBAZAAR_API_
 
 ### MalwareBazaar
 
-1. Use WebFetch to POST to `https://mb-api.abuse.ch/api/v1/` with body:
-   ```json
-   {"query": "get_file_type", "file_type": "apk", "limit": 1000}
+1. POST to the MalwareBazaar API via curl (form-encoded, per the MB API):
+   ```bash
+   curl -s https://mb-api.abuse.ch/api/v1/ \
+     -H "Auth-Key: $MALWAREBAZAAR_API_KEY" \
+     --data "query=get_file_type&file_type=apk&limit=1000"
    ```
    Do NOT use `get_taginfo` with `tag=android` — that only returns samples a reporter explicitly tagged "android", missing most APK uploads. `get_file_type&file_type=apk` returns all recent APKs regardless of tagging (AndroDR #146). The limit of 1000 is the endpoint maximum; MalwareBazaar holds ~6 months of Android samples within that window.
 2. Parse the response. Each sample has: `sha256_hash`, `md5_hash`, `file_name`, `file_type`, `signature` (malware family), `tags`, `first_seen`

--- a/.claude/commands/update-rules-validate.md
+++ b/.claude/commands/update-rules-validate.md
@@ -1,10 +1,10 @@
 ---
-description: "Validator — runs 5-gate validation pipeline on candidate SIGMA rules"
+description: "Validator — runs the six-gate validation pipeline (1, 1.2, 2, 3, 4, 5) on candidate SIGMA rules"
 ---
 
 # Rule Validator
 
-You are the Validator agent. You receive a candidate SIGMA rule and run it through five sequential validation gates. You NEVER modify the rule — only assess it.
+You are the Validator agent. You receive a candidate SIGMA rule and run it through six sequential validation gates (1, 1.2, 2, 3, 4, 5). You NEVER modify the rule — only assess it.
 
 ## Input
 
@@ -27,7 +27,7 @@ If exit code != 0, record errors and FAIL this gate.
 Also check manually:
 - `status` is `experimental` (mandatory for AI-generated rules)
 - `logsource.product` is `androdr`
-- `logsource.service` is one of: `app_scanner`, `device_auditor`, `dns_monitor`, `process_monitor`, `file_scanner`
+- `logsource.service` is in the service enum of `{sigma_repo_path}/validation/rule-schema.json` AND has `status: active` in `{sigma_repo_path}/validation/logsource-taxonomy.yml` — do NOT hardcode a service list here; read those files. Rules targeting a `status: unwired` service (currently `network_monitor`) cannot fire and must FAIL this gate.
 - All regex patterns under 500 characters
 - `id` follows `androdr-NNN` pattern
 
@@ -110,7 +110,7 @@ Record: `{ pass: bool, tp_fired: bool, tn_clean: bool, errors: string[] }`
 
 ## Gate 5: LLM Self-Review
 
-Spawn the `update-rules-review` agent with the candidate rule, source SIR, and existing similar rules. It returns a structured review.
+Perform the self-review yourself, inline: read `.claude/commands/update-rules-review.md` and apply its criteria to the candidate rule, source SIR, and existing similar rules with fresh eyes — do not let your earlier gate findings pre-bias the verdict. (You run as a subagent and cannot spawn further agents, so Gate 5 is always inline.)
 
 Record: `{ pass: bool, verdict: string, fp_risk: string, suggestions: string[], issues: string[] }`
 
@@ -155,13 +155,11 @@ See `third-party/android-sigma-rules/validation/allowed-sources.json` for the ca
 
 ### Required fields per entry type
 
-**Package IOC:** indicator, family, category, severity, source
-**Cert hash IOC:** indicator, familyName, category, severity, source
-**Domain IOC:** indicator, family, category, severity, source
+All entry types (per `ioc-entry-schema.json`): `indicator`, `category`, `severity`, `source` required; `family` optional but recommended. There is no `familyName` field — the schema sets `additionalProperties: false`, so an entry using `familyName` is rejected.
 
 ## Rules
 
 - NEVER modify the candidate rule — only assess it
 - Run gates sequentially — if Gate 1 fails, still run remaining gates to provide complete feedback
 - Record ALL errors, not just the first one
-- IOC data entries are validated SEPARATELY from SIGMA rules — they go through the IOC validation section above, not through the 5-gate pipeline
+- IOC data entries are validated SEPARATELY from SIGMA rules — they go through the IOC validation section above, not through the six-gate pipeline

--- a/.claude/commands/update-rules.md
+++ b/.claude/commands/update-rules.md
@@ -27,17 +27,19 @@ Runs from a terminal shell; subagents inherit the parent session's environment v
 | nvd | `NVD_API_KEY` | **Optional** — raises anon rate limit from 5 req/30s to 50 req/30s. Weekly cadence works anonymously. |
 | amnesty, stalkerware, attack (GitHub-based) | `GITHUB_TOKEN` | **Optional** — raises anon GitHub API limit from 60/hr to 5000/hr. Weekly cadence works anonymously. |
 
-**Abort the full-sweep run** if `MALWAREBAZAAR_API_KEY` is missing when `abusech` is in the dispatch set. A single-feed invocation (`/update-rules source asb`, `/update-rules source amnesty`, etc.) that doesn't need abusech should proceed regardless.
+If `MALWAREBAZAAR_API_KEY` is missing when `abusech` is in the dispatch set, **do not abort the run**: skip the abusech ingester, record it as a feed FAILURE (distinct from "no new data"), and continue with the remaining feeds — a degraded sweep with a loud per-feed error beats no sweep. This matches the `update-rules-e2e` workflow's behavior. A single-feed `/update-rules source abusech` invocation with no key should stop immediately, since there is nothing else to run.
+
+**Tool note:** WebFetch cannot send POST requests or custom headers. Authenticated calls (`Auth-Key` for abuse.ch, `Authorization: token $GITHUB_TOKEN` for GitHub) must use Bash + curl. Anonymous GET access via WebFetch is fine for the GitHub/NVD/ASB feeds at the lower rate limits.
 
 Note: `virustotal` is listed in `allowed-sources.json` as a valid provenance label but no ingester currently calls the VT API. `VIRUSTOTAL_API_KEY` is not needed today.
 
 ## Step 1: Read State
 
-1. Read `feed-state.json` from the public sigma repo to get feed cursors
-2. Glob `rules/production/**/*.yml` and `rules/staging/**/*.yml` to build an index of existing rules (IDs, titles, IOCs referenced)
-3. Determine the next available rule ID by finding the highest `androdr-NNN` across all existing rules and incrementing
+1. Read `feed-state.json` from the sigma repo root to get feed cursors
+2. Build an index of existing rules (IDs, titles, IOCs referenced). Production rules live in **service-named directories at the sigma repo root** (`app_scanner/`, `device_auditor/`, `dns_monitor/`, `file_scanner/`, `process_monitor/`, `receiver_audit/`, `accessibility_audit/`, `appops_audit/`, ...); staged rules live under `staging/<service>/`. Glob `<service>/**/*.yml` and `staging/**/*.yml` — there is no `rules/` prefix directory.
+3. Determine the next available rule ID by finding the highest `androdr-NNN` across all existing rules and incrementing. Never reuse an ID that previously existed and was later removed (check `git log` in the sigma repo if in doubt).
 
-The public sigma repo path: check if `../android-sigma-rules/` exists relative to the AndroDR repo. If not, ask the user where it is.
+The sigma repo is the git submodule at `third-party/android-sigma-rules/` (see CLAUDE.md). If the submodule is not initialized, run `git submodule update --init` rather than asking the user for a path.
 
 ## Step 2: Dispatch Ingesters
 
@@ -86,7 +88,7 @@ For each SIR:
 ## Step 4: Generate Rules
 
 **Before dispatching the Rule Author**, read the logsource field taxonomy:
-1. Read `android-sigma-rules/validation/logsource-taxonomy.yml`
+1. Read `third-party/android-sigma-rules/validation/logsource-taxonomy.yml`
 2. Identify which services are relevant based on the SIRs' `rule_hint` values:
    - `ioc_lookup` → `app_scanner` (package names), `dns_monitor` (domains)
    - `behavioral` → `app_scanner`, `accessibility_audit`, `appops_audit`, `receiver_audit`
@@ -146,9 +148,10 @@ by the `parser` field. Take the union with `U_ingesters` → `U_authoritative`.
 
 ### 6.5.3 Filter candidates
 
-For each candidate across all ingesters, drop it if
-`(type, normalized_value)` is in `U_authoritative`. The survivors form the
-**approved delta** that proceeds to Step 7.
+For each candidate across all ingesters — **plus any `ioc_data` entries
+emitted by the Rule Author** from research/discover SIRs (Step 4 output) —
+drop it if `(type, normalized_value)` is in `U_authoritative`. The
+survivors form the **approved delta** that proceeds to Step 7.
 
 ### 6.5.4 Safety checks before Step 7
 
@@ -220,7 +223,7 @@ User actions for an IOC-only candidate: same as for a rule candidate —
 ## Step 8: Process User Decisions
 
 For each passing candidate, ask the user to:
-- **Approve** — write the rule to `rules/staging/[category]/` in the sigma repo, commit
+- **Approve** — write the rule to `staging/<service>/` in the sigma repo (per-service subdirectories, e.g. `staging/app_scanner/`), commit
 - **Modify** — apply user's changes, re-validate, then write
 - **Reject** — discard, log reason
 
@@ -254,7 +257,7 @@ For each approved candidate (rule OR IOC-only):
 4. Commit the ioc-data change(s) + rule change(s) + feed-state update as
    a single atomic commit. Commit message format:
    ```
-   feat(rules+ioc): add <threat-name> (source: <source-id>) [Phase 4 of #117]
+   feat(rules+ioc): add <threat-name> (source: <source-id>)
    ```
 
 ### 8.2 Safety rules
@@ -269,7 +272,7 @@ For each approved candidate (rule OR IOC-only):
 
 ## Safety Rules
 
-- NEVER write rules directly to `rules/production/` — staging only
+- NEVER write rules directly to the production service directories at the sigma repo root (`app_scanner/`, `device_auditor/`, etc.) — `staging/<service>/` only
 - NEVER set `status` to anything other than `experimental` for AI-generated rules
 - NEVER modify AndroDR application code (Kotlin sources)
 - NEVER commit API keys or credentials to any file

--- a/.claude/workflows/update-rules-e2e.workflow.js
+++ b/.claude/workflows/update-rules-e2e.workflow.js
@@ -1,0 +1,401 @@
+export const meta = {
+  name: 'update-rules-e2e',
+  description: 'Research Android threat intel across feeds + open sources, author & validate AndroDR SIGMA rule/IOC candidates for a final human-in-the-loop review (no writes/commits in the workflow)',
+  phases: [
+    { title: 'Ingest', detail: 'parallel feed ingesters (abuse.ch, ASB, NVD, stalkerware, ATT&CK, Amnesty)' },
+    { title: 'Discover', detail: 'vendor-blog discovery → top-5 emerging threat names' },
+    { title: 'Research', detail: 'per-threat + open-web researchers → SIRs' },
+    { title: 'Author', detail: 'SIRs → candidate rules + IOC-data entries' },
+    { title: 'Dedup', detail: 'drop IOC candidates already pulled on-device via kotlin-mirror-feeds (incl. manual MVT STIX traversal — parser_limited feeds the validator skips)' },
+    { title: 'Validate', detail: 'gates 1/1.2/2/3/5 + IOC structural validation (gate 4 + strict complementarity deferred)' },
+  ],
+}
+
+// ---- Run-specific state: supplied via `args` by the main session, which must
+// read the LIVE feed-state.json and glob the rules index immediately before
+// invoking. Workflow scripts cannot call Date.now(), and baked-in constants go
+// stale (a previous revision hardcoded a month-old cursor set and a since-
+// retired next_id) — so live state is REQUIRED, not optional.
+const REPO = '/home/yasir/AndroDR'
+const SIGMA = REPO + '/third-party/android-sigma-rules'
+
+const REQUIRED_ARGS = ['today', 'next_id', 'rule_index', 'tracked_threat_names', 'cursors', 'discover_cursors', 'since']
+const ARGS = (typeof args === 'undefined' || !args) ? {} : args
+const missingArgs = REQUIRED_ARGS.filter(k => !ARGS[k])
+if (missingArgs.length) {
+  return {
+    status: 'error',
+    error: 'Missing required args: ' + missingArgs.join(', '),
+    usage: {
+      today: 'YYYY/MM/DD (current date — scripts cannot read the clock)',
+      next_id: 'androdr-NNN — highest existing ID + 1 from globbing <service>/ and staging/ in the submodule; NEVER reuse an ID that existed before and was removed (check git log)',
+      rule_index: 'one "androdr-NNN Title" line per existing rule (production service dirs + staging/)',
+      tracked_threat_names: 'comma-separated threat names already covered by rules/IOC data',
+      cursors: 'object keyed abusech/asb/nvd/stalkerware/attack/amnesty — one human-readable cursor summary string per feed, from the live feed-state.json',
+      discover_cursors: 'per-source "id: last_seen=... url=..." lines from feed-state.json discover.sources',
+      since: 'YYYY-MM-DD lower bound for the open-web sweep (use feed-state.json last_full_sweep)',
+    },
+  }
+}
+const TODAY = ARGS.today
+const NEXT_ID = ARGS.next_id
+const RULE_INDEX = ARGS.rule_index
+const TRACKED_THREAT_NAMES = ARGS.tracked_threat_names
+const CURSORS = ARGS.cursors
+const DISCOVER_CURSORS = ARGS.discover_cursors
+const OPEN_WEB_SINCE = ARGS.since
+
+// ---- Schemas (kept loose on item shape to avoid spurious retries) ----
+const SIR_OUT = {
+  type: 'object',
+  required: ['sirs', 'updated_cursors'],
+  additionalProperties: true,
+  properties: {
+    sirs: { type: 'array', items: { type: 'object', additionalProperties: true } },
+    updated_cursors: { type: 'object', additionalProperties: true },
+    error: { type: 'string' },
+    log: { type: 'array', items: { type: 'string' } },
+  },
+}
+const DISCOVER_OUT = {
+  type: 'object',
+  required: ['threat_names'],
+  additionalProperties: true,
+  properties: {
+    threat_names: { type: 'array', items: { type: 'string' } },
+    source_urls: { type: 'object', additionalProperties: true },
+    updated_cursors: { type: 'object', additionalProperties: true },
+    log: { type: 'array', items: { type: 'string' } },
+  },
+}
+const AUTHOR_OUT = {
+  type: 'object',
+  required: ['candidates', 'ioc_data'],
+  additionalProperties: true,
+  properties: {
+    candidates: { type: 'array', items: { type: 'object', additionalProperties: true } },
+    ioc_data: { type: 'array', items: { type: 'object', additionalProperties: true } },
+  },
+}
+const VALIDATE_OUT = {
+  type: 'object',
+  required: ['rule_id', 'overall', 'gates'],
+  additionalProperties: true,
+  properties: {
+    rule_id: { type: 'string' },
+    overall: { type: 'string' },
+    gates: { type: 'object', additionalProperties: true },
+    retry_count: { type: 'number' },
+  },
+}
+const DEDUP_OUT = {
+  type: 'object',
+  required: ['additive', 'dropped'],
+  additionalProperties: true,
+  properties: {
+    additive: { type: 'array', items: { type: 'object', additionalProperties: true } },
+    dropped: { type: 'array', items: { type: 'object', additionalProperties: true } },
+    log: { type: 'array', items: { type: 'string' } },
+  },
+}
+const IOC_VALIDATE_OUT = {
+  type: 'object',
+  required: ['valid_entries', 'rejected'],
+  additionalProperties: true,
+  properties: {
+    valid_entries: { type: 'array', items: { type: 'object', additionalProperties: true } },
+    rejected: { type: 'array', items: { type: 'object', additionalProperties: true } },
+    log: { type: 'array', items: { type: 'string' } },
+  },
+}
+
+const TOOLING = `Tooling: you have Bash, WebFetch, WebSearch, Read, Glob, Write. If WebFetch/WebSearch show up as deferred tools, load them first with ToolSearch ("select:WebFetch,WebSearch"). Use a polite User-Agent for raw fetches: AndroDR-AI-Rule-Pipeline/1.0 (+https://github.com/yasirhamza/AndroDR).`
+const INTEGRITY = `INTEGRITY RULES (non-negotiable): NEVER invent, guess, or extrapolate IOCs — include ONLY exact values returned by a source you fetched in THIS session. NEVER use IOCs from training data. NEVER generate SIGMA rules in this role — only SIRs. Tag each IOC with the source URL it came from.`
+
+function ingestPrompt(id) {
+  const abuse = id === 'abusech'
+  return `You are the "${id}" threat-intel feed ingester for the AndroDR SIGMA pipeline, running inside ${REPO} (rules submodule at ${SIGMA}).
+
+Read ${REPO}/.claude/commands/update-rules-ingest-${id}.md and follow it EXACTLY — it defines the fetch procedure and the precise SIR JSON output shape.
+
+Cursor / last-seen state for this feed:
+  ${CURSORS[id]}
+
+Existing AndroDR rule index (id + title), for DEDUP AWARENESS only — do not regenerate these:
+${RULE_INDEX}
+
+${TOOLING}
+${abuse
+    ? `The abuse.ch endpoints (ThreatFox + MalwareBazaar) REQUIRE the header "Auth-Key: $MALWAREBAZAAR_API_KEY". Use Bash + curl (NOT WebFetch) so you can set that header. The key is exported in this shell — first verify: test -n "$MALWAREBAZAAR_API_KEY" && echo present. If empty, abort and return {"sirs":[],"updated_cursors":{},"error":"MALWAREBAZAAR_API_KEY not set"}.`
+    : `Check the source's robots.txt where the command instructs. Anonymous access is fine (NVD/GitHub work without tokens at lower rate limits).`}
+${INTEGRITY}
+
+Return ONLY the JSON object the command specifies (top-level keys: sirs, updated_cursors, and optionally error/log). Your entire final message must be that JSON object — it is parsed by a program, not read by a human.`
+}
+
+function discoverPrompt() {
+  return `You are the discover agent for the AndroDR SIGMA pipeline, running inside ${REPO}.
+
+Read ${REPO}/.claude/commands/update-rules-discover.md and follow it EXACTLY, with top_n=5.
+
+rule_index (already-tracked threat names, comma-separated): ${TRACKED_THREAT_NAMES}
+
+cursor_per_source:
+${DISCOVER_CURSORS}
+
+${TOOLING}
+Use the helper exactly as the command says: python3 ${REPO}/.claude/commands/scripts/discover_extract.py (parse mode for RSS, --validate-tokens for the structural XPIA filter, --check-robots for robots). Run per-post LLM extraction yourself, ONE post at a time (per-post isolation is the XPIA boundary — never batch). EVERY extracted name MUST pass through --validate-tokens before you emit it. Advance a source cursor ONLY if that source parsed successfully.
+
+Return ONLY the JSON the command specifies (threat_names, source_urls, updated_cursors, log). Entire final message = that JSON.`
+}
+
+function researchPrompt(name, url) {
+  return `You are a threat researcher for the AndroDR SIGMA pipeline, running inside ${REPO}.
+
+Read ${REPO}/.claude/commands/update-rules-research-threat.md and follow it EXACTLY.
+
+threat_name: "${name}"
+primary source hint: ${url || '(none — locate authoritative coverage yourself)'}
+existing_rule_ids / tracked threats (avoid duplicating coverage): ${TRACKED_THREAT_NAMES}
+
+Search broadly across reliable sources: Kaspersky Securelist, Lookout, Zimperium, ESET/WeLiveSecurity, Dr.Web, Cleafy, ThreatFabric, Bitdefender, Google TAG/GTIG, Amnesty Tech, Citizen Lab, MITRE ATT&CK Mobile, NVD (for CVEs), abuse.ch. ${TOOLING}
+${INTEGRITY}
+MANDATORY: if a SIR is built entirely from a single unstructured source (one blog/report, no corroborating feed), set "requires_verification": true at the SIR top level.
+
+Return ONLY {sirs, updated_cursors} JSON. Entire final message = that JSON.`
+}
+
+function openWebPrompt() {
+  return `You are an open-source threat-intel researcher casting a WIDE net for AndroDR, running inside ${REPO}.
+
+Goal: find EMERGING Android malware / spyware / stalkerware / commercial-surveillance campaigns disclosed roughly since ${OPEN_WEB_SINCE} that are NOT already covered by AndroDR and that the configured feeds + the discover source list (Securelist / WeLiveSecurity / Google / Zimperium / Lookout) may have MISSED.
+
+Cast wider — search these additional reliable vendors/authorities: Dr.Web, Cleafy, ThreatFabric, Bitdefender, McAfee, Trend Micro, Check Point Research, Group-IB, Palo Alto Unit 42, CISA mobile advisories, NCSC. ${TOOLING}
+
+Already tracked (skip): ${TRACKED_THREAT_NAMES}.
+
+Follow the SIR construction + integrity rules in ${REPO}/.claude/commands/update-rules-research-threat.md. For each distinct threat that has at least one concrete IOC OR a crisp, detectable behavioral pattern, build a SIR.
+${INTEGRITY}
+Set "requires_verification": true on any SIR built from a single unstructured source.
+
+Return ONLY {sirs, updated_cursors: {}} JSON. Entire final message = that JSON.`
+}
+
+function authorPrompt(sirs) {
+  return `You are the Rule Author for the AndroDR SIGMA pipeline, running inside ${REPO} (rules submodule at ${SIGMA}).
+
+Read ${REPO}/.claude/commands/update-rules-author.md and follow it EXACTLY, including the IOC-data-vs-rule Decision Gate that you MUST apply to every SIR.
+
+next_id: ${NEXT_ID}  (assign rule IDs sequentially from here)
+today's date: ${TODAY}
+
+Existing rule index (for dedup; do NOT recreate):
+${RULE_INDEX}
+
+Existing IOC database — READ the actual files under ${SIGMA}/ioc-data/ (c2-domains.yml, malware-hashes.yml, package-names.yml, cert-hashes.yml) and do NOT re-add indicators already present there.
+
+Logsource taxonomy: READ ${SIGMA}/validation/logsource-taxonomy.yml. Only use field names listed there for the target service, and only target services with status: active in that file (do not rely on a memorized list — the taxonomy is the source of truth). Any status: unwired service (currently network_monitor) must NEVER be targeted; record a telemetry_gap decision instead.
+
+Decision Gate reminder: pure indicator lists (package names / cert hashes / domains / file hashes) → emit ioc_data entries (the generic androdr-001/002/003/004 lookups already match them), do NOT create a per-family rule. Only unique behavioral / TTP / device-posture patterns become SIGMA rules. status must be experimental; author "AndroDR AI Pipeline". Use ONLY the supported modifiers listed in the command.
+
+SIRs to process (JSON array):
+${JSON.stringify(sirs)}
+
+Return ONLY {candidates:[...], ioc_data:[...]} JSON as the command specifies. Entire final message = that JSON.`
+}
+
+function validatePrompt(c, sirs) {
+  const yaml = c.yaml || ''
+  const rid = c.rule_id || 'unknown'
+  // Match SIRs the author attributed to this candidate; source_sirs entries may
+  // be SIR ids or threat names. Fall back to ALL SIRs only if nothing matches.
+  const matched = (Array.isArray(c.source_sirs) && c.source_sirs.length)
+    ? sirs.filter(s => s && c.source_sirs.some(ref =>
+        ref === s.id || ref === s.sir_id || (s.threat && ref === s.threat.name)))
+    : []
+  const srcSirs = matched.length ? matched : sirs
+  return `You are the rule Validator for the AndroDR SIGMA pipeline, running inside ${REPO} (rules submodule at ${SIGMA}). You NEVER modify the rule — only assess it.
+
+Read ${REPO}/.claude/commands/update-rules-validate.md. Run Gates 1, 1.2, 2, 3, and 5.
+DO NOT run Gate 4 (the gradle dry-run): it is DEFERRED to the post-approval step in the main session to avoid concurrent gradle builds racing in a shared working tree. Record gates.dry_run = {"pass": null, "skipped": true, "reason": "deferred to post-approval"}.
+
+Write the candidate YAML to a UNIQUE temp file: /tmp/cand-${rid}.yml (do NOT use a shared filename — other validators run in parallel). Then:
+  python3 ${SIGMA}/validation/validate-rule.py /tmp/cand-${rid}.yml
+If the candidate carries a non-empty decisions array, also validate it via ${SIGMA}/validation/validate-decisions.py (wrap under a decisions: key in a temp file). Include validator stderr verbatim in any failure.
+
+Gate 2: verify every concrete IOC in the rule exists in the source SIR(s) below; permission names against ${SIGMA}/validation/android-permissions.txt; ATT&CK tags match attack.tNNNN[.NNN].
+Gate 3: check ID collision / exact-duplicate / subsumption against the existing rule index below.
+Gate 5: perform the self-review yourself following ${REPO}/.claude/commands/update-rules-review.md criteria (read it first); report verdict, fp_risk, suggestions, issues.
+
+sigma_repo_path: ${SIGMA}
+existing rule index:
+${RULE_INDEX}
+source SIR(s) (JSON):
+${JSON.stringify(srcSirs)}
+
+Candidate YAML:
+---
+${yaml}
+---
+
+Return ONLY the ValidationResult JSON (rule_id, overall, gates{schema,ioc_verify,dedup,dry_run,self_review}, retry_count). Entire final message = that JSON.`
+}
+
+function dedupPrompt(iocs) {
+  return `You enforce the IOC complementarity invariant for the AndroDR SIGMA pipeline, running inside ${REPO} (rules submodule at ${SIGMA}). AndroDR's on-device Kotlin "bypass" feed clients fetch some upstreams DIRECTLY, so any ioc-data entry that duplicates them is REDUNDANT and must be dropped.
+
+Proposed IOC-data candidates (JSON array):
+${JSON.stringify(iocs)}
+
+Step 1 — read ${SIGMA}/validation/kotlin-mirror-feeds.yml. It lists the feeds the app pulls on-device and the IOC TYPES each delivers. Note that NO mirror feed carries file hashes (APK_HASH / cert hashes) — so file_hash candidates are always additive and never need dropping.
+
+Step 2 — build the authoritative on-device coverage set U for the candidate types present (domains, package names). CRITICAL: feeds tagged 'parser_limited: true' (currently mvt-indicators and threatfox) are SKIPPED by validate-ioc-complementarity.py, but the Kotlin client still delivers them on-device — so you MUST fetch them MANUALLY rather than trusting the Python parser:
+  - mvt-indicators: fetch https://raw.githubusercontent.com/mvt-project/mvt-indicators/main/indicators.yaml (a dict with key 'indicators'). Each item has a 'github' ref {owner,repo,branch,path}; build the raw URL https://raw.githubusercontent.com/<owner>/<repo>/<branch>/<path> and fetch that STIX2 JSON. From each object of type 'indicator', regex the pattern for domain-name:value and (for package candidates) app/process names. Union every bundle. (As of last run there were 15 bundles incl. a dedicated "Wintego Helios" bundle — MVT mirrors AmnestyTech/investigations, so Amnesty-sourced domains very often ALREADY live in MVT.)
+  - threatfox: its on-device parser is currently broken vs the live schema (#127), so it delivers 0 — treat threatfox C2 domains as ADDITIVE for now, but say so in the log.
+  - stalkerware-indicators: fetch https://raw.githubusercontent.com/AssoEchap/stalkerware-indicators/master/ioc.yaml directly (PACKAGE_NAME only) if any package candidates exist.
+Use Bash + python3 + urllib for the fetch/traversal (a polite User-Agent). ${TOOLING}
+
+Step 3 — for each candidate, drop it if its normalized (type,value) is in U. Keep the rest.
+
+Return ONLY {additive:[...full candidate objects that survive...], dropped:[{indicator, type, reason}], log:[...per-feed counts + which manual fetches you ran...]}. Entire final message = that JSON.`
+}
+
+function iocValidatePrompt(iocs) {
+  return `You validate proposed IOC-data entries for the AndroDR SIGMA pipeline, running inside ${REPO} (rules submodule at ${SIGMA}). Read-only: NEVER modify the real ioc-data files.
+
+Proposed entries (JSON array):
+${JSON.stringify(iocs)}
+
+For each entry, route to its target file under ${SIGMA}/ioc-data/ by type:
+  package_name → package-names.yml ; cert_hash → cert-hashes.yml ; domain → c2-domains.yml ; file_hash → malware-hashes.yml
+Per-entry checks (reject with a reason if any fail):
+  1. Required fields present per ${SIGMA}/validation/ioc-entry-schema.json: indicator, category, severity, source ("family" is optional but recommended; "familyName" is NOT a valid key — the schema rejects unknown properties). "source" MUST appear in ${SIGMA}/validation/allowed-sources.json.
+  2. category MUST be in the schema enum (STALKERWARE, SPYWARE, MALWARE, NATION_STATE_SPYWARE, FORENSIC_TOOL, MONITORING, DATA_BROKER_SDK — no TROJAN; label trojans/RATs as MALWARE); family must NOT contain test/fixture/simulation/sample/example.
+  3. cert hashes: 64 lowercase hex (SHA-256) or 40 (SHA-1).
+  4. NOT already present in the target file — READ the target file and dedup by normalized indicator (this is the local authoritative-coverage filter; the strict upstream complementarity check is deferred to the commit step in the main session).
+
+Structural validation of the SURVIVORS: write surviving entries (preserving the target file's header shape) to a temp file per target type and run:
+  python3 ${SIGMA}/validation/validate-ioc-data.py <tmpfile>
+Include validator stderr in your log. Do NOT run validate-ioc-complementarity.py here (it may need reachable upstream; deferred to commit). Do NOT touch the real files.
+
+Return ONLY {valid_entries:[...], rejected:[{entry, reason}], log:[...]}. Entire final message = that JSON.`
+}
+
+// ============================ ORCHESTRATION ============================
+
+phase('Ingest')
+const INGEST_IDS = ['abusech', 'asb', 'nvd', 'stalkerware', 'attack', 'amnesty']
+const ingestRaw = await parallel(
+  INGEST_IDS.map(id => () => agent(ingestPrompt(id), { label: `ingest:${id}`, phase: 'Ingest', schema: SIR_OUT }))
+)
+const ingestResults = ingestRaw.map((r, i) => ({ id: INGEST_IDS[i], r }))
+const feedLogs = []
+for (const { id, r } of ingestResults) {
+  if (!r) { feedLogs.push(`[ingest:${id}] FAILED (agent error/skip)`); continue }
+  if (r.error) { feedLogs.push(`[ingest:${id}] feed error: ${r.error}`); continue }
+  feedLogs.push(`[ingest:${id}] ${(r.sirs || []).length} SIR(s)`)
+}
+
+phase('Discover')
+const discover = await agent(discoverPrompt(), { label: 'discover:top5', phase: 'Discover', schema: DISCOVER_OUT })
+const threatNames = (discover && discover.threat_names ? discover.threat_names : []).slice(0, 5)
+log(`Discover surfaced ${threatNames.length} threat name(s): ${threatNames.join(', ') || '(none)'}`)
+
+phase('Research')
+const researchThunks = [
+  ...threatNames.map(name => () =>
+    agent(researchPrompt(name, discover.source_urls && discover.source_urls[name]),
+      { label: `research:${name}`.slice(0, 60), phase: 'Research', schema: SIR_OUT })),
+  () => agent(openWebPrompt(), { label: 'research:open-web', phase: 'Research', schema: SIR_OUT }),
+]
+const researchRaw = await parallel(researchThunks)
+
+// ---- Collect + triage SIRs ----
+const allSirs = [
+  ...ingestRaw.filter(Boolean).flatMap(r => r.sirs || []),
+  ...researchRaw.filter(Boolean).flatMap(r => r.sirs || []),
+].filter(s => s && s.confidence !== 'none')
+
+log(`Collected ${allSirs.length} usable SIR(s) after triage`)
+
+const proposedCursors = {}
+for (const r of [...ingestRaw, discover, ...researchRaw].filter(Boolean)) {
+  if (r.updated_cursors) Object.assign(proposedCursors, r.updated_cursors)
+}
+
+if (allSirs.length === 0) {
+  return {
+    status: 'no_new_intel',
+    summary: { feeds_checked: INGEST_IDS.length, discover_names: threatNames.length, new_sirs: 0 },
+    feed_logs: feedLogs,
+    discover_log: (discover && discover.log) || [],
+    proposed_cursors: proposedCursors,
+    note: 'No usable threat intelligence found this run. Cursors above can still be advanced. Nothing to approve.',
+  }
+}
+
+phase('Author')
+const authored = await agent(authorPrompt(allSirs), { label: 'author', phase: 'Author', schema: AUTHOR_OUT })
+const candidates = (authored && authored.candidates) || []
+const iocDataRaw = (authored && authored.ioc_data) || []
+log(`Author produced ${candidates.length} rule candidate(s) + ${iocDataRaw.length} IOC-data entr(ies)`)
+
+phase('Dedup')
+let iocData = iocDataRaw
+let dedupResult = { additive: iocDataRaw, dropped: [], log: ['no IOC candidates to dedup'] }
+if (iocDataRaw.length) {
+  dedupResult = await agent(dedupPrompt(iocDataRaw), { label: 'dedup:mirror-feeds', phase: 'Dedup', schema: DEDUP_OUT })
+  iocData = (dedupResult && dedupResult.additive) || []
+  log(`Mirror-feed dedup: ${iocData.length} additive, ${(dedupResult.dropped || []).length} dropped as on-device-redundant`)
+}
+
+phase('Validate')
+const validationThunks = candidates.map(c => () =>
+  agent(validatePrompt(c, allSirs), { label: `validate:${c.rule_id || 'rule'}`, phase: 'Validate', schema: VALIDATE_OUT })
+    .then(v => ({ candidate: c, validation: v }))
+)
+const iocValidationThunk = iocData.length
+  ? [() => agent(iocValidatePrompt(iocData), { label: 'validate:ioc-data', phase: 'Validate', schema: IOC_VALIDATE_OUT })]
+  : []
+
+const validatedAll = await parallel([...validationThunks, ...iocValidationThunk])
+// A null slot means the validator agent errored or was skipped — keep the
+// candidate visible as a failure instead of silently dropping it.
+const ruleValidations = validatedAll.slice(0, candidates.length)
+  .map((v, i) => v || { candidate: candidates[i], validation: null })
+const iocValidation = iocData.length
+  ? (validatedAll[validatedAll.length - 1] || { valid_entries: [], rejected: [], log: ['ioc validation agent failed or was skipped'] })
+  : { valid_entries: [], rejected: [], log: [] }
+
+const passed = ruleValidations.filter(rv => rv.validation && rv.validation.overall === 'pass')
+const failed = ruleValidations.filter(rv => !rv.validation || rv.validation.overall !== 'pass')
+
+return {
+  status: 'candidates_ready',
+  summary: {
+    feeds_checked: INGEST_IDS.length,
+    discover_names: threatNames.length,
+    new_sirs: allSirs.length,
+    rule_candidates: candidates.length,
+    rules_passed: passed.length,
+    rules_failed: failed.length,
+    ioc_authored: iocDataRaw.length,
+    ioc_dropped_redundant: (dedupResult && dedupResult.dropped ? dedupResult.dropped.length : 0),
+    ioc_additive: iocData.length,
+    ioc_valid: (iocValidation && iocValidation.valid_entries ? iocValidation.valid_entries.length : 0),
+    ioc_rejected: (iocValidation && iocValidation.rejected ? iocValidation.rejected.length : 0),
+  },
+  feed_logs: feedLogs,
+  discover_log: (discover && discover.log) || [],
+  dedup_log: (dedupResult && dedupResult.log) || [],
+  dropped_redundant: (dedupResult && dedupResult.dropped) || [],
+  passed_candidates: passed,
+  failed_candidates: failed,
+  ioc_candidates: iocValidation,
+  proposed_cursors: proposedCursors,
+  deferred_to_main_session: [
+    'Gate 4 (gradle dry-run via GateFourFixtureTest) for each approved rule',
+    'validate-ioc-complementarity.py --mode strict for each approved IOC entry (needs reachable upstream)',
+    'HiTL approve/modify/reject per candidate, then write to staging/ + ioc-data/, re-validate, and commit to the submodule',
+  ],
+}


### PR DESCRIPTION
## Summary

A full audit of the `update-rules` skill family (12 skill files + the `update-rules-e2e` workflow) found 12 issues — broken paths, an invalid IOC category taught by example, impossible tool instructions, a stale validator service list, an always-true filter bug, and month-old baked-in workflow state. This PR fixes all of them, plus additional findings from the two-reviewer cycle.

## Changes

**`update-rules.md` (dispatcher)**
- Sigma repo layout corrected: production rules live in service dirs at the submodule root + `staging/<service>/` — the referenced `rules/production/` and `rules/staging/` never existed; repo path is `third-party/android-sigma-rules/`
- Missing `MALWAREBAZAAR_API_KEY` no longer aborts a full sweep — abusech is skipped and recorded as a feed FAILURE, remaining feeds continue (matches e2e behavior)
- Tool note: WebFetch cannot POST or set headers; Auth-Key / `GITHUB_TOKEN` calls need curl
- Step 6.5 cross-dedup explicitly covers Rule-Author-emitted `ioc_data`, not just ingester candidates
- Dropped stale `[Phase 4 of #117]` commit-message tag

**`update-rules-author.md`**
- `TROJAN` example replaced with `MALWARE` + the actual `ioc-entry-schema.json` category enum documented (no TROJAN category exists; the example was teaching a schema violation)
- New mandatory section on the device-posture severity cap: `SeverityCapPolicy` clamps `device_posture` findings to `medium` at runtime, so declaring `high`/`critical` on posture rules is dead text (root cause of the recurring "pipeline proposes high" annoyance)
- Generic lookup rules corrected to 001–004 (APK-hash 004 was omitted)
- `threat_research` added to allowed sources (present in `allowed-sources.json`); `familyName` → `family` per schema

**`update-rules-validate.md`**
- Gate 1 service check now reads the `rule-schema.json` enum + taxonomy `status: active` instead of a stale 5-service hardcode that would falsely fail valid `receiver_audit`/`accessibility_audit`/`appops_audit` rules
- Gate 5 self-review documented as inline (subagents cannot spawn agents)
- Gate count corrected to six; IOC required fields aligned with the actual schema

**`update-rules-ingest-abusech.md`**
- "WebFetch to POST with Auth-Key header" replaced with working Bash + curl invocations (ThreatFox JSON POST, MalwareBazaar form-encoded POST)

**`update-rules-e2e.workflow.js`** (now git-tracked — was ignored, so the pipeline's orchestration was unversioned)
- Live state is now REQUIRED via `args` (today, next_id, rule_index, tracked_threat_names, cursors, discover_cursors, since) with a usage-error return — replaces baked-in constants that were a month stale and pointed `next_id` at the retired androdr-084
- Fixed always-true `|| true` in the source-SIR filter: validators now receive only their candidate's SIRs (with fallback), restoring Gate 2 precision
- Null validator results surface as failed candidates instead of silently vanishing; null IOC validation gets a logged fallback
- De-hardcoded the author prompt's service list (taxonomy is the source of truth); schema-accurate IOC field checks; `Array.isArray` guard

## Verification

- Workflow body + meta parse cleanly (`node --check` on the harness-wrapped body)
- Grep confirms zero residual stale strings (`rules/production`, `5-gate`, `familyName`, `TROJAN`, `WebFetch to POST`, retired IDs/dates) across all 13 files
- Discover helper test suite: 19/19 pass
- Two independent review agents (spec-compliance + adversarial fact-checker) verified every factual claim against repo ground truth; all their findings are addressed in this PR

No app code touched — changes are limited to `.claude/` skill/workflow files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)