### PR TITLE
fix(security): repin raw.githubusercontent.com on CA-root SPKIs — restore rule/IOC delivery

### DIFF
--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -7,7 +7,11 @@
         </trust-anchors>
     </base-config>
 
-    <!-- Pin CISA feed domain -->
+    <!-- Pin CISA feed domain.
+         KNOWN OUTLIER: still pins an intermediate + leaf (the pattern that
+         caused the 2026-07-03 GitHub outage below), and the pinned leaf
+         expires 2026-09-22. Migration to root pins (needs DigiCert Global
+         Root G3 for the current ECC chain) is tracked in a follow-up issue. -->
     <domain-config>
         <domain includeSubdomains="true">cisa.gov</domain>
         <pin-set expiration="2027-06-01">
@@ -29,14 +33,51 @@
          standard secure TLS for a public read-only data feed. The primary
          actively-exploited source (cisa.gov) remains pinned. -->
 
-    <!-- Pin GitHub (SIGMA rule feed) -->
+    <!-- Pin GitHub (SIGMA rule + IOC feed — the app's detection-content channel).
+
+         ROOT-SPKI pins only for this host, never leaf or intermediate.
+         Incident 2026-07-03 (see PR for this change + issue on feed
+         observability): the previous set pinned the Let's Encrypt R12
+         intermediate + a *.github.io leaf; GitHub's chain moved to LE's
+         next hierarchy (YR2 intermediate under ISRG Root YR) and the
+         ~90-day leaf rotated, so BOTH pins died and every rule/IOC fetch
+         failed closed — silently, on every device, until found via
+         on-device testing (the same failure mode as the
+         storage.googleapis.com note above).
+
+         Roots live for decades and survive leaf/intermediate churn. This
+         set mirrors GitHub's own CAA policy for githubusercontent.com
+         (issue "letsencrypt.org" / "digicert.com" / "sectigo.com"): both
+         LE generations incl. RSA+ECDSA siblings, both classic DigiCert
+         roots, both USERTrust (Sectigo) roots. Only GitHub adopting a CA
+         outside its current CAA set breaks it, and the pin-set expiration
+         bounds that worst case (Android stops enforcing expired pins —
+         fail-open to system-CA TLS, not an outage).
+
+         To re-verify against the live chain:
+           openssl s_client -connect raw.githubusercontent.com:443 \
+             -servername raw.githubusercontent.com -showcerts
+           openssl x509 -pubkey -noout | openssl pkey -pubin -outform der \
+             | openssl dgst -sha256 -binary | base64 -->
     <domain-config>
         <domain includeSubdomains="true">raw.githubusercontent.com</domain>
         <pin-set expiration="2027-06-01">
-            <!-- Let's Encrypt R12 intermediate -->
-            <pin digest="SHA-256">kZwN96eHtZftBWrOZUsd6cA4es80n3NzSk/XtYz2EqQ=</pin>
-            <!-- Leaf: *.github.io -->
-            <pin digest="SHA-256">ccs02cz7WiIuRPsyJxR7Gs1f3flkG9wDnaPocSu+U+8=</pin>
+            <!-- ISRG Root YR (letsencrypt.org/certs/gen-y/root-yr.pem; matches live chain 2026-07-03) -->
+            <pin digest="SHA-256">fk6IOKit1ild5647BH06ujSIq5XbCgqlbYl6ANhhi88=</pin>
+            <!-- ISRG Root YE (letsencrypt.org/certs/gen-y/root-ye.pem — gen-Y ECDSA sibling) -->
+            <pin digest="SHA-256">sCkq5UWXjg+7mKu9lMhhYF5bGLsy7VI/UNW3tccdR7w=</pin>
+            <!-- ISRG Root X1 (letsencrypt.org/certs/isrgrootx1.pem) -->
+            <pin digest="SHA-256">C5+lpZ7tcVwmwQIMcRtPbsQtWLABXhQzejna0wHFr8M=</pin>
+            <!-- ISRG Root X2 (letsencrypt.org/certs/isrg-root-x2.pem) -->
+            <pin digest="SHA-256">diGVwiVYbubAI3RW4hB9xU8e/CH2GnkuvVFZE8zmgzI=</pin>
+            <!-- DigiCert Global Root CA (cacerts.digicert.com/DigiCertGlobalRootCA.crt) -->
+            <pin digest="SHA-256">r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E=</pin>
+            <!-- DigiCert Global Root G2 (cacerts.digicert.com/DigiCertGlobalRootG2.crt) -->
+            <pin digest="SHA-256">i7WTqTvh0OioIruIfFR4kMPnBqrS2rdiVPl/s2uC/CY=</pin>
+            <!-- USERTrust RSA Certification Authority (crt.usertrust.com AIA) -->
+            <pin digest="SHA-256">x4QzPSC810K5/cMjb05Qm4k3Bw5zBn4lTdO/nEW/Td4=</pin>
+            <!-- USERTrust ECC Certification Authority (crt.usertrust.com AIA) -->
+            <pin digest="SHA-256">ICGRfpgmOUXIWcQ/HXPLQTkFPEFPoDyjvH7ohhQpjzs=</pin>
         </pin-set>
     </domain-config>
 </network-security-config>

--- a/app/src/test/java/com/androdr/security/NetworkSecurityConfigTest.kt
+++ b/app/src/test/java/com/androdr/security/NetworkSecurityConfigTest.kt
@@ -24,6 +24,10 @@ import javax.xml.parsers.DocumentBuilderFactory
  */
 class NetworkSecurityConfigTest {
 
+    private companion object {
+        const val NINETY_DAYS_MS = 90L * 24 * 60 * 60 * 1000
+    }
+
     private fun configFile(): File = listOf(
         File("app/src/main/res/xml/network_security_config.xml"),
         File("src/main/res/xml/network_security_config.xml"),
@@ -55,17 +59,39 @@ class NetworkSecurityConfigTest {
             assertTrue("$domain: <pin-set> is missing an expiration", expiration.isNotBlank())
             val expiresAt = dateFormat.parse(expiration)?.time
                 ?: error("$domain: unparseable expiration '$expiration'")
+            // Lead-time, not just expiry: Android FAIL-OPENS on an expired pin-set
+            // (pins silently stop being enforced), so a test that only fails after
+            // the date has passed fires when protection is already gone. 90 days
+            // gives a release cycle to remeasure roots and extend.
             assertTrue(
-                "$domain: pin-set expired on $expiration — pinning is no longer enforced",
-                expiresAt > now,
+                "$domain: pin-set expires $expiration — within 90 days. Remeasure the " +
+                    "roots (recipe in network_security_config.xml) and extend the date " +
+                    "BEFORE devices fail open to unpinned TLS",
+                expiresAt > now + NINETY_DAYS_MS,
             )
 
-            val pinCount = pinSet.getElementsByTagName("pin").length
+            val pins = pinSet.getElementsByTagName("pin")
             assertTrue(
-                "$domain: only $pinCount pin(s) — ship at least 2 (a backup) so cert " +
+                "$domain: only ${pins.length} pin(s) — ship at least 2 (a backup) so cert " +
                     "rotation cannot brick the domain",
-                pinCount >= 2,
+                pins.length >= 2,
             )
+            // A malformed pin doesn't fail gracefully: Android rejects the whole
+            // config at runtime. Catch truncated/typo'd digests at build time.
+            for (p in 0 until pins.length) {
+                val value = pins.item(p).textContent.trim()
+                val decoded = try {
+                    java.util.Base64.getDecoder().decode(value)
+                } catch (e: IllegalArgumentException) {
+                    throw AssertionError("$domain: pin '$value' is not valid base64", e)
+                }
+                assertEquals(
+                    "$domain: pin '$value' decodes to ${decoded.size} bytes — a SHA-256 " +
+                        "SPKI pin must be exactly 32",
+                    32,
+                    decoded.size,
+                )
+            }
         }
     }
 


### PR DESCRIPTION
## Incident

Found via your "App update issues?" hunch + on-device adb testing: every fetch from `raw.githubusercontent.com` — the app's entire detection-content channel (8 of ~12 remote sources: SIGMA rules, all repo IOC files, MVT, stalkerware ×2, HaGeZi, UAD) — was failing with **Pin verification failed**, silently, on every device. GitHub's cert chain moved to Let's Encrypt's gen-Y hierarchy (YR2 intermediate under ISRG Root YR) and the ~90-day leaf rotated, killing both existing pins (an LE intermediate + a leaf). Devices were frozen on bundled rules and pre-sweep IOCs; WorkManager reported success throughout. Duration unknown.

## Fix

Pin **root SPKIs only** — the set mirrors GitHub's own CAA policy (`letsencrypt.org` / `digicert.com` / `sectigo.com`): ISRG Root YR + YE (gen-Y RSA+ECDSA), X1 + X2, DigiCert Global Root CA + G2, USERTrust RSA + ECC. Roots survive leaf/intermediate churn; only GitHub adopting a CA outside its CAA set breaks this, and the pin-set `expiration` (2027-06-01, Android fail-open) bounds that. Config comment carries the incident note + a re-verification recipe; cisa.gov is flagged as the known outlier (#237).

Guard-test hardening: **90-day expiry lead time** (the old assertion fired only after devices had already failed open) and **32-byte base64 decode** per pin (a malformed pin rejects the entire config at runtime).

## Verification

- All 8 pin values recomputed from official CA publications; the correctness and security reviewers each **independently re-derived every value** — three-way agreement, and ISRG Root YR additionally matches the live served chain.
- Real device (Samsung, R3CR300WRRH), before/after: fetches went from 100% `Pin verification failed` to **952 repo IOC entries upserted, 36 remote SIGMA rules, 402k indicators refreshed**; today's sweep spot-checks present in Room (Arsink CRITICAL hash, Glitch SPY C2, MagicAd package); the HitL-rejected Unknown hash correctly absent; zero pin failures.
- Full local gate green: testDebugUnitTest, lintDebug, detekt.

## 4-agent review ceremony

No blockers. Applied: ISRG Root YE addition (found independently by 2 reviewers), Sectigo/USERTrust coverage (security reviewer — CAA alignment), YR provenance citation, cisa.gov outlier note, test hardenings, wording fixes. Follow-ups filed: **#236** (per-feed health + stale-intel finding — the outage was architecturally invisible), **#237** (cisa.gov root-pin migration before its 2026-09-22 leaf expiry), **#238** (rules.sha256 is fail-open when the manifest is missing + offline content signing), plus a #217 comment (RemoteJsonFeed dead code).

**Ship priority: this blocks all detection-content delivery — every fielded device is running stale rules until an APK with this fix reaches it.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Q9BCHXefR4CPzF94LsdSD