### PR TITLE
test(scanner): guard rule permission literals against scanner set (#225)

### DIFF
--- a/app/src/main/java/com/androdr/scanner/AppScanner.kt
+++ b/app/src/main/java/com/androdr/scanner/AppScanner.kt
@@ -6,6 +6,7 @@ import android.content.pm.ApplicationInfo
 import android.content.pm.PackageManager
 import android.os.Build
 import android.util.Log
+import androidx.annotation.VisibleForTesting
 import com.androdr.data.model.AppTelemetry
 import com.androdr.data.model.TelemetrySource
 import com.androdr.data.model.KnownAppCategory
@@ -33,7 +34,7 @@ class AppScanner @Inject constructor(
 
     private val localDevice = DeviceIdentity.local()
 
-    private companion object {
+    companion object {
         private const val TAG = "AppScanner"
 
         /**
@@ -51,37 +52,54 @@ class AppScanner @Inject constructor(
         // NEW (#168):
         private const val MAX_COMPONENTS_PER_APP = 1024
         private const val MAX_NATIVE_LIBS_PER_APP = 256
+
+        /**
+         * Dangerous permission combinations that, when two or more appear together,
+         * suggest a high-risk surveillance or data-exfiltration capability. Counted
+         * by [AppTelemetry.surveillancePermissionCount].
+         */
+        private val SURVEILLANCE_PERMISSIONS = setOf(
+            Manifest.permission.RECORD_AUDIO,
+            Manifest.permission.READ_CONTACTS,
+            Manifest.permission.READ_CALL_LOG,
+            Manifest.permission.PROCESS_OUTGOING_CALLS,
+            Manifest.permission.READ_SMS,
+            Manifest.permission.SEND_SMS,
+            Manifest.permission.ACCESS_FINE_LOCATION,
+            Manifest.permission.CAMERA,
+            Manifest.permission.READ_EXTERNAL_STORAGE
+        )
+
+        /**
+         * High-risk permissions that are NOT surveillance signals but are abused by
+         * malware — e.g. SYSTEM_ALERT_WINDOW (banking-trojan credential overlays) and
+         * NFC (card-emulation relay fraud). Surfaced in the `permissions` telemetry
+         * field (short-named), but deliberately excluded from
+         * [AppTelemetry.surveillancePermissionCount] so they do not inflate the
+         * surveillance-cluster rules (androdr-011/017).
+         */
+        private val HIGH_RISK_PERMISSIONS = setOf(
+            Manifest.permission.SYSTEM_ALERT_WINDOW,
+            Manifest.permission.NFC
+        )
+
+        /**
+         * The exact set of short-named permissions the scanner places in
+         * [AppTelemetry.permissions]. This is the SINGLE SOURCE OF TRUTH for which
+         * permissions a SIGMA rule can match via `permissions|contains`.
+         * `PermissionLiteralCrossCheckTest` asserts every bundled rule's permission
+         * literal is a member — closing the dead-rule class that silently killed
+         * androdr-069 (a rule referenced a permission the scanner never emitted; #225).
+         */
+        @VisibleForTesting
+        internal val EXPOSED_PERMISSION_SHORT_NAMES: Set<String> =
+            (SURVEILLANCE_PERMISSIONS + HIGH_RISK_PERMISSIONS)
+                .map { it.substringAfterLast('.') }
+                .toSet()
     }
 
-    /**
-     * Dangerous permission combinations that, when two or more appear together,
-     * suggest a high-risk surveillance or data-exfiltration capability.
-     */
-    private val surveillancePermissions = setOf(
-        Manifest.permission.RECORD_AUDIO,
-        Manifest.permission.READ_CONTACTS,
-        Manifest.permission.READ_CALL_LOG,
-        Manifest.permission.PROCESS_OUTGOING_CALLS,
-        Manifest.permission.READ_SMS,
-        Manifest.permission.SEND_SMS,
-        Manifest.permission.ACCESS_FINE_LOCATION,
-        Manifest.permission.CAMERA,
-        Manifest.permission.READ_EXTERNAL_STORAGE
-    )
-
-    /**
-     * High-risk permissions that are NOT surveillance signals but are abused by
-     * malware — e.g. SYSTEM_ALERT_WINDOW, which banking trojans use to draw fake
-     * credential-overlay screens. These are surfaced in the `permissions`
-     * telemetry field (short-named, the same convention as surveillance perms,
-     * so rules match them as `permissions|contains: "SYSTEM_ALERT_WINDOW"`), but
-     * are deliberately excluded from [AppTelemetry.surveillancePermissionCount]
-     * so they do not inflate the surveillance-cluster rules (androdr-011/017).
-     */
-    private val highRiskPermissions = setOf(
-        Manifest.permission.SYSTEM_ALERT_WINDOW,
-        Manifest.permission.NFC
-    )
+    // Permission sets moved to the companion object as the single source of truth
+    // for EXPOSED_PERMISSION_SHORT_NAMES (see #225).
 
     /**
      * Collects per-app telemetry metadata for every installed package without performing
@@ -233,8 +251,8 @@ class AppScanner @Inject constructor(
 
         // Surveillance permissions
         val grantedPermissions = pkg.requestedPermissions?.toList() ?: emptyList()
-        val matchedSurveillancePerms = grantedPermissions.filter { it in surveillancePermissions }
-        val matchedHighRiskPerms = grantedPermissions.filter { it in highRiskPermissions }
+        val matchedSurveillancePerms = grantedPermissions.filter { it in SURVEILLANCE_PERMISSIONS }
+        val matchedHighRiskPerms = grantedPermissions.filter { it in HIGH_RISK_PERMISSIONS }
 
         // Accessibility service
         val hasAccessibilityService = pkg.services?.any { svc ->

--- a/app/src/main/java/com/androdr/scanner/AppScanner.kt
+++ b/app/src/main/java/com/androdr/scanner/AppScanner.kt
@@ -98,8 +98,6 @@ class AppScanner @Inject constructor(
                 .toSet()
     }
 
-    // Permission sets moved to the companion object as the single source of truth
-    // for EXPOSED_PERMISSION_SHORT_NAMES (see #225).
 
     /**
      * Collects per-app telemetry metadata for every installed package without performing

--- a/app/src/test/java/com/androdr/sigma/PermissionLiteralCrossCheckTest.kt
+++ b/app/src/test/java/com/androdr/sigma/PermissionLiteralCrossCheckTest.kt
@@ -1,0 +1,97 @@
+package com.androdr.sigma
+
+import com.androdr.scanner.AppScanner
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.snakeyaml.engine.v2.api.Load
+import org.snakeyaml.engine.v2.api.LoadSettings
+import java.io.File
+
+/**
+ * Build-time guard against the dead-rule CLASS that silently killed androdr-069
+ * (and would silently kill the next NFC/media-projection rule): a bundled
+ * `app_scanner` rule that matches `permissions|contains: "X"` can only ever fire
+ * if "X" is a short-named member of the set the scanner actually emits in
+ * [com.androdr.data.model.AppTelemetry.permissions] —
+ * [AppScanner.EXPOSED_PERMISSION_SHORT_NAMES].
+ *
+ * This test reads that set DIRECTLY from the scanner (not a hardcoded copy), so
+ * it can never drift from reality — which is the whole point. It asserts every
+ * `permissions` literal in every bundled rule is a member. Adding a rule that
+ * references a permission the scanner doesn't expose fails the build at authoring
+ * time. See #225.
+ *
+ * Scope: the `permissions` field only. `service_permissions` / `receiver_permissions`
+ * are open-ended (the scanner emits every declared component permission verbatim),
+ * so they are intentionally NOT constrained here.
+ */
+class PermissionLiteralCrossCheckTest {
+
+    private val yamlLoader: Load = Load(LoadSettings.builder().build())
+
+    private fun rulesDirectory(): File {
+        val candidates = listOf(
+            File("app/src/main/res/raw"),
+            File("src/main/res/raw"),
+            File("/home/yasir/AndroDR/app/src/main/res/raw"),
+        )
+        return candidates.firstOrNull { it.isDirectory }
+            ?: error("Could not locate res/raw; tried: ${candidates.map { it.absolutePath }}")
+    }
+
+    private fun bundledRuleFiles(): List<File> =
+        rulesDirectory().listFiles { f ->
+            f.name.startsWith("sigma_androdr_") &&
+                f.name.endsWith(".yml") &&
+                !f.name.startsWith("sigma_androdr_corr_")
+        }?.sorted() ?: emptyList()
+
+    /** Field name of a SIGMA matcher key, stripping any `|modifier` suffix. */
+    private fun fieldName(key: String): String = key.substringBefore('|')
+
+    /** Recursively collect the literal value(s) of every `permissions` matcher. */
+    private fun collectPermissionLiterals(node: Any?, into: MutableList<String>) {
+        when (node) {
+            is Map<*, *> -> node.forEach { (k, v) ->
+                if (k is String && fieldName(k) == "permissions") {
+                    when (v) {
+                        is String -> into.add(v)
+                        is List<*> -> v.forEach { it?.let { e -> into.add(e.toString()) } }
+                    }
+                }
+                collectPermissionLiterals(v, into)
+            }
+            is List<*> -> node.forEach { collectPermissionLiterals(it, into) }
+        }
+    }
+
+    @Test
+    fun `every bundled rule permissions literal is exposed by the scanner`() {
+        val exposed = AppScanner.EXPOSED_PERMISSION_SHORT_NAMES
+        assertTrue("Exposed permission set is unexpectedly empty", exposed.isNotEmpty())
+
+        val failures = mutableListOf<String>()
+
+        bundledRuleFiles().forEach { file ->
+            @Suppress("UNCHECKED_CAST")
+            val root = yamlLoader.loadFromString(file.readText()) as? Map<String, Any?> ?: return@forEach
+            val detection = root["detection"] ?: return@forEach
+            val literals = mutableListOf<String>()
+            collectPermissionLiterals(detection, literals)
+            literals.forEach { literal ->
+                if (literal !in exposed) {
+                    failures += "${file.name}: permissions literal \"$literal\" is not a short-named " +
+                        "member of AppScanner.EXPOSED_PERMISSION_SHORT_NAMES $exposed — the rule can " +
+                        "never fire. Use a short name the scanner emits, or add the permission to " +
+                        "AppScanner's surveillance/high-risk set."
+                }
+            }
+        }
+
+        assertTrue(
+            "Dead-rule guard (#225) found rule(s) matching permissions the scanner never emits:\n" +
+                failures.joinToString("\n"),
+            failures.isEmpty(),
+        )
+    }
+}

--- a/app/src/test/java/com/androdr/sigma/PermissionLiteralCrossCheckTest.kt
+++ b/app/src/test/java/com/androdr/sigma/PermissionLiteralCrossCheckTest.kt
@@ -54,16 +54,19 @@ class PermissionLiteralCrossCheckTest {
     /** Field name of a SIGMA matcher key, stripping any `|modifier` suffix. */
     private fun fieldName(key: String): String = key.substringBefore('|')
 
+    /** Add the literal value(s) of a single matcher (scalar or list). */
+    private fun addLiterals(value: Any?, into: MutableList<String>) {
+        when (value) {
+            is String -> into.add(value)
+            is List<*> -> value.forEach { it?.let { e -> into.add(e.toString()) } }
+        }
+    }
+
     /** Recursively collect the literal value(s) of every `permissions` matcher. */
     private fun collectPermissionLiterals(node: Any?, into: MutableList<String>) {
         when (node) {
             is Map<*, *> -> node.forEach { (k, v) ->
-                if (k is String && fieldName(k) == "permissions") {
-                    when (v) {
-                        is String -> into.add(v)
-                        is List<*> -> v.forEach { it?.let { e -> into.add(e.toString()) } }
-                    }
-                }
+                if (k is String && fieldName(k) == "permissions") addLiterals(v, into)
                 collectPermissionLiterals(v, into)
             }
             is List<*> -> node.forEach { collectPermissionLiterals(it, into) }

--- a/app/src/test/java/com/androdr/sigma/PermissionLiteralCrossCheckTest.kt
+++ b/app/src/test/java/com/androdr/sigma/PermissionLiteralCrossCheckTest.kt
@@ -22,8 +22,13 @@ import java.io.File
  * time. See #225.
  *
  * Scope: the `permissions` field only. `service_permissions` / `receiver_permissions`
- * are open-ended (the scanner emits every declared component permission verbatim),
- * so they are intentionally NOT constrained here.
+ * are open-ended (the scanner emits every declared component permission verbatim, FQN),
+ * so they have no fixed enum to validate against and are intentionally NOT constrained
+ * here. The guard also requires WHOLE short names — substring matchers like
+ * `permissions|contains: "ALERT"` are deliberately disallowed (use the exact name).
+ *
+ * Longer term this is subsumed by the machine-readable telemetry contract (#137);
+ * until then it is a tactical, drift-proof guard for the one enumerable field.
  */
 class PermissionLiteralCrossCheckTest {
 
@@ -70,9 +75,20 @@ class PermissionLiteralCrossCheckTest {
         val exposed = AppScanner.EXPOSED_PERMISSION_SHORT_NAMES
         assertTrue("Exposed permission set is unexpectedly empty", exposed.isNotEmpty())
 
+        val ruleFiles = bundledRuleFiles()
+        // Floor guard: a guard test that silently checks ZERO rules (wrong working
+        // directory, null listFiles) would pass green having validated nothing —
+        // the exact failure mode this test exists to prevent. Mirror the floor in
+        // BundledRulesSchemaCrossCheckTest.
+        assertTrue(
+            "Expected at least 40 bundled rule files but found ${ruleFiles.size} — is the " +
+                "test running from the correct working directory?",
+            ruleFiles.size >= 40,
+        )
+
         val failures = mutableListOf<String>()
 
-        bundledRuleFiles().forEach { file ->
+        ruleFiles.forEach { file ->
             @Suppress("UNCHECKED_CAST")
             val root = yamlLoader.loadFromString(file.readText()) as? Map<String, Any?> ?: return@forEach
             val detection = root["detection"] ?: return@forEach
@@ -82,8 +98,11 @@ class PermissionLiteralCrossCheckTest {
                 if (literal !in exposed) {
                     failures += "${file.name}: permissions literal \"$literal\" is not a short-named " +
                         "member of AppScanner.EXPOSED_PERMISSION_SHORT_NAMES $exposed — the rule can " +
-                        "never fire. Use a short name the scanner emits, or add the permission to " +
-                        "AppScanner's surveillance/high-risk set."
+                        "never fire (the scanner emits short names like \"NFC\", not this value). " +
+                        "Fix: use the exact short name the scanner emits, or add the permission to " +
+                        "AppScanner's surveillance/high-risk set. If you intended a SUBSTRING match " +
+                        "(e.g. \"ALERT\" for SYSTEM_ALERT_WINDOW), that is intentionally disallowed — " +
+                        "use the whole short name."
                 }
             }
         }


### PR DESCRIPTION
Closes #225.

## Why
androdr-069 was a **dead rule for months** — it matched a permission the scanner never emitted (FQN vs short-named field). Nothing stopped the *next* such rule (the NFC/087 and future media-projection work add more `permissions|contains` rules).

## What
`PermissionLiteralCrossCheckTest` fails the build if any bundled `app_scanner` rule's `permissions|contains` literal is not a short-named member of what the scanner actually emits. It reads **`AppScanner.EXPOSED_PERMISSION_SHORT_NAMES` directly** (not a hardcoded copy), so it can't drift — which is the whole point.

- Refactor: the surveillance + high-risk permission sets moved into `AppScanner`'s companion object as the single source of truth; `EXPOSED_PERMISSION_SHORT_NAMES` derived there, exposed `@VisibleForTesting internal`. Behavior-preserving (membership byte-identical; `surveillancePermissionCount` unchanged).
- **Proven:** temporarily reintroducing the original 069 FQN made the guard fail; reverting made it pass.

## Review (4-agent ceremony) — no blockers
Verdicts: SOUND / SHIP-WITH-NIT / SOUND-WITH-NIT / SECURE-NO-REGRESSION. Applied: a `>=40` file-count floor (so a wrong-CWD run can't silently pass), substring-policy guidance in the failure message, dead-comment cleanup, `#137` breadcrumb.

## Scoped out (by design, documented)
`service_permissions`/`receiver_permissions` literals (067/087) are **open-ended** (the scanner emits every declared component permission verbatim — no fixed enum to validate against), so they're not guarded. The substring-vs-exact policy is now documented: the guard requires whole short names. Both fold into the machine-readable telemetry contract (#137) long-term.

🤖 Generated with [Claude Code](https://claude.com/claude-code)