### PR TITLE
test(scanner): verifiedbootstate coverage for DeviceAuditor (#86)

### DIFF
--- a/app/src/main/java/com/androdr/scanner/DeviceAuditor.kt
+++ b/app/src/main/java/com/androdr/scanner/DeviceAuditor.kt
@@ -148,9 +148,7 @@ class DeviceAuditor @Inject constructor(
             val systemPropertiesClass = Class.forName("android.os.SystemProperties")
             val getMethod = systemPropertiesClass.getMethod("get", String::class.java, String::class.java)
             val verifiedBootState = getMethod.invoke(null, "ro.boot.verifiedbootstate", "") as? String
-            if (!verifiedBootState.isNullOrBlank()) {
-                return verifiedBootState.lowercase() == "orange"
-            }
+            interpretVerifiedBootState(verifiedBootState)?.let { return it }
         } catch (e: Exception) {
             Log.w(TAG, "DeviceAuditor: SystemProperties reflection blocked, falling through: ${e.message}")
             // Reflection blocked on this device/API level — fall through
@@ -166,6 +164,26 @@ class DeviceAuditor @Inject constructor(
         } catch (e: Exception) {
             Log.w(TAG, "DeviceAuditor: bootloader lock state check failed: ${e.message}")
             false
+        }
+    }
+
+    /**
+     * Interprets the authoritative Android Verified Boot state string
+     * (`ro.boot.verifiedbootstate`).
+     *
+     * - `orange` → bootloader unlocked (`true`)
+     * - `green` / `yellow` / `red` → bootloader locked (`false`)
+     * - null/blank/unrecognised → `null`, signalling the caller to fall back to
+     *   the OEM `Build.BOOTLOADER` heuristic.
+     *
+     * `internal` for unit-test visibility within the module.
+     */
+    internal fun interpretVerifiedBootState(state: String?): Boolean? {
+        if (state.isNullOrBlank()) return null
+        return when (state.lowercase()) {
+            "orange" -> true
+            "green", "yellow", "red" -> false
+            else -> null
         }
     }
 }

--- a/app/src/test/java/com/androdr/scanner/DeviceAuditorBootStateTest.kt
+++ b/app/src/test/java/com/androdr/scanner/DeviceAuditorBootStateTest.kt
@@ -1,0 +1,65 @@
+package com.androdr.scanner
+
+import android.content.Context
+import com.androdr.data.repo.CveRepository
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Covers [DeviceAuditor.interpretVerifiedBootState] — the decision logic for the
+ * authoritative `ro.boot.verifiedbootstate` property (issue #86). Reflection into
+ * `android.os.SystemProperties` is not reachable on the JVM test runtime, so the
+ * boot-state interpretation is extracted into a pure function and verified here
+ * across all four documented states plus the fall-through cases.
+ */
+class DeviceAuditorBootStateTest {
+
+    private val auditor = DeviceAuditor(
+        context = mockk<Context>(relaxed = true),
+        cveRepository = mockk<CveRepository>(relaxed = true)
+    )
+
+    @Test
+    fun `orange means bootloader unlocked`() {
+        assertEquals(true, auditor.interpretVerifiedBootState("orange"))
+    }
+
+    @Test
+    fun `green means bootloader locked`() {
+        assertEquals(false, auditor.interpretVerifiedBootState("green"))
+    }
+
+    @Test
+    fun `yellow means bootloader locked`() {
+        assertEquals(false, auditor.interpretVerifiedBootState("yellow"))
+    }
+
+    @Test
+    fun `red means bootloader locked`() {
+        assertEquals(false, auditor.interpretVerifiedBootState("red"))
+    }
+
+    @Test
+    fun `state is case-insensitive`() {
+        assertEquals(true, auditor.interpretVerifiedBootState("ORANGE"))
+        assertEquals(false, auditor.interpretVerifiedBootState("Green"))
+    }
+
+    @Test
+    fun `null state falls through to heuristic`() {
+        assertNull(auditor.interpretVerifiedBootState(null))
+    }
+
+    @Test
+    fun `blank state falls through to heuristic`() {
+        assertNull(auditor.interpretVerifiedBootState(""))
+        assertNull(auditor.interpretVerifiedBootState("   "))
+    }
+
+    @Test
+    fun `unrecognised state falls through to heuristic`() {
+        assertNull(auditor.interpretVerifiedBootState("purple"))
+    }
+}


### PR DESCRIPTION
## Summary
Backfills the unit test required by the #86 acceptance criteria, covering all four Android Verified Boot states (`green`/`yellow`/`orange`/`red`).

The authoritative `ro.boot.verifiedbootstate` path already landed in `DeviceAuditor` (reflection into `SystemProperties`, `orange` ⇒ unlocked). Reflection into `android.os.SystemProperties` is unreachable on the JVM test runtime, so the boot-state **decision logic** is extracted into a pure, `internal` `interpretVerifiedBootState()` — matching the existing internal test-seam convention used by `AppScanner` / `DeviceAdminGrantEmitter` (the repo uses `internal` seams, not `@VisibleForTesting`) — and verified directly.

## Behavior note (flagged by both reviewers)
An **unrecognised non-blank** `verifiedbootstate` value now returns `null` → falls through to the `Build.BOOTLOADER` heuristic, where the old code hard-returned `false`. This is a deliberate improvement: a device reporting an unexpected/future state no longer suppresses the secondary unlock check. The heuristic still defaults to `locked` when it finds no unlock marker, so the locked-case outcome is unchanged.

## Test plan
- `./gradlew :app:testDebugUnitTest --tests "com.androdr.scanner.DeviceAuditorBootStateTest"` — 8 cases pass (4 states + case-insensitivity + null/blank/unrecognised fall-through)
- `./gradlew detekt` — clean
- Reviewed by two independent agents (correctness + style) — both APPROVE

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)