### PR TITLE
feat(pipeline): encode implies_flags + severity policies into author/review skills

### DIFF
--- a/.claude/commands/update-rules-author.md
+++ b/.claude/commands/update-rules-author.md
@@ -70,6 +70,7 @@ Generate rules following this exact structure (match the style of example_rules)
 title: [Descriptive title — what is detected]
 id: androdr-[NNN]
 status: experimental
+category: [incident/device_posture — top-level field; drives SeverityCapPolicy, distinct from display.category]
 description: [What the rule detects and why it matters. Reference the threat name.]
 author: AndroDR AI Pipeline
 date: [YYYY/MM/DD — today's date]
@@ -94,6 +95,8 @@ falsepositives:
     - "[Realistic false positive scenario]"
 remediation:
     - "[Actionable step for the user]"
+implies_flags:              # OPTIONAL — app_scanner only; OMIT this entire block (never emit an empty list) when no flag applies
+    - [sideloaded and/or known_malware — see "implies_flags Annotation" below]
 ```
 
 ### Supported modifiers
@@ -112,6 +115,44 @@ Use ONLY these modifiers. Any other modifier name will be rejected by the parser
 
 **List-field defaults (no `|all` suffix):** `field|contains: [A, B, C]` on a list-valued field matches if ANY element of the field contains ANY of `[A, B, C]`. Add `|all` to require every listed value.
 
+## implies_flags Annotation (app_scanner rules — MANDATORY check)
+
+The rule schema defines an optional top-level `implies_flags:` list — orthogonal
+facts about the app the rule fires on that the detection **structurally
+guarantees**. Renderers aggregate them into Flag chips on the per-app report card
+(`Flags: Sideloaded`, `Flags: [!] Known Malware`). A rule that omits a due
+annotation still fires, but its chip silently fails to render — a UX regression
+no gate catches. The only structural gate (`BundledRulesSchemaCrossCheckTest`)
+rejects over-claimed `sideloaded`, and only for rules bundled into the app;
+`known_malware` has no structural gate in either direction, and feed-delivered
+rules get only an enum check. Getting this right is on you and Gate 5.
+(Authoritative enum: `validation/rule-schema.json` `implies_flags`; database
+registry: `validation/ioc-lookup-definitions.yml`.)
+
+Apply these checks to EVERY new `app_scanner` rule:
+
+1. The detection structurally guarantees sideloadedness, in either sanctioned
+   form — (a) a positively-referenced block requires `is_sideloaded: true` or
+   `from_trusted_store: false`, or (b) a negated block (`not filter_x` in the
+   condition) requires `from_trusted_store: true` / `is_sideloaded: false`
+   (androdr-068's shape) → declare `implies_flags: [sideloaded]`.
+2. Selection matches curated known-BAD data — `|ioc_lookup` against
+   `package_ioc_db` / `cert_hash_ioc_db` / `apk_hash_ioc_db`, or exact literal
+   known-malware package-name / cert-hash / APK-hash values in the rule itself
+   (androdr-078's shape) → add `known_malware`. These three databases are
+   exhaustive for `known_malware`; domain matches identify traffic, not the
+   app's identity.
+3. Both can apply: `implies_flags: [sideloaded, known_malware]`.
+4. `known_good_app_db` lookups are ALLOWLIST filters (used in negated `filter_*`
+   blocks) — they never justify `known_malware`.
+
+Rules for any non-app_scanner service (e.g. `service: dns_monitor`) have no app
+subject — never declare `implies_flags` on them, even on IOC matches.
+
+Exemplars: androdr-001/002/004 (`known_malware` via `|ioc_lookup`); androdr-078
+(`known_malware` via exact literal); androdr-069/077/087/088 (`sideloaded`);
+androdr-068 (`sideloaded` via negated trusted-store filter).
+
 ## Severity Assignment
 
 | Criteria | Level |
@@ -121,9 +162,51 @@ Use ONLY these modifiers. Any other modifier name will be rejected by the parser
 | Sideloaded app with suspicious permissions, outdated patch (CVSS 7.0-8.9) | `medium` |
 | Informational signal, low-confidence IOC, minor CVE (CVSS < 7.0) | `low` |
 
+### Multi-condition requirement for `high` (MANDATORY)
+
+For behavioral (non-IOC) rules, `level: high` or above requires the detection to
+combine **at least two independent conditions** — signals where one does not
+imply the other. Counting rules:
+
+- Coupled declarations count as ONE condition: a card-emulation service's
+  `BIND_NFC_SERVICE` always co-occurs with the `NFC` permission, so matching
+  both is one signal, not two.
+- An aggregate threshold over individually-common signals
+  (`surveillance_permission_count|gte: N`) counts as ONE condition regardless
+  of N — cf. androdr-011, which pairs the count with `from_trusted_store: false`
+  to earn `high`. A `permissions|contains|all` list of mutually independent
+  permissions counts each listed permission as its own signal.
+- Sideloadedness counts as one condition — in selection form OR negated
+  trusted-store-filter form (androdr-068's shape) — but never alone justifies
+  `high`.
+
+Two independent conditions are the FLOOR, not a guarantee: a weak, common
+capability plus sideloaded stays `medium` (androdr-069: sideloaded + overlay),
+while a strong, specific capability plus sideloaded earns `high` (androdr-067:
+sideloaded + notification-listener binding; androdr-012: sideloaded +
+accessibility; androdr-087: sideloaded + the coupled NFC card-emulation pair
+counted as one capability). androdr-088 (sideloaded + overlay + accessibility)
+exceeds the floor. A behavioral rule resting on ONE independent signal is
+`medium` at most, full stop.
+
+This requirement gates the Severity Assignment table above: threat-class rows
+set the ceiling, this section sets the evidence floor. A single-signal
+behavioral rule stays `medium` even when it targets a banking-trojan family —
+record a severity decision flag if that feels wrong.
+
+Exception: an exact match against curated known-bad data — `|ioc_lookup`
+against an IOC database, exact literal known-malware package/cert/hash/domain
+values in the rule (androdr-005/078), or a curated artifact-path list
+(androdr-020) — may be `high`/`critical` on that single condition: confidence
+is carried by the curated data. The generic IOC rules (androdr-001/002/004)
+declare `critical` directly in their `level:`; per-entry family/category
+attribution lives in the IOC data entry, not in the finding severity.
+
 ### Device-posture severity cap (MANDATORY)
 
-Findings from `device_posture`-category rules are **clamped to `medium` at
+Findings from rules with top-level `category: device_posture` (the field the cap
+keys on — NOT `display.category`; cf. androdr-020: `category: incident`,
+displayed under device_posture, uncapped) are **clamped to `medium` at
 runtime** by `SeverityCapPolicy` (`app/src/main/java/com/androdr/sigma/SeverityCapPolicy.kt`),
 regardless of the declared `level:`. Declaring `high` or `critical` on a
 device-posture rule (CVE / patch-level / device-flag checks, typically

--- a/.claude/commands/update-rules-review.md
+++ b/.claude/commands/update-rules-review.md
@@ -15,7 +15,7 @@ You receive:
 
 ## Review Criteria
 
-Evaluate the rule on five dimensions:
+Evaluate the rule on six dimensions:
 
 ### 1. Logical Correctness
 - Does the detection condition actually match the stated threat?
@@ -31,6 +31,24 @@ Evaluate the rule on five dimensions:
 ### 3. Severity Appropriateness
 - Does the `level` match the actual impact of the detected threat?
 - Compare with similar existing rules — is it consistent?
+- **Device-posture cap**: a rule with top-level `category: device_posture`
+  (NOT `display.category` — androdr-020 is `category: incident` displayed
+  under device_posture, legitimately uncapped) declaring `high` or `critical`
+  is a blocking issue — the engine clamps those findings to `medium` at
+  runtime (`SeverityCapPolicy`), so the declared level is dead text.
+- **Multi-condition floor**: a behavioral (non-IOC) rule at `level: high` or
+  above must combine at least two INDEPENDENT conditions. Counting:
+  sideloadedness counts as one (whether required in the selection or
+  guaranteed by a negated trusted-store filter, cf. androdr-068); coupled
+  declarations count as one (a card-emulation service's `BIND_NFC_SERVICE`
+  always co-occurs with the `NFC` permission — androdr-087 is sideloaded +
+  that pair = two conditions, and ships as `high`); an aggregate count
+  threshold (`surveillance_permission_count|gte: N`) counts as one. One
+  independent signal → fail with a downgrade-to-`medium` recommendation. Two
+  is the floor, not a guarantee — a weak, common capability + sideloaded can
+  still merit only `medium` (androdr-069); judge signal strength. Exempt:
+  exact matches against curated known-bad data (`|ioc_lookup` databases,
+  in-rule exact literals, curated artifact paths — androdr-005/020/078).
 
 ### 4. Completeness
 - Are there obvious detection opportunities the rule misses?
@@ -39,6 +57,24 @@ Evaluate the rule on five dimensions:
 ### 5. Remediation Quality
 - Are the remediation steps actionable for a non-technical user?
 - Do they address the actual threat, not just a generic "uninstall the app"?
+
+### 6. implies_flags Annotation (app_scanner rules)
+- If the detection structurally guarantees sideloadedness — `is_sideloaded:
+  true` / `from_trusted_store: false` in a positively-referenced block, OR a
+  negated filter requiring `from_trusted_store: true` (androdr-068's shape) —
+  the rule must declare `implies_flags: [sideloaded]`.
+- If the selection matches curated known-bad data (`|ioc_lookup` against
+  `package_ioc_db` / `cert_hash_ioc_db` / `apk_hash_ioc_db`, or exact literal
+  known-malware package/cert/hash values), it must include `known_malware`.
+- `known_good_app_db` lookups are allowlist filters — they never justify
+  `known_malware`.
+- Rules for any non-app_scanner service (DNS/network events) must NOT declare
+  `implies_flags` (no app subject).
+- Missing AND wrong annotations are **blocking issues**, in both directions:
+  the build gate catches over-claimed `sideloaded` only (and only for rules
+  bundled into the app); `known_malware` has no structural gate either way —
+  a wrong claim paints a false "[!] Known Malware" chip on a legitimate app
+  and nothing downstream stops it. This review is the only check.
 
 ## Output
 

--- a/.claude/workflows/update-rules-e2e.workflow.js
+++ b/.claude/workflows/update-rules-e2e.workflow.js
@@ -277,7 +277,7 @@ function reviewPrompt(c, sirs) {
     .join('\n')
   return `You are an INDEPENDENT reviewer for the AndroDR SIGMA pipeline (Gate 5), running inside ${REPO} (rules submodule at ${SIGMA}). You have NOT seen the Rule Author's reasoning or any validator gate results — review with completely fresh eyes.
 
-Read ${REPO}/.claude/commands/update-rules-review.md and apply its five criteria exactly.
+Read ${REPO}/.claude/commands/update-rules-review.md and apply ALL of its review criteria exactly (the skill file is authoritative — do not assume a fixed count).
 Also READ ${SIGMA}/validation/authoring-lessons.yml if it exists and apply its guidance; if missing, proceed without it.
 
 For "similar_rules" context, pick 2-3 same-category entries from this index and read their YAML files in the submodule (production rules live in service-named dirs at the repo root, staged ones under staging/<service>/):

--- a/docs/AI-PIPELINE-CONVENTIONS.md
+++ b/docs/AI-PIPELINE-CONVENTIONS.md
@@ -96,6 +96,18 @@ changes.
 
 ## Architectural decisions
 
+### Workflow prompts reference skill files — never restate their rules
+
+Orchestration prompts (`.claude/workflows/*.workflow.js`, the `update-rules.md`
+dispatcher) must point agents at the authoritative skill file ("read
+`update-rules-review.md` and apply ALL of its criteria") instead of
+paraphrasing, counting, or summarizing its content inline. Every inline
+restatement is a second dispatch path that silently drifts when the skill
+changes — a hardcoded "apply its five criteria" survived the addition of a
+sixth criterion and would have caused the primary Gate-5 path to skip it.
+When a prompt needs shared policy text, inject the file (as done with
+`authoring-lessons.yml`), don't copy it.
+
 ### Detection logic is rule-driven YAML, never hardcoded Kotlin
 
 Detection patterns (system name impersonation, permission clusters,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -180,7 +180,7 @@ A detection rule is a YAML document with these sections:
 - `logsource.service` — names the telemetry type the rule targets. Supported services (verified in `SigmaRuleEngine`): `app_scanner`, `device_auditor`, `process_monitor`, `dns_monitor`, `file_scanner`, `accessibility_audit`, `receiver_audit`, `appops_audit`, `tombstone_parser`, `wakelock_parser`, `battery_daily`, `package_install_history`, `platform_compat`, `db_info`.
 - `detection` — one or more named selections, each mapping field names (with optional modifiers) to match values, plus a `condition` expression combining selection names with `and`, `or`, `not`.
 - `category` — required top-level field, must be `incident` or `device_posture`. Missing or invalid category raises `SigmaRuleParseException` and fails the build.
-- `level` — severity string (`informational`, `low`, `medium`, `high`, `critical`). The `SeverityCapPolicy` caps `device_posture` rules at `high`.
+- `level` — severity string (`informational`, `low`, `medium`, `high`, `critical`). The `SeverityCapPolicy` caps `device_posture` rules at `medium`.
 - `display` — contains `triggered_title`, `safe_title`, `icon`, `evidence_type`, `summary_template`, `guidance`.
 - `remediation` — list of strings (template-expanded at finding-build time).
 
@@ -246,7 +246,7 @@ Feed-level cursor state (last-fetched timestamps) and per-indicator provenance (
 When `SigmaRuleEvaluator` matches a rule against a telemetry record, it produces a `Finding` via the internal `buildFinding()` factory (the only sanctioned construction path — bypassing it risks severity-cap violations). A `Finding` carries:
 
 - `ruleId`, `title` — rule identity and display title (template-expanded from the matched record)
-- `level` — severity after `SeverityCapPolicy.applyCap()` (caps `device_posture` rules at `high`)
+- `level` — severity after `SeverityCapPolicy.applyCap()` (caps `device_posture` rules at `medium`)
 - `category` — `FindingCategory` enum: `DEVICE_POSTURE`, `APP_RISK`, or `NETWORK`
 - `tags` — MITRE ATT&CK and other tags from the rule
 - `remediation` — list of template-expanded remediation strings

--- a/docs/superpowers/specs/2026-06-23-nfc-relay-detection-design.md
+++ b/docs/superpowers/specs/2026-06-23-nfc-relay-detection-design.md
@@ -86,6 +86,15 @@ Domains only — IP filtering is parked (DNS-only scope). `nfcrackatm.com` (Devi
 
 Single capability signal + sideloaded → `medium`. Multiple conditions across distinct dimensions → `high`. This codifies the detection reviewer's guidance from the androdr-069 review (see issue #226, the overlay+accessibility combo) and the user's directive. androdr-087 is `high` because it requires four conditions.
 
+> **Superseded (2026-07-03):** the normative statement of this convention now
+> lives in `.claude/commands/update-rules-author.md` § "Multi-condition
+> requirement for `high`". Two corrections relative to the paragraph above:
+> coupled declarations count as ONE condition (BIND_NFC_SERVICE + NFC is one
+> signal, so androdr-087 is sideloaded + one strong capability = two
+> independent conditions, not four — conclusion unchanged, 087 stays `high`),
+> and two independent conditions are the floor for `high`, with signal
+> strength deciding sufficiency (069's weak overlay stays `medium`).
+
 ## 8. Delivery
 
 - **AndroDR PR:** the rule (`res/raw`), the `AppScanner.kt` one-liner, register the rule in `SigmaRuleEngine`'s bundled list, gate4 fixture, scanner unit test, adversary `nfc-relay` fixture (+ `settings.gradle.kts`).


### PR DESCRIPTION
Closes #209

## What

Encodes three standing policies into the AI pipeline's authoring and Gate-5 review skills so they stop being enforced by hand in HitL review:

**`update-rules-author.md`**
- New **implies_flags annotation** section (#209, all four scope points): both sanctioned sideload forms — selection-required AND the negated trusted-store-filter shape (androdr-068) that the build gate explicitly accepts; known-bad db enumeration (`package_ioc_db`/`cert_hash_ioc_db`/`apk_hash_ioc_db`, exhaustive for `known_malware`) with the `known_good_app_db`-is-an-allowlist exclusion; exact-literal shape (androdr-078); non-app_scanner prohibition. Pointers to the authoritative enum/registry files.
- New **multi-condition floor for `high`**: at least two independent conditions, with explicit counting rules (coupled pairs like BIND_NFC_SERVICE+NFC = one; `surveillance_permission_count|gte` = one; sideloadedness = one, never sufficient alone) and floor-vs-sufficiency semantics calibrated against the shipped corpus (069 `medium` vs 067/012/087 `high`; 088 exceeds). Curated-data exception covers `|ioc_lookup` dbs, in-rule exact literals (005/078), and artifact paths (020). Explicit precedence over the severity table (ceiling vs floor).
- Template: adds the required top-level `category:` field (was missing entirely) and a leak-proof `implies_flags` placeholder (omit-the-block, never an empty list).
- Device-posture cap section now disambiguates top-level `category:` from `display.category` (the androdr-020 trap).

**`update-rules-review.md`** — matching Gate-5 dimension 6 (implies_flags, blocking in BOTH directions — `known_malware` has no structural gate anywhere, and the sideloaded gate covers bundled rules only) plus severity checks with the 087 boundary case spelled out so Gate 5 doesn't demand downgrades of owner-accepted patterns.

## Drift fixes found by the 4-agent review ceremony

- **Blocker**: `update-rules-e2e.workflow.js` hardcoded *"apply its five criteria exactly"* — the primary automated Gate-5 path would have been invited to skip the new sixth criterion. Now count-free; the class-level fix is recorded as a new convention in `AI-PIPELINE-CONVENTIONS.md` (workflow prompts reference skill files, never restate them).
- `ARCHITECTURE.md` said `SeverityCapPolicy` caps device_posture at `high` in two places; the code clamps to `medium`.
- NFC spec §7 marked superseded (its "four conditions" counting double-counted the coupled NFC pair; conclusion unchanged — 087 stays `high`).

## Review ceremony

4 agents (correctness, prompt-quality, architect, code-security), all findings triaged: 1 blocker + 8 convergent should-fixes applied (three reviewers independently caught the over-claim-gate overgeneralization); mechanical-lint layering recommendation filed as #232.

## Verification

- Workflow JS syntax-checked under the harness's async-wrap semantics.
- No stale criteria counts remain (`grep` clean across skills + workflows).
- Prose-only change otherwise; no Kotlin touched, no unit-test surface (no test reads these files — verified). The new guidance gets its first live exercise on the next pipeline run; the sweep currently in flight intentionally uses the pre-change skills, and its candidates will be hand-checked against these rules during HitL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Q9BCHXefR4CPzF94LsdSD