### PR TITLE
fix(scan): repair 4 pipeline bugs found in live-device audit + lint guards

### DIFF
--- a/app/src/main/java/com/androdr/ioc/IndicatorUpdater.kt
+++ b/app/src/main/java/com/androdr/ioc/IndicatorUpdater.kt
@@ -63,7 +63,19 @@ class IndicatorUpdater @Inject constructor(
     private suspend fun runFeed(sourceId: String, fetch: suspend () -> List<Indicator>): Int {
         val entries = fetch()
         if (entries.isNotEmpty()) {
-            dao.upsertAll(entries)
+            // Upsert in bounded chunks rather than one giant transaction. A single
+            // `upsertAll` of a large feed (e.g. hagezi_tif ~540k rows) holds the
+            // sole write connection for the entire run, starving reader threads on
+            // the connection pool for tens of seconds (observed ~28s) and stalling
+            // the UI. Each chunk is its own transaction, so the write lock is
+            // released between batches and readers can interleave.
+            //
+            // Tradeoff: the feed write is no longer atomic with the
+            // deleteStaleEntries below — a crash mid-feed leaves new + old rows
+            // coexisting. That is benign for an IOC cache (PK is (type,value)
+            // with REPLACE, and the next successful sync self-heals), and is the
+            // intended price for not holding one long write lock.
+            entries.chunked(UPSERT_CHUNK_SIZE).forEach { chunk -> dao.upsertAll(chunk) }
             val runStart = entries.minOf { it.fetchedAt } - 1
             dao.deleteStaleEntries(sourceId, runStart)
             Log.i(TAG, "Feed '$sourceId': ${entries.size} indicators upserted")
@@ -75,6 +87,18 @@ class IndicatorUpdater @Inject constructor(
 
     companion object {
         private const val TAG = "IndicatorUpdater"
+
+        /**
+         * Rows per upsert transaction. Bounds how long the single write lock is
+         * held per batch so reader threads on the connection pool are not starved
+         * during a bulk feed sync, while keeping per-batch overhead low.
+         *
+         * This is a transaction-duration knob, not a binding-count limit: Room's
+         * `@Insert(List)` compiles one statement and executes it per row, so
+         * SQLite's ~999-variable limit does not apply. Value is empirically in
+         * the range that keeps lock-release frequent without excessive batches.
+         */
+        internal const val UPSERT_CHUNK_SIZE = 2_000
     }
 }
 

--- a/app/src/main/java/com/androdr/scanner/bugreport/ReceiverModule.kt
+++ b/app/src/main/java/com/androdr/scanner/bugreport/ReceiverModule.kt
@@ -33,14 +33,31 @@ class ReceiverModule @Inject constructor(
     )
 
     /**
+     * Matches an intent-action header line within the "Non-Data Actions" table,
+     * e.g. `    android.provider.Telephony.SMS_RECEIVED:`. The action must
+     * contain at least one dot and the line must end at the colon, which
+     * distinguishes it from receiver-entry lines (`<n> pkg/component ...`) and
+     * from the nested `Action: "..."` evidence lines.
+     */
+    private val intentHeaderRegex = Regex(
+        """^\s+[A-Za-z][\w.]*\.[\w.]+\s*:\s*$""",
+        RegexOption.MULTILINE
+    )
+
+    /**
      * Safety cap on how much text we read past the LAST sensitive intent's
      * header when building its per-intent block. Intermediate intents are
      * naturally bounded by the next intent's start position, so this cap
-     * only applies to the final one in the list. Chosen large enough to
-     * hold thousands of receiver entries (the biggest realistic intent
-     * block is ~tens of KB on any device), small enough to prevent a
-     * degenerate bug report from making us substring most of a 16+ MB
-     * package section.
+     * only applies to the final one in the list.
+     *
+     * Note: `truncateAtNextHeader` now trims every block (including the last)
+     * at the next intent-action header of any kind, so in practice this cap
+     * only takes effect when the last enumerated intent is genuinely the final
+     * group in the table (no following header at all). It is kept as a bound on
+     * the substring length so a degenerate bug report cannot make us copy most
+     * of a 16+ MB package section before truncation runs. Chosen large enough
+     * to hold thousands of receiver entries (the biggest realistic intent block
+     * is ~tens of KB on any device).
      */
     private val lastIntentBlockCap = 256 * 1024
 
@@ -100,7 +117,17 @@ class ReceiverModule @Inject constructor(
             } else {
                 minOf(intentStart + lastIntentBlockCap, sectionText.length)
             }
-            val block = sectionText.substring(intentStart, blockEnd)
+            // `blockEnd` only bounds us at the next *enumerated* intent (or the
+            // cap, for the last enumerated intent). But the dumpsys table also
+            // contains NON-enumerated intent groups, and the receivers under
+            // those must not be attributed to this intent. Concretely, because
+            // SMS_RECEIVED sorts last among the enumerated actions, its block
+            // ran to the 256 KB cap and swept in every following group — e.g.
+            // androidx.work's DiagnosticsReceiver (registered under
+            // androidx.work.diagnostics.*) was reported as an SMS receiver.
+            // Truncate at the first intent-action header that follows this
+            // intent's own header so each block holds only its own receivers.
+            val block = truncateAtNextHeader(sectionText.substring(intentStart, blockEnd))
 
             receiverEntryRegex.findAll(block).forEach { match ->
                 val packageName = match.groupValues[1]
@@ -122,5 +149,18 @@ class ReceiverModule @Inject constructor(
             telemetry = telemetry,
             telemetryService = "receiver_audit"
         )
+    }
+
+    /**
+     * Trims [block] (which begins with one intent-action header) so it ends at
+     * the next intent-action header, keeping only the receiver entries that
+     * belong to this intent. If no following header is present, the block is
+     * returned unchanged.
+     */
+    private fun truncateAtNextHeader(block: String): String {
+        val firstLineEnd = block.indexOf('\n')
+        if (firstLineEnd < 0) return block
+        val next = intentHeaderRegex.find(block, firstLineEnd + 1) ?: return block
+        return block.substring(0, next.range.first)
     }
 }

--- a/app/src/main/res/raw/sigma_androdr_066_boot_persistence.yml
+++ b/app/src/main/res/raw/sigma_androdr_066_boot_persistence.yml
@@ -24,7 +24,26 @@ detection:
         is_system_app: false
     filter_known_good:
         package_name|ioc_lookup: known_good_app_db
-    condition: selection and not filter_known_good
+    # Jetpack/Play-services libraries register their own boot receivers in
+    # virtually every modern app (e.g. androidx.work's RescheduleReceiver for
+    # WorkManager, which is the receiver this rule was firing on for AndroDR
+    # itself). The receiving *component* being a well-known framework class
+    # carries no persistence signal on its own, so exclude those to avoid
+    # flagging essentially every app. Prefixes are scoped to the specific
+    # framework packages that ship boot receivers — not a blanket "androidx." —
+    # to keep the exclusion narrow.
+    #
+    # Tradeoff: component_name is attacker-controllable, so a determined threat
+    # could name its receiver e.g. "androidx.work.Evil" to evade this filter.
+    # That is acceptable for a level:low informational rule whose unfiltered
+    # signal is near-zero (almost every app has a boot receiver); do NOT promote
+    # this rule above low while this component-prefix filter stands.
+    filter_framework_component:
+        component_name|startswith:
+            - "androidx.work."
+            - "com.google.android.gms."
+            - "com.google.firebase."
+    condition: selection and not filter_known_good and not filter_framework_component
 level: low
 display:
     category: app_risk

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -18,14 +18,22 @@
         </pin-set>
     </domain-config>
 
-    <!-- Pin Google Storage (OSV feeds) -->
+    <!-- Pin Google Storage (OSV feeds). The bucket
+         osv-vulnerabilities.storage.googleapis.com now serves a chain rooted at
+         GTS Root R4 via the WE2 intermediate (migrated from GTS Root R1 / WR2,
+         which silently broke pinning and disabled OSV CVE enrichment). We pin
+         the current intermediate + root and keep GTS Root R1 as a backup root,
+         since Google rotates between roots and Android matches any pin in the
+         set against any cert in the verified chain. -->
     <domain-config>
         <domain includeSubdomains="true">storage.googleapis.com</domain>
         <pin-set expiration="2027-06-01">
-            <!-- GTS Root R1 -->
+            <!-- GTS Root R4 (current root) -->
+            <pin digest="SHA-256">mEflZT5enoR1FuXLgYYGqnVEoZvmf9c2bVBpiOjYQ0c=</pin>
+            <!-- WE2 intermediate (current) -->
+            <pin digest="SHA-256">vh78KSg1Ry4NaqGDV10w/cTb9VH3BQUZoCWNa93W/EY=</pin>
+            <!-- GTS Root R1 (backup root) -->
             <pin digest="SHA-256">hxqRlPTu1bMS/0DITB1SSu0vd4u/8l8TjPgfaAp63Gc=</pin>
-            <!-- WR2 intermediate -->
-            <pin digest="SHA-256">YPtHaftLw6/0vnc2BnNKGF54xiCA28WFcccjkA4ypCM=</pin>
         </pin-set>
     </domain-config>
 

--- a/app/src/test/java/com/androdr/ioc/IndicatorUpdaterTest.kt
+++ b/app/src/test/java/com/androdr/ioc/IndicatorUpdaterTest.kt
@@ -1,0 +1,80 @@
+package com.androdr.ioc
+
+import com.androdr.data.db.IndicatorDao
+import com.androdr.data.model.Indicator
+import com.androdr.data.model.IocEntry
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class IndicatorUpdaterTest {
+
+    private val dao: IndicatorDao = mockk(relaxed = true)
+    private val resolver: IndicatorResolver = mockk(relaxed = true)
+
+    private fun packageFeed(id: String, count: Int): IocFeed = object : IocFeed {
+        override val sourceId: String = id
+        override suspend fun fetch(): List<IocEntry> = (0 until count).map {
+            IocEntry(
+                packageName = "com.pkg$it",
+                name = "n", category = "c", severity = "LOW",
+                description = "d", source = id, fetchedAt = 1_000L + it,
+            )
+        }
+    }
+
+    @Test
+    fun `large feed is upserted in bounded chunks rather than one transaction`() = runBlocking {
+        val total = IndicatorUpdater.UPSERT_CHUNK_SIZE * 2 + 37
+        val sizes = mutableListOf<Int>()
+        coEvery { dao.upsertAll(any()) } answers {
+            sizes += firstArg<List<Indicator>>().size
+        }
+
+        val updater = IndicatorUpdater(
+            dao = dao,
+            resolver = resolver,
+            domainFeeds = emptyList(),
+            certHashFeeds = emptyList(),
+            packageFeeds = listOf(packageFeed("test_feed", total)),
+        )
+
+        val returned = updater.update()
+
+        assertEquals("update() should report the full fetched count", total, returned)
+        // No single transaction may exceed the chunk cap.
+        assertTrue(
+            "no chunk may exceed UPSERT_CHUNK_SIZE; saw $sizes",
+            sizes.all { it <= IndicatorUpdater.UPSERT_CHUNK_SIZE },
+        )
+        // All rows must still be written exactly once in aggregate.
+        assertEquals(total, sizes.sum())
+        // It must actually be split into multiple transactions (regression guard
+        // against reverting to one giant upsert). Derive the expected count from
+        // the chunk size rather than hard-coding it, so the assertion tracks
+        // UPSERT_CHUNK_SIZE instead of breaking when it is retuned.
+        val expectedChunks =
+            (total + IndicatorUpdater.UPSERT_CHUNK_SIZE - 1) / IndicatorUpdater.UPSERT_CHUNK_SIZE
+        assertTrue("bulk feed must be split across transactions", sizes.size > 1)
+        assertEquals(expectedChunks, sizes.size)
+    }
+
+    @Test
+    fun `empty feed performs no upsert`() = runBlocking {
+        val updater = IndicatorUpdater(
+            dao = dao,
+            resolver = resolver,
+            domainFeeds = emptyList(),
+            certHashFeeds = emptyList(),
+            packageFeeds = listOf(packageFeed("empty_feed", 0)),
+        )
+
+        updater.update()
+
+        coVerify(exactly = 0) { dao.upsertAll(any()) }
+    }
+}

--- a/app/src/test/java/com/androdr/scanner/bugreport/ReceiverModuleTest.kt
+++ b/app/src/test/java/com/androdr/scanner/bugreport/ReceiverModuleTest.kt
@@ -139,6 +139,83 @@ class ReceiverModuleTest {
     }
 
     @Test
+    fun `does not attribute receivers from a following non-enumerated intent`() = runBlocking {
+        // SMS_RECEIVED sorts last among the enumerated actions, so its block
+        // previously ran to the safety cap and swept in receivers belonging to
+        // later, non-enumerated intent groups (e.g. androidx.work's
+        // DiagnosticsReceiver under androidx.work.diagnostics.*).
+        val section = """
+            Receiver Resolver Table:
+              Non-Data Actions:
+                  android.provider.Telephony.SMS_RECEIVED:
+                    12345 com.evil.sms/.SmsReceiver filter abcdef
+                      Action: "android.provider.Telephony.SMS_RECEIVED"
+                  androidx.work.impl.diagnostics.REQUEST_DIAGNOSTICS:
+                    67890 com.benign.app/androidx.work.impl.diagnostics.DiagnosticsReceiver filter beef
+                      Action: "androidx.work.impl.diagnostics.REQUEST_DIAGNOSTICS"
+        """.trimIndent()
+
+        val result = module.analyze(section, mockIndicatorResolver, DeviceIdentity.UNKNOWN)
+
+        // The real SMS receiver is still detected...
+        assertTrue(
+            "expected the genuine SMS receiver to be detected",
+            result.telemetry.any { it["package_name"] == "com.evil.sms" },
+        )
+        // ...but the WorkManager diagnostics receiver must NOT be mislabelled as
+        // an SMS receiver (nor appear at all — its intent is not enumerated).
+        assertTrue(
+            "WorkManager DiagnosticsReceiver must not be attributed to SMS_RECEIVED",
+            result.telemetry.none { it["package_name"] == "com.benign.app" },
+        )
+    }
+
+    @Test
+    fun `non-enumerated group between two enumerated intents is excluded from both`() = runBlocking {
+        // A non-enumerated intent group sits BETWEEN two enumerated ones. This
+        // is the case only `truncateAtNextHeader` handles: BOOT_COMPLETED's
+        // blockEnd is the SMS header, so without header-level truncation the
+        // in-between receiver would be swept into BOOT_COMPLETED.
+        val section = """
+            Receiver Resolver Table:
+              Non-Data Actions:
+                  android.intent.action.BOOT_COMPLETED:
+                    11111 com.app.boot/.BootReceiver filter aaaa
+                      Action: "android.intent.action.BOOT_COMPLETED"
+                  com.example.custom.MIDDLE_ACTION:
+                    33333 com.middle.app/.MiddleReceiver filter cccc
+                      Action: "com.example.custom.MIDDLE_ACTION"
+                  android.provider.Telephony.SMS_RECEIVED:
+                    22222 com.app.sms/.SmsReceiver filter bbbb
+                      Action: "android.provider.Telephony.SMS_RECEIVED"
+        """.trimIndent()
+
+        val result = module.analyze(section, mockIndicatorResolver, DeviceIdentity.UNKNOWN)
+
+        assertTrue(
+            "boot receiver must map to BOOT_COMPLETED only",
+            result.telemetry.any {
+                it["package_name"] == "com.app.boot" &&
+                    it["intent_action"] == "android.intent.action.BOOT_COMPLETED"
+            },
+        )
+        assertTrue(
+            "sms receiver must map to SMS_RECEIVED only",
+            result.telemetry.any {
+                it["package_name"] == "com.app.sms" &&
+                    it["intent_action"] == "android.provider.Telephony.SMS_RECEIVED"
+            },
+        )
+        // The in-between non-enumerated receiver must not be attributed to the
+        // preceding enumerated intent (nor appear at all — its action is not
+        // enumerated). This is what fails if truncateAtNextHeader is a no-op.
+        assertTrue(
+            "middle receiver must not be swept into BOOT_COMPLETED",
+            result.telemetry.none { it["package_name"] == "com.middle.app" },
+        )
+    }
+
+    @Test
     fun `empty section produces no telemetry`() = runBlocking {
         val result = module.analyze("", mockIndicatorResolver, com.androdr.ioc.DeviceIdentity.UNKNOWN)
         assertTrue(result.telemetry.isEmpty())

--- a/app/src/test/java/com/androdr/security/NetworkSecurityConfigTest.kt
+++ b/app/src/test/java/com/androdr/security/NetworkSecurityConfigTest.kt
@@ -1,0 +1,70 @@
+package com.androdr.security
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.w3c.dom.Element
+import java.io.File
+import java.text.SimpleDateFormat
+import java.util.Locale
+import java.util.TimeZone
+import javax.xml.parsers.DocumentBuilderFactory
+
+/**
+ * Lightweight guard for the certificate-pinning config.
+ *
+ * This cannot verify pins against live certificate chains offline (that failure
+ * mode — Google rotating storage.googleapis.com from GTS Root R1/WR2 to R4/WE2 —
+ * silently disabled OSV CVE enrichment). But it does catch the two static
+ * mistakes that turn pinning into an outage:
+ *  - an expiration date that has already passed (pins stop being enforced, or
+ *    worse, all traffic to the domain breaks depending on OS behaviour), and
+ *  - a single-pin set, which bricks the domain the moment that one cert rotates
+ *    (the standard guidance is to always ship a backup pin).
+ */
+class NetworkSecurityConfigTest {
+
+    private fun configFile(): File = listOf(
+        File("app/src/main/res/xml/network_security_config.xml"),
+        File("src/main/res/xml/network_security_config.xml"),
+        File("/home/yasir/AndroDR/app/src/main/res/xml/network_security_config.xml"),
+    ).firstOrNull { it.isFile }
+        ?: error("network_security_config.xml not found")
+
+    @Test
+    fun `every pin-set is future-dated and has a backup pin`() {
+        val doc = DocumentBuilderFactory.newInstance()
+            .newDocumentBuilder()
+            .parse(configFile())
+
+        val dateFormat = SimpleDateFormat("yyyy-MM-dd", Locale.US).apply {
+            timeZone = TimeZone.getTimeZone("UTC")
+        }
+        val now = System.currentTimeMillis()
+
+        val pinSets = doc.getElementsByTagName("pin-set")
+        assertTrue("expected at least one <pin-set>", pinSets.length > 0)
+
+        for (i in 0 until pinSets.length) {
+            val pinSet = pinSets.item(i) as Element
+            val domain = (pinSet.parentNode as? Element)
+                ?.getElementsByTagName("domain")?.item(0)?.textContent?.trim()
+                ?: "pin-set[$i]"
+
+            val expiration = pinSet.getAttribute("expiration")
+            assertTrue("$domain: <pin-set> is missing an expiration", expiration.isNotBlank())
+            val expiresAt = dateFormat.parse(expiration)?.time
+                ?: error("$domain: unparseable expiration '$expiration'")
+            assertTrue(
+                "$domain: pin-set expired on $expiration — pinning is no longer enforced",
+                expiresAt > now,
+            )
+
+            val pinCount = pinSet.getElementsByTagName("pin").length
+            assertTrue(
+                "$domain: only $pinCount pin(s) — ship at least 2 (a backup) so cert " +
+                    "rotation cannot brick the domain",
+                pinCount >= 2,
+            )
+        }
+    }
+}

--- a/app/src/test/java/com/androdr/sigma/RuleManifestIntegrityTest.kt
+++ b/app/src/test/java/com/androdr/sigma/RuleManifestIntegrityTest.kt
@@ -1,0 +1,133 @@
+package com.androdr.sigma
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Assume.assumeTrue
+import org.junit.Test
+import java.io.File
+import java.security.MessageDigest
+
+/**
+ * Build-time guard against rule-feed integrity drift.
+ *
+ * The app fetches `rules.txt` + `rules.sha256` from the android-sigma-rules repo
+ * and skips any rule whose content hash does not match the manifest
+ * (`SigmaRuleFeed.fetchFromRepo`). If a rule YAML is edited without regenerating
+ * `rules.sha256`, the integrity check fails silently on-device and that rule is
+ * dropped — degrading detection with no build-time signal.
+ *
+ * Scope: this checks the **submodule manifest's** internal consistency
+ * (`rules.txt` ⇔ `rules.sha256` ⇔ on-disk file content) — i.e. the data the
+ * remote feed serves. It does NOT cross-check the bundled `res/raw` cold-start
+ * copies, and rules that live under `staging/` (not yet listed in `rules.txt`)
+ * are out of scope until promoted. Regenerate the manifest with:
+ *
+ *     cd third-party/android-sigma-rules
+ *     while read -r f; do printf '%s  %s\n' "$(sha256sum "$f" | cut -d' ' -f1)" "$f"; done < rules.txt > rules.sha256
+ */
+class RuleManifestIntegrityTest {
+
+    private fun repoRoot(): File? = listOf(
+        File("third-party/android-sigma-rules"),
+        File("../third-party/android-sigma-rules"),
+        File("/home/yasir/AndroDR/third-party/android-sigma-rules"),
+    ).firstOrNull { it.isDirectory }
+
+    private fun sha256Hex(file: File): String =
+        MessageDigest.getInstance("SHA-256").digest(file.readBytes())
+            .joinToString("") { "%02x".format(it) }
+
+    @Test
+    fun `rules manifest and hashes are in sync with rule files`() {
+        val root = repoRoot()
+        assumeTrue("android-sigma-rules submodule not checked out — skipping", root != null)
+        requireNotNull(root)
+
+        val manifest = File(root, "rules.txt")
+        val hashManifest = File(root, "rules.sha256")
+        assumeTrue("rules.txt missing — skipping", manifest.isFile)
+        assumeTrue("rules.sha256 missing — skipping", hashManifest.isFile)
+
+        val listedFiles = manifest.readLines().map { it.trim() }.filter { it.endsWith(".yml") }
+        val expectedHashes = parseHashManifest(hashManifest.readLines())
+
+        val problems = findManifestProblems(listedFiles, expectedHashes) { rel ->
+            File(root, rel).takeIf { it.isFile }?.let { sha256Hex(it) }
+        }
+
+        if (problems.isNotEmpty()) {
+            fail(
+                "rules.sha256 is out of sync with rule content — these rules would be " +
+                    "silently skipped on-device. Regenerate rules.sha256 (see test header).\n" +
+                    problems.joinToString("\n"),
+            )
+        }
+    }
+
+    /**
+     * Proves the guard itself detects drift, independent of the real submodule
+     * state, so the positive test above cannot pass merely because the manifest
+     * happens to be in sync right now.
+     */
+    @Test
+    fun `findManifestProblems detects stale hash, missing file, and set mismatch`() {
+        val listed = listOf("a.yml", "b.yml", "c.yml")
+        val expected = mapOf(
+            "a.yml" to "aaaa",            // will match
+            "b.yml" to "ffff",            // stale — content hashes to "bbbb"
+            // c.yml present in rules.txt but absent from rules.sha256 → set mismatch
+        )
+        val onDisk = mapOf("a.yml" to "aaaa", "b.yml" to "bbbb") // c.yml missing on disk
+
+        val problems = findManifestProblems(listed, expected) { onDisk[it] }
+
+        assertTrue("should flag stale hash for b.yml", problems.any { it.contains("STALE") && it.contains("b.yml") })
+        assertTrue("should flag missing file c.yml", problems.any { it.contains("MISSING") && it.contains("c.yml") })
+        assertTrue("should flag manifest set mismatch", problems.any { it.contains("SET-MISMATCH") })
+
+        // And a fully-consistent manifest yields no problems.
+        val clean = findManifestProblems(
+            listOf("a.yml"),
+            mapOf("a.yml" to "aaaa"),
+        ) { mapOf("a.yml" to "aaaa")[it] }
+        assertEquals(emptyList<String>(), clean)
+    }
+
+    private companion object {
+
+        /** sha256sum convention: "<hex>  <path>" (two-space separator). */
+        fun parseHashManifest(lines: List<String>): Map<String, String> = lines.mapNotNull { line ->
+            val parts = line.trim().split(Regex("\\s+"), limit = 2)
+            if (parts.size == 2) parts[1] to parts[0].lowercase() else null
+        }.toMap()
+
+        /**
+         * Pure comparison core shared by the live and synthetic tests.
+         * @param hashProvider returns the actual content hash for a listed path,
+         *   or null if the file does not exist.
+         */
+        fun findManifestProblems(
+            listedFiles: List<String>,
+            expectedHashes: Map<String, String>,
+            hashProvider: (String) -> String?,
+        ): List<String> {
+            val problems = mutableListOf<String>()
+            if (listedFiles.toSortedSet() != expectedHashes.keys.toSortedSet()) {
+                problems += "SET-MISMATCH: rules.txt and rules.sha256 list different files"
+            }
+            for (rel in listedFiles) {
+                val actual = hashProvider(rel)
+                if (actual == null) {
+                    problems += "MISSING: $rel (listed in rules.txt but not on disk)"
+                    continue
+                }
+                val expected = expectedHashes[rel]
+                if (expected != null && actual.lowercase() != expected.lowercase()) {
+                    problems += "STALE:   $rel (expected=$expected actual=$actual)"
+                }
+            }
+            return problems
+        }
+    }
+}

--- a/app/src/test/resources/gate4-fixtures/boot-persistence.yml
+++ b/app/src/test/resources/gate4-fixtures/boot-persistence.yml
@@ -15,8 +15,27 @@ true_positives:
   - package_name: "com.shady.persistence"
     intent_action: "android.intent.action.LOCKED_BOOT_COMPLETED"
     is_system_app: false
+  # Genuine boot persistence via the app's OWN receiver component must still
+  # fire even though component_name is present (guards filter_framework_component
+  # against over-matching).
+  - package_name: "com.shady.malware"
+    intent_action: "android.intent.action.BOOT_COMPLETED"
+    component_name: "com.shady.malware.BootReceiver"
+    is_system_app: false
 
 true_negatives:
+  # WorkManager's reschedule receiver (androidx.work) — present in nearly every
+  # modern app; filtered by filter_framework_component. This is the false
+  # positive the filter exists to suppress (AndroDR itself flagged on it).
+  - package_name: "com.benign.app"
+    intent_action: "android.intent.action.BOOT_COMPLETED"
+    component_name: "androidx.work.impl.background.systemalarm.RescheduleReceiver"
+    is_system_app: false
+  # Play-services boot receiver — also filtered by framework-component prefix.
+  - package_name: "com.benign.gmsapp"
+    intent_action: "android.intent.action.LOCKED_BOOT_COMPLETED"
+    component_name: "com.google.android.gms.measurement.AppMeasurementReceiver"
+    is_system_app: false
   # System app — filtered by is_system_app
   - package_name: "com.android.phone"
     intent_action: "android.intent.action.BOOT_COMPLETED"


### PR DESCRIPTION
Found by auditing a live scan + bug-report run on a physical Galaxy device. Four defects, none visible in the UI, plus guards so two of the classes can't silently recur.

## Bugs fixed

**Bug 2 — IOC ingestion stalls the DB for ~28s.** `IndicatorUpdater` upserted each feed in one giant transaction, holding the sole write connection and starving the pool (observed 28s denial during `hagezi_tif` ~540k rows). Now upserts in bounded chunks (`UPSERT_CHUNK_SIZE=2000`); the write lock is released between batches.

**Bug 3 — OSV CVE enrichment fully broken (cert pinning).** `storage.googleapis.com` rotated from GTS Root R1/WR2 → **GTS Root R4/WE2**, so the pinned set no longer matched and every OSV fetch failed with `Pin verification failed`. Updated pins to R4 + WE2, keeping R1 as a backup root.

**Bug 4a — bug-report parser mis-attributes receivers.** Each enumerated intent's receiver block was bounded only by the next *enumerated* intent (or a 256KB cap for the last). `SMS_RECEIVED` sorts last, so its block swept in receivers from following *non-enumerated* groups — e.g. `androidx.work`'s `DiagnosticsReceiver` was reported as an SMS receiver. `truncateAtNextHeader` now bounds each block at the next intent-action header of any kind.

**Bug 4b — rule 066 false-positives on WorkManager.** "Boot Persistence" fired on `androidx.work`'s `RescheduleReceiver` in essentially every app (incl. AndroDR itself). Added a narrow `filter_framework_component` (scoped `androidx.work.`/`com.google.android.gms.`/`com.google.firebase.` prefixes) with a documented evasion tradeoff; mirrored to the submodule staging copy.

## Lint guards (Bug 5)
- **`RuleManifestIntegrityTest`** — fails the build if `rules.sha256` drifts from rule content. This is the silent-detection-loss class: **12 `app_scanner` rules were being skipped on-device** because the published `rules.sha256` was stale. Manifest regenerated in android-sigma-rules#35.
- **`NetworkSecurityConfigTest`** — asserts every cert pin-set is future-dated and ships a backup pin.

## Related
- Rule-repo fix (re-enables the 12 dropped rules for users): android-sigma-rules#35. Submodule pointer will be bumped here once that merges.

## Verification
- `./gradlew :app:testDebugUnitTest :app:lintDebug` — green (new tests included; manifest guard verified to fail on injected drift).
- Two-reviewer cycle (correctness/security + maintainability) — both APPROVE after fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)