### PR TITLE
feat(rules): overlay + accessibility combo detection (androdr-088)

### DIFF
--- a/app/src/main/java/com/androdr/sigma/SigmaRuleEngine.kt
+++ b/app/src/main/java/com/androdr/sigma/SigmaRuleEngine.kt
@@ -352,6 +352,7 @@ class SigmaRuleEngine @Inject constructor(
             R.raw.sigma_androdr_082_data_broker_cuebiq,
             R.raw.sigma_androdr_083_broker_sdk_with_location_permission,
             R.raw.sigma_androdr_087_nfc_relay,
+            R.raw.sigma_androdr_088_overlay_accessibility_combo,
             // Atom rules — pass-through matchers for raw timeline event categories.
             // Referenced by sprint-75 correlation rules (Task 9); tagged
             // level: informational so they are filtered out of the user-facing

--- a/app/src/main/res/raw/sigma_androdr_088_overlay_accessibility_combo.yml
+++ b/app/src/main/res/raw/sigma_androdr_088_overlay_accessibility_combo.yml
@@ -8,9 +8,10 @@ description: >
     device-takeover pattern: the overlay draws a fake credential screen over a real
     banking app while the accessibility service auto-grants permissions, auto-clicks,
     and harvests typed input and on-screen content (Crocodilus, PixRevolution,
-    AntiDot). Either capability alone is a weaker signal (androdr-069 overlay /
-    androdr-012 accessibility); together on a sideloaded, unvetted app they are a
-    high-confidence takeover indicator.
+    AntiDot). Overlay access alone (androdr-069) is a weak, common signal; accessibility
+    access alone (androdr-012) is already high-severity but generic. Their combination on a
+    sideloaded, unvetted app specifically attributes the banking-trojan takeover pattern and
+    warrants takeover-specific remediation.
 author: AndroDR
 date: 2026/06/23
 references:

--- a/app/src/main/res/raw/sigma_androdr_088_overlay_accessibility_combo.yml
+++ b/app/src/main/res/raw/sigma_androdr_088_overlay_accessibility_combo.yml
@@ -1,0 +1,44 @@
+title: Sideloaded app with screen-overlay and accessibility access (banking-trojan takeover)
+id: androdr-088
+status: experimental
+category: incident
+description: >
+    A sideloaded app combines the screen-overlay permission (SYSTEM_ALERT_WINDOW)
+    with an accessibility service. This is the core Android banking-trojan
+    device-takeover pattern: the overlay draws a fake credential screen over a real
+    banking app while the accessibility service auto-grants permissions, auto-clicks,
+    and harvests typed input and on-screen content (Crocodilus, PixRevolution,
+    AntiDot). Either capability alone is a weaker signal (androdr-069 overlay /
+    androdr-012 accessibility); together on a sideloaded, unvetted app they are a
+    high-confidence takeover indicator.
+author: AndroDR
+date: 2026/06/23
+references:
+    - https://www.threatfabric.com/blogs/exposing-crocodilus-new-device-takeover-malware-targeting-android-devices
+    - https://zimperium.com/blog/pixrevolution-the-agent-operated-android-trojan-hijacking-brazils-pix-payments-in-real-time
+tags:
+    - attack.t1626
+    - attack.t1417.001
+logsource:
+    product: androdr
+    service: app_scanner
+detection:
+    selection:
+        is_sideloaded: true
+        permissions|contains: "SYSTEM_ALERT_WINDOW"
+        has_accessibility_service: true
+    filter_known_good:
+        package_name|ioc_lookup: known_good_app_db
+    condition: selection and not filter_known_good
+level: high
+falsepositives:
+    - "Sideloaded but legitimate apps that genuinely combine overlay + accessibility: screen readers and accessibility suites, password managers with autofill-over-apps, screen-dimmer/automation tools (e.g. Tasker-style), and remote-support apps. Popular ones are suppressed by filter_known_good; niche tools may still trip this."
+display:
+    category: app_risk
+    icon: layers
+    triggered_title: "Overlay + Accessibility (Sideloaded)"
+    evidence_type: none
+remediation:
+    - "This sideloaded app can both draw over other apps AND read/control your screen — the combination banking-trojan malware uses to show fake login screens and steal what you type. If you don't fully trust it, uninstall it: Settings > Apps > [this app] > Uninstall, and revoke its access under Settings > Accessibility and Settings > Apps > Special access > Display over other apps."
+implies_flags:
+    - sideloaded

--- a/app/src/test/resources/gate4-fixtures/overlay-accessibility-combo.yml
+++ b/app/src/test/resources/gate4-fixtures/overlay-accessibility-combo.yml
@@ -1,0 +1,41 @@
+# Fixture for androdr-088: sideloaded app combining screen-overlay + accessibility.
+# Telemetry mirrors real AppScanner output: permissions short-named ("SYSTEM_ALERT_WINDOW"),
+# has_accessibility_service a boolean derived from a BIND_ACCESSIBILITY_SERVICE service.
+rule_file: sigma_androdr_088_overlay_accessibility_combo.yml
+service: app_scanner
+ioc_stubs:
+  known_good_app_db:
+    - "com.trusted.accessibilitytool"
+
+true_positives:
+  - package_name: "com.shady.takeover"
+    is_sideloaded: true
+    has_accessibility_service: true
+    permissions:
+      - "SYSTEM_ALERT_WINDOW"
+
+true_negatives:
+  # Play-installed app with both — not sideloaded
+  - package_name: "com.legit.suite"
+    is_sideloaded: false
+    has_accessibility_service: true
+    permissions:
+      - "SYSTEM_ALERT_WINDOW"
+  # Known-good sideloaded accessibility tool — filtered by known_good_app_db
+  - package_name: "com.trusted.accessibilitytool"
+    is_sideloaded: true
+    has_accessibility_service: true
+    permissions:
+      - "SYSTEM_ALERT_WINDOW"
+  # Sideloaded app with overlay but NO accessibility service
+  - package_name: "com.shady.overlayonly"
+    is_sideloaded: true
+    has_accessibility_service: false
+    permissions:
+      - "SYSTEM_ALERT_WINDOW"
+  # Sideloaded app with accessibility but NO overlay permission
+  - package_name: "com.shady.a11yonly"
+    is_sideloaded: true
+    has_accessibility_service: true
+    permissions:
+      - "CAMERA"

--- a/test-adversary/fixtures/mercenary/overlay-accessibility-combo/build.gradle.kts
+++ b/test-adversary/fixtures/mercenary/overlay-accessibility-combo/build.gradle.kts
@@ -1,0 +1,12 @@
+plugins { id("com.android.application") }
+android {
+    namespace = "com.androdr.fixture.overlaya11y"
+    compileSdk = 34
+    defaultConfig {
+        applicationId = "com.androdr.fixture.overlaya11y"
+        minSdk = 21
+        targetSdk = 34
+        versionCode = 1
+        versionName = "1.0"
+    }
+}

--- a/test-adversary/fixtures/mercenary/overlay-accessibility-combo/src/main/AndroidManifest.xml
+++ b/test-adversary/fixtures/mercenary/overlay-accessibility-combo/src/main/AndroidManifest.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Adversary fixture for androdr-088 (Overlay + Accessibility / Sideloaded).
+  Declares SYSTEM_ALERT_WINDOW + an accessibility service guarded by
+  BIND_ACCESSIBILITY_SERVICE — the banking-trojan device-takeover fingerprint.
+  The service class is a stub; the scanner reads the manifest declaration
+  statically (it derives has_accessibility_service from the service permission)
+  and never starts it.
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
+    <application android:label="Overlay A11y Test">
+        <service
+            android:name=".A11yService"
+            android:exported="true"
+            android:permission="android.permission.BIND_ACCESSIBILITY_SERVICE">
+            <intent-filter>
+                <action android:name="android.accessibilityservice.AccessibilityService" />
+            </intent-filter>
+        </service>
+    </application>
+</manifest>

--- a/test-adversary/fixtures/mercenary/overlay-accessibility-combo/src/main/java/com/androdr/fixture/overlaya11y/A11yService.java
+++ b/test-adversary/fixtures/mercenary/overlay-accessibility-combo/src/main/java/com/androdr/fixture/overlaya11y/A11yService.java
@@ -1,0 +1,6 @@
+package com.androdr.fixture.overlaya11y;
+
+// Stub — never instantiated. The scanner only reads the manifest <service>
+// declaration (its BIND_ACCESSIBILITY_SERVICE permission), not the class.
+// Present so the manifest reference resolves and lint does not flag MissingClass.
+public class A11yService {}

--- a/test-adversary/fixtures/mercenary/settings.gradle.kts
+++ b/test-adversary/fixtures/mercenary/settings.gradle.kts
@@ -23,5 +23,6 @@ include(
     ":firmware-implant-sim",
     ":notification-listener-abuse",
     ":overlay-permission",
-    ":nfc-relay"
+    ":nfc-relay",
+    ":overlay-accessibility-combo"
 )


### PR DESCRIPTION
Closes #226.

## What
**androdr-088** — a `high`-severity composite detecting the Android banking-trojan **device-takeover** pattern: a sideloaded, unvetted app that holds the screen-overlay permission (`SYSTEM_ALERT_WINDOW`) **AND** registers an accessibility service. The overlay draws a fake credential screen over a real banking app while accessibility auto-grants/auto-clicks and harvests input (Crocodilus, PixRevolution, AntiDot).

```
is_sideloaded: true
permissions|contains: "SYSTEM_ALERT_WINDOW"
has_accessibility_service: true
and not (package_name in known_good_app_db)
```

Pure YAML rule over **existing** telemetry — no scanner change.

## Why high (the clean composite)
Unlike NFC-087 (where the two signals co-occur), overlay and accessibility are **genuinely independent capabilities** from different manifest constructs serving different attack functions — so this cleanly meets the "high requires multiple distinct conditions" bar. It layers on the atomic rules: 069 (overlay, medium) + 012 (accessibility, high) still fire individually; 088 adds the specific takeover **attribution** + takeover-specific remediation.

## Verification
- TDD; gate4 fixture (TP + 4 TNs each dropping exactly one condition); full unit suite + lint green.
- **Real Galaxy device:** a sideloaded overlay+accessibility fixture triggers androdr-088 (`high`); only 1 finding (no false positives). The layered design confirmed on-device (069+012+088 all fire, 088 is the escalation).
- **4-agent review** — no blockers (SOUND / SHIP-WITH-NIT / ARCHITECTURALLY SOUND / SECURE). Applied the one should-fix (description wording — accessibility-alone/012 is already high, not "weak").

## Notes from review (tracked, not blocking)
- Companion submodule mirror: **android-sigma-rules #39**.
- Residual evasion (honest): accessibility-only takeover via `TYPE_ACCESSIBILITY_OVERLAY` without `SYSTEM_ALERT_WINDOW` evades 088 but is still caught by 012 — a candidate follow-up rule.
- Architect's forward note: a future *static co-occurrence / severity-boost* primitive would let atomic rules compose declaratively and pre-empt combo-rule sprawl.

🤖 Generated with [Claude Code](https://claude.com/claude-code)