### PR TITLE
fix(security): stop pinning storage.googleapis.com (OSV CVE feed)

### DIFF
--- a/app/src/main/java/com/androdr/data/repo/CveRepository.kt
+++ b/app/src/main/java/com/androdr/data/repo/CveRepository.kt
@@ -235,6 +235,10 @@ class CveRepository @Inject constructor(
         private const val TAG = "CveRepository"
         private const val CISA_KEV_URL =
             "https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json"
+        // storage.googleapis.com is intentionally NOT certificate-pinned: Google
+        // serves it from many POPs with varying cert chains, so any pin breaks
+        // per-device. Do not "fix" an OSV TLS failure by adding a pin — see the
+        // rationale in res/xml/network_security_config.xml.
         private const val OSV_ANDROID_URL =
             "https://osv-vulnerabilities.storage.googleapis.com/Android/all.zip"
         private const val TIMEOUT_MS = 30_000

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -18,24 +18,15 @@
         </pin-set>
     </domain-config>
 
-    <!-- Pin Google Storage (OSV feeds). The bucket
-         osv-vulnerabilities.storage.googleapis.com now serves a chain rooted at
-         GTS Root R4 via the WE2 intermediate (migrated from GTS Root R1 / WR2,
-         which silently broke pinning and disabled OSV CVE enrichment). We pin
-         the current intermediate + root and keep GTS Root R1 as a backup root,
-         since Google rotates between roots and Android matches any pin in the
-         set against any cert in the verified chain. -->
-    <domain-config>
-        <domain includeSubdomains="true">storage.googleapis.com</domain>
-        <pin-set expiration="2027-06-01">
-            <!-- GTS Root R4 (current root) -->
-            <pin digest="SHA-256">mEflZT5enoR1FuXLgYYGqnVEoZvmf9c2bVBpiOjYQ0c=</pin>
-            <!-- WE2 intermediate (current) -->
-            <pin digest="SHA-256">vh78KSg1Ry4NaqGDV10w/cTb9VH3BQUZoCWNa93W/EY=</pin>
-            <!-- GTS Root R1 (backup root) -->
-            <pin digest="SHA-256">hxqRlPTu1bMS/0DITB1SSu0vd4u/8l8TjPgfaAp63Gc=</pin>
-        </pin-set>
-    </domain-config>
+    <!-- Google Storage (OSV CVE feed) is deliberately NOT pinned. Google serves
+         *.storage.googleapis.com from many POPs with varying intermediates and
+         roots (GTS CA 1C3/1D4, WR1-4, WE1-2; roots R1-R4) and rotates keys
+         frequently, so any fixed pin set breaks unpredictably per-device — it
+         silently disabled OSV enrichment until found via on-device testing.
+         Google explicitly advises against pinning their domains. This host
+         falls back to base-config: system CAs only, no user CAs, no cleartext —
+         standard secure TLS for a public read-only data feed. The primary
+         actively-exploited source (cisa.gov) remains pinned. -->
 
     <!-- Pin GitHub (SIGMA rule feed) -->
     <domain-config>

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -23,8 +23,9 @@
          roots (GTS CA 1C3/1D4, WR1-4, WE1-2; roots R1-R4) and rotates keys
          frequently, so any fixed pin set breaks unpredictably per-device — it
          silently disabled OSV enrichment until found via on-device testing.
-         Google explicitly advises against pinning their domains. This host
-         falls back to base-config: system CAs only, no user CAs, no cleartext —
+         Google rotates CAs frequently across their fleet and advises against
+         pinning leaf/intermediate certs for their domains. This host falls back
+         to base-config: system CAs only, no user CAs, no cleartext —
          standard secure TLS for a public read-only data feed. The primary
          actively-exploited source (cisa.gov) remains pinned. -->
 

--- a/app/src/test/java/com/androdr/security/NetworkSecurityConfigTest.kt
+++ b/app/src/test/java/com/androdr/security/NetworkSecurityConfigTest.kt
@@ -1,5 +1,6 @@
 package com.androdr.security
 
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.w3c.dom.Element
@@ -65,6 +66,37 @@ class NetworkSecurityConfigTest {
                     "rotation cannot brick the domain",
                 pinCount >= 2,
             )
+        }
+    }
+
+    /**
+     * Guards the deliberate decision to NOT pin storage.googleapis.com: Google
+     * serves it from many POPs with varying cert chains, so any pin breaks
+     * per-device and silently disables OSV CVE enrichment. This makes that
+     * decision enforced rather than merely documented in a comment — a
+     * re-added Google pin fails the build.
+     */
+    @Test
+    fun `storage_googleapis_com is not pinned`() {
+        val doc = DocumentBuilderFactory.newInstance()
+            .newDocumentBuilder()
+            .parse(configFile())
+
+        val domainConfigs = doc.getElementsByTagName("domain-config")
+        for (i in 0 until domainConfigs.length) {
+            val dc = domainConfigs.item(i) as Element
+            val domains = dc.getElementsByTagName("domain")
+            val coversGoogleStorage = (0 until domains.length).any {
+                domains.item(it).textContent.trim().contains("storage.googleapis.com")
+            }
+            if (coversGoogleStorage) {
+                assertEquals(
+                    "storage.googleapis.com must not be pinned (Google rotates CAs per-POP; " +
+                        "pinning it silently breaks OSV CVE enrichment)",
+                    0,
+                    dc.getElementsByTagName("pin-set").length,
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
## What
Removes the certificate-pinning `<pin-set>` for `storage.googleapis.com` (the OSV CVE feed host). The host falls back to base-config: **system CAs only, no user CAs, no cleartext** — standard secure TLS for a public read-only data feed.

## Why
Follow-up from on-device verification of #220. OSV CVE enrichment still failed with `Pin verification failed` on a real Galaxy (Android 13) **even after** updating the pins to the chain this dev machine sees (GTS Root R4 / WE2). Root cause: Google serves `*.storage.googleapis.com` from many POPs with varying intermediates/roots (GTS CA 1C3/1D4, WR1-4, WE1-2; roots R1-R4) and rotates keys frequently, so the device validates a chain containing **none** of the pinned keys. No fixed pin set matches reliably.

**Verified on-device after removal:** OSV now connects (HTTP 304, no pin error). `cisa.gov` (primary actively-exploited source) and `raw.githubusercontent.com` remain pinned and work.

## Review fixes applied (two-reviewer cycle, both approved)
- Breadcrumb at `CveRepository.OSV_ANDROID_URL` so the no-pin decision is discoverable from the fetch code.
- `NetworkSecurityConfigTest` negative assertion: `storage.googleapis.com` must not be pinned — re-adding a Google pin fails the build.
- Softened the "Google advises against pinning" wording to match their actual guidance.

## Note (pre-existing, out of scope)
The `raw.githubusercontent.com` pin comment labels a pin "Leaf: *.github.io", which looks like a copy/paste artifact — flagged for a separate follow-up, not touched here.

## Verification
- `./gradlew :app:testDebugUnitTest :app:lintDebug` — green (NetworkSecurityConfigTest now 2 tests).
- On-device: OSV connects, no `Pin verification failed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)