### PR TITLE
docs: rules-repo CI gate is live — retire the dormant-Actions caveat

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,10 +119,13 @@ while read -r f; do printf '%s  %s\n' "$(sha256sum "$f" | cut -d' ' -f1)" "$f"; 
 ```
 
 `RuleManifestIntegrityTest` (AndroDR unit tests) fails the build if the pinned
-submodule's manifest has drifted, and a `validate-manifest` job exists in
-`android-sigma-rules`'s `validate.yml`. **Note: that org's GitHub Actions are
-currently dormant** (0 runs), so the rules-repo gate does not execute yet —
-AndroDR's CI is the enforced guard for now.
+submodule's manifest has drifted, and `android-sigma-rules`'s `validate.yml`
+gates that repo directly. **The rules-repo gate is live as of 2026-07-03**
+(verified green on all three trigger paths: `pull_request`, `push` to main,
+and manual `workflow_dispatch` — the last added via rules PR #41 as a standing
+re-validation lever). Rules-repo PRs must have a green `validate` check before
+merge; AndroDR's CI remains the second, independent guard via the pinned
+submodule.
 
 **Safe ordering for any rule change** (so AndroDR CI gates *before* the change
 reaches production — the app pulls rules from `android-sigma-rules` main on a 12h


### PR DESCRIPTION
The android-sigma-rules org's Actions suppression ended today: `validate.yml` produced its first-ever runs and **all three trigger paths passed** — `pull_request` (run 28659937102), `push` to main (28659939361), and manual `workflow_dispatch` (28659947582; trigger added via [rules PR #41](https://github.com/android-sigma-rules/rules/pull/41)).

This PR updates the CLAUDE.md caveat that said the rules-repo gate "does not execute yet": rules-repo PRs should now require a green `validate` check before merge, with AndroDR CI remaining the independent second guard via the pinned submodule. The safe-ordering protocol is unchanged — the 12h on-device fetch window it protects against still exists.

Doc-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Q9BCHXefR4CPzF94LsdSD